### PR TITLE
Issue #100 fix.

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -61,6 +61,8 @@ def prompt(msg):
     """Prints a message to the std err stream defined in util."""
     if not msg.endswith("\n"):
         msg += "\n"
+    print "barf"
+    print msg 
     STDERR.write(u(msg))
 
 def py23_input(msg):


### PR DESCRIPTION
/U in paths on (user directories in Windows) is being inetrperted as unicode......

In my naivety, I'm going to suggest that util.py:57 be changed to:

```
    return s if PY3 or type(s) is unicode else unicode(s.encode('string-escape'), "unicode_escape")
```

to  force strings.
