### PR TITLE
Try $VISUAL and $EDITOR for config['editor']

### DIFF
--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -23,7 +23,7 @@ default_config = {
     'journals': {
         "default": os.path.expanduser("~/journal.txt")
     },
-    'editor': "",
+    'editor': os.getenv('VISUAL') or os.getenv('EDITOR') or "",
     'encrypt': False,
     'default_hour': 9,
     'default_minute': 0,


### PR DESCRIPTION
On UNIX derivates they expand to the default or preferred editor and avoid unnecessary first time edits of the config file.
