### PR TITLE
Add export options to help message

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -41,7 +41,7 @@ def parse_args(args=None):
     exporting = parser.add_argument_group('Export / Import', 'Options for transmogrifying your journal')
     exporting.add_argument('--short', dest='short', action="store_true", help='Show only titles or line containing the search tags')
     exporting.add_argument('--tags', dest='tags', action="store_true", help='Returns a list of all tags and number of occurences')
-    exporting.add_argument('--export', metavar='TYPE', dest='export', help='Export your journal to Markdown, JSON or Text', default=False, const=None)
+    exporting.add_argument('--export', metavar='TYPE', dest='export', help='Export your journal.  Options: json, text, markdown', default=False, const=None)
     exporting.add_argument('-o', metavar='OUTPUT', dest='output', help='The output of the file can be provided when using with --export', default=False, const=None)
     exporting.add_argument('--encrypt', metavar='FILENAME', dest='encrypt', help='Encrypts your existing journal with a new password', nargs='?', default=False, const=None)
     exporting.add_argument('--decrypt', metavar='FILENAME', dest='decrypt', help='Decrypts your journal and stores it in plain text', nargs='?', default=False, const=None)


### PR DESCRIPTION
To fix issue https://github.com/maebert/jrnl/issues/187.  Guess this might be better in the drill down help `$ jrnl --export --help`
