### PR TITLE
Added support for importing entries

### DIFF
--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -74,6 +74,9 @@ class Entry:
     def __repr__(self):
         return "<Entry '{0}' on {1}>".format(self.title.strip(), self.date.strftime("%Y-%m-%d %H:%M"))
 
+    def __hash__(self):
+        return hash(self.__repr__())
+
     def __eq__(self, other):
         if not isinstance(other, Entry) \
            or self.title.strip() != other.title.strip() \

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -109,6 +109,14 @@ class Journal(object):
         self.entries = self._parse(journal)
         self.sort()
 
+    def import_(self, other_journal_txt):
+        other_entries = self._parse(other_journal_txt)
+        entries_set = frozenset(self.entries)
+        for other_entry in other_entries:
+            if other_entry not in entries_set:
+                self.entries.append(other_entry)
+        self.sort()
+
     def _parse(self, journal_txt):
         """Parses a journal that's stored in a string and returns a list of entries"""
 


### PR DESCRIPTION
Hi! This pull adds --import support to jrnl, which lets the user import entries into the current journal from either stdin or another journal (if -i is specified).  It does not import duplicate entries (defined to be entries with both the same date and content), which means that it provides a safe way to merge two journals.

This functionality is important to me because I put my journal.txt into a Dropbox and update it on multiple computers, and occasionally there is a conflict which results in multiple versions of journal.txt. Using --import I can easily resolve the conflict by importing journal entries from the conflicting version of journal.txt into the main journal.txt file.

Also, I designed --import so that plays nicely with --export and --edit; this was done not out of an immediate need but because part of the philosophy behind jrnl seems to be that the user should be able to ask for whatever they want in any combination and we should do our best to grant it.
