### PR TITLE
Allow use of environment variables in config paths

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -155,7 +155,7 @@ def run(manual_args=None):
         config.update(journal_conf)
     else:  # But also just give them a string to point to the journal file
         config['journal'] = journal_conf
-    config['journal'] = os.path.expanduser(config['journal'])
+    config['journal'] = os.path.expanduser(os.path.expandvars(config['journal']))
     touch_journal(config['journal'])
     mode_compose, mode_export = guess_mode(args, config)
 

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -54,7 +54,7 @@ def save_config(config=default_config, config_path=os.path.expanduser("~/.jrnl_c
 
 def install_jrnl(config_path='~/.jrnl_config'):
     def autocomplete(text, state):
-        expansions = glob.glob(os.path.expanduser(text)+'*')
+        expansions = glob.glob(os.path.expanduser(os.path.expandvars(text))+'*')
         expansions = [e+"/" if os.path.isdir(e) else e for e in expansions]
         expansions.append(None)
         return expansions[state]
@@ -65,7 +65,7 @@ def install_jrnl(config_path='~/.jrnl_config'):
     # Where to create the journal?
     path_query = 'Path to your journal file (leave blank for ~/journal.txt): '
     journal_path = util.py23_input(path_query).strip() or os.path.expanduser('~/journal.txt')
-    default_config['journals']['default'] = os.path.expanduser(journal_path)
+    default_config['journals']['default'] = os.path.expanduser(os.path.expandvars(journal_path))
 
     # Encrypt it?
     if module_exists("Crypto"):


### PR DESCRIPTION
This patch simply adds several calls to `os.expandvars` to functions
that parse paths in the config file.
