### PR TITLE
Add missing line-break.

### DIFF
--- a/_sources/advanced.txt
+++ b/_sources/advanced.txt
@@ -51,6 +51,7 @@ Using your DayOne journal instead of a flat text file is dead simple -- instead 
 * ``~/Library/Mobile Documents/5U8NS4GX82~com~dayoneapp~dayone/Documents/`` if you're syncing with iCloud.
 
 Instead of all entries being in a single file, each entry will live in a separate `plist` file.
+
 Multiple journal files
 ----------------------
 


### PR DESCRIPTION
The missing line-break before the heading "Multiple journal files" caused it to be rendered improperly.
