### PR TITLE
remove the leading whitespace introduced by textwrap

### DIFF
--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -35,11 +35,11 @@ class Entry:
         if self.journal.config['linewrap']:
             title = textwrap.fill(date_str + " " + self.title, self.journal.config['linewrap'])
             body = "\n".join([
-                    textwrap.fill(line+" ", 
-                        self.journal.config['linewrap'], 
-                        initial_indent="| ", 
+                    textwrap.fill(line+" ",
+                        self.journal.config['linewrap'],
+                        initial_indent="| ",
                         subsequent_indent="| ",
-                        drop_whitespace=False)
+                        drop_whitespace=False).replace('  ', ' ')
                     for line in self.body.strip().splitlines()
                 ])
         else:


### PR DESCRIPTION
jrnl output often looked like:

```
title
| bla bla
|  bla bla bla
| bla bla
```

when the textwrap linebreak left a whitespace in front of the line. now it would be:

```
title
| bla bla
| bla bla bla
| bla bla
```
