### PR TITLE
Make the cli work again.

### DIFF
--- a/jrnl/__init__.py
+++ b/jrnl/__init__.py
@@ -14,3 +14,4 @@ __copyright__ = 'Copyright 2013 Manuel Ebert'
 
 from . import Journal
 from . import jrnl
+from .jrnl import cli


### PR DESCRIPTION
Cloning the repo from git and then running `jrnl` currently failes because the setup.py references an entry point that is not present.
This fixes that.
