### PR TITLE
Close file handle before passing edit's tempfile to editor.

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -163,14 +163,14 @@ def get_text_from_editor(config, template=""):
     with codecs.open(tmpfile, 'w', "utf-8") as f:
         if template:
             f.write(template)
+    os.close(filehandle)  # remove process lock on temp file
     try:
         subprocess.call(shlex.split(config['editor'], posix="win" not in sys.platform) + [tmpfile])
     except AttributeError:
         subprocess.call(config['editor'] + [tmpfile])
     with codecs.open(tmpfile, "r", "utf-8") as f:
         raw = f.read()
-    os.close(filehandle)
-    os.remove(tmpfile)
+    os.remove(tmpfile)  # delete temp file
     if not raw:
         prompt('[Nothing saved to file]')
     return raw


### PR DESCRIPTION
Fix for #415 on Windows.
