### PR TITLE
Linewrap fixes

### DIFF
--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -42,7 +42,7 @@ class Entry:
         if not short and self.journal.config['linewrap']:
             title = textwrap.fill(date_str + " " + self.title, self.journal.config['linewrap'])
             body = "\n".join([
-                    textwrap.fill(line+" ",
+                    textwrap.fill((line + " ") if (len(line) == 0) else line,
                         self.journal.config['linewrap'],
                         initial_indent="| ",
                         subsequent_indent="| ",


### PR DESCRIPTION
- don't replace double spaces blindly.
- don't blindly add a space at the end of each line. A space seems to be needed if the line is blank to maintain the `|` sidebar.  If however a space is added to a line that is exactly `linewrap` long, this results in a blank line. So a space is only added to the line if it is otherwise blank.
