### PR TITLE
Fixed "-on today" option inclusive date parsing

### DIFF
--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -48,7 +48,10 @@ def parse(date_str, inclusive=False, default_hour=None, default_minute=None):
             return None
 
     if flag is 1:  # Date found, but no time. Use the default time.
-        date = datetime(*date[:3], hour=default_hour or 0, minute=default_minute or 0)
+        date = datetime(*date[:3],
+                        hour=23 if inclusive else default_hour or 0,
+                        minute=59 if inclusive else default_minute or 0,
+                        second=59 if inclusive else 0)
     else:
         date = datetime(*date[:6])
 


### PR DESCRIPTION
It's a one line fix, basically when the parsed date is parsed from the CALENDAR I force time to end of day if inclusive is set.

Ran the behave tests and works, also ran some jrnl live tests checking behavior:

``` bash
jrnl(ontoday)$ jrnl -on today
2014-09-25 10:03 Fixed @jrnl @today feature
```
