### PR TITLE
Allow parallel edits

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -159,17 +159,6 @@ def run(manual_args=None):
     touch_journal(config['journal'])
     mode_compose, mode_export = guess_mode(args, config)
 
-    # open journal file or folder
-    if os.path.isdir(config['journal']):
-        if config['journal'].strip("/").endswith(".dayone") or \
-           "entries" in os.listdir(config['journal']):
-            journal = DayOneJournal.DayOne(**config)
-        else:
-            util.prompt(u"[Error: {0} is a directory, but doesn't seem to be a DayOne journal either.".format(config['journal']))
-            sys.exit(1)
-    else:
-        journal = Journal.Journal(journal_name, **config)
-
     # How to quit writing?
     if "win32" in sys.platform:
         _exit_multiline_code = "on a blank line, press Ctrl+Z and then Enter"
@@ -188,6 +177,17 @@ def run(manual_args=None):
             args.text = [raw]
         else:
             mode_compose = False
+
+    # open journal file or folder
+    if os.path.isdir(config['journal']):
+        if config['journal'].strip("/").endswith(".dayone") or \
+           "entries" in os.listdir(config['journal']):
+            journal = DayOneJournal.DayOne(**config)
+        else:
+            util.prompt(u"[Error: {0} is a directory, but doesn't seem to be a DayOne journal either.".format(config['journal']))
+            sys.exit(1)
+    else:
+        journal = Journal.Journal(journal_name, **config)
 
     # Writing mode
     if mode_compose:

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -114,7 +114,7 @@ def load_and_fix_json(json_path):
             sys.exit(1)
 
 def get_text_from_editor(config, template=""):
-    tmpfile = os.path.join(tempfile.gettempdir(), "jrnl")
+    tmpfile = os.path.join(tempfile.mktemp(prefix="jrnl"))
     with codecs.open(tmpfile, 'w', "utf-8") as f:
         if template:
             f.write(template)


### PR DESCRIPTION
Proposed fix for #203
- Wait to open the journal until after getting text
- Use mktemp so that editors like vim get separate files for editing
