### PR TITLE
Initial support for Day One tag syncing

### DIFF
--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -341,6 +341,7 @@ class DayOne(Journal):
                     'Starred': entry.starred if hasattr(entry, 'starred') else False,
                     'Entry Text': entry.title+"\n"+entry.body,
                     'Time Zone': get_local_timezone(),
-                    'UUID': new_uuid
+                    'UUID': new_uuid,
+                    'Tags': [tag for tag in entry.tags] if entry.parse_tags() and hasattr(entry, 'tags') else False
                 }
                 plistlib.writePlist(entry_plist, filename)


### PR DESCRIPTION
I am actually not sure if this is merge-ready, but I thought I would demonstrate how easy it is to sync tags with Day One. In this state, the tags are being synced with the `@`s (`@tag`). This can easily be remedied with a `.split` if you want.
