### PR TITLE
Set end_date appropriately when using on_date

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -205,7 +205,8 @@ def run(manual_args=None):
     else:
         old_entries = journal.entries
         if args.on_date:
-            args.start_date = args.end_date = args.on_date
+            args.start_date = args.on_date
+            args.end_date = args.on_date + ' 23:59'
         journal.filter(tags=args.text,
                        start_date=args.start_date, end_date=args.end_date,
                        strict=args.strict,


### PR DESCRIPTION
end_date was incorrectly being set to start_date, which caused
`jrnl -on today` to only report entries which were written at 00:00.
This commit appends ' 23:59' to the start_date in order to show all entries
from that particular day.

Fixes #279
