### PR TITLE
Support a custom location for the config

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -24,7 +24,7 @@ __version__ = '1.0.0-rc1'
 __author__ = 'Manuel Ebert, Stephan Gabler'
 __license__ = 'MIT'
 
-CONFIG_PATH = os.path.expanduser('~/.jrnl_config')
+CONFIG_PATH = os.environ.get('JRNL_CONFIG', os.path.expanduser('~/.jrnl_config'))
 PYCRYPTO = install.module_exists("Crypto")
 
 def parse_args():


### PR DESCRIPTION
Export $JRNL_CONFIG to override the location instead of using $HOME. Too many dotfiles are literring it, ya' know?

Linux desktop users, you might like if you follow the XDG standards:

```
export JRNL_CONFIG=$XDG_CONFIG_HOME/jrnl/config
```
