### PR TITLE
Force conversion to string in print messages to avoid \U used as unicode.

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -61,8 +61,6 @@ def prompt(msg):
     """Prints a message to the std err stream defined in util."""
     if not msg.endswith("\n"):
         msg += "\n"
-    print "barf"
-    print msg 
     STDERR.write(u(msg))
 
 def py23_input(msg):


### PR DESCRIPTION
In my naivety, I'm going to suggest that util.py:57 be changed to:

```
    return s if PY3 or type(s) is unicode else unicode(s.encode('string-escape'), "unicode_escape")
```

for issue #100
