### PR TITLE
Embedded decimal causes title to be truncated

### DIFF
--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -252,7 +252,7 @@ class Journal(object):
 
         # Split raw text into title and body
         title_end = len(raw)
-        for separator in ".?!\n":
+        for separator in ["\n",". ","? ","! "]:
             sep_pos = raw.find(separator)
             if 1 < sep_pos < title_end:
                 title_end = sep_pos


### PR DESCRIPTION
Hi,  I've got journal entries with a title like: `Ran 5.2 miles. <Run report>` and when it gets added to the journal, the entry ends up looking like:
     `2013-03-28 21:43 Ran 5.
      2 miles. <Run report>`

I made a one line change that looks for a `.!?` _and_ a space afterwards before considering it to be a title.

Please consider if the modification looks ok.
Thanks.
