### PR TITLE
Update jrnl.py so that a trailing / for a DayOne journal config is seen as a DayOne journal.

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -159,7 +159,10 @@ def cli():
     mode_compose, mode_export = guess_mode(args, config)
 
     # open journal file or folder
-    if os.path.isdir(config['journal']) and config['journal'].endswith(".dayone"):
+
+
+    if os.path.isdir(config['journal']) and ( config['journal'].endswith(".dayone") or \
+        config['journal'].endswith(".dayone/")):
         journal = Journal.DayOne(**config)
     else:
         journal = Journal.Journal(**config)


### PR DESCRIPTION
https://github.com/maebert/jrnl#dayone-integration
sort of infers that it in the .jrnl_config it should end in a /

but prior to this, if there was a trailing / then jrnl thought it was
looking at a text type journal.
