### PR TITLE
Add ability to search in entry title and body

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -98,6 +98,17 @@ the last five entries containing both ``@pineapple`` **and** ``@lubricant``. You
 
   ``jrnl @pinkie @WorldDomination`` will switch to viewing mode because although **no** command line arguments are given, all the input strings look like tags - *jrnl* will assume you want to filter by tag.
 
+Searching
+---------
+
+To search for a string ``"excellent idea"`` in all journal entries, use the ``-search`` argument::
+
+    jrnl -search "excellent idea"
+
+The ``-search`` argument can be combined with other filters, such as ``-from`` and ``-until``.
+
+Note that the searching is case-insensitive and doesn't accept any wildcards or regular expression syntax.
+
 Editing older entries
 ---------------------
 

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -165,7 +165,7 @@ class Journal(object):
         tag_counts = set([(tags.count(tag), tag) for tag in tags])
         return [Tag(tag, count=count) for count, tag in sorted(tag_counts)]
 
-    def filter(self, tags=[], start_date=None, end_date=None, starred=False, strict=False, short=False):
+    def filter(self, tags=[], start_date=None, end_date=None, starred=False, strict=False, short=False, search_plain=None):
         """Removes all entries from the journal that don't match the filter.
 
         tags is a list of tags, each being a string that starts with one of the
@@ -189,6 +189,7 @@ class Journal(object):
             and (not starred or entry.starred)
             and (not start_date or entry.date >= start_date)
             and (not end_date or entry.date <= end_date)
+            and (not search_plain or search_plain in entry.title or search_plain in entry.body)
         ]
 
         self.entries = result

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -35,7 +35,7 @@ def parse_args(args=None):
     reading = parser.add_argument_group('Reading', 'Specifying either of these parameters will display posts of your journal')
     reading.add_argument('-from', dest='start_date', metavar="DATE", help='View entries after this date')
     reading.add_argument('-until', '-to', dest='end_date', metavar="DATE", help='View entries before this date')
-    reading.add_argument('-p', '-search', dest='search_plain', help='View entries containing a specific string')
+    reading.add_argument('-S', '-search', dest='search_plain', help='View entries containing a specific string')
     reading.add_argument('-on', dest='on_date', metavar="DATE", help='View entries on this date')
     reading.add_argument('-and', dest='strict', action="store_true", help='Filter by tags using AND (default: OR)')
     reading.add_argument('-starred', dest='starred', action="store_true", help='Show only starred entries')

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -35,6 +35,7 @@ def parse_args(args=None):
     reading = parser.add_argument_group('Reading', 'Specifying either of these parameters will display posts of your journal')
     reading.add_argument('-from', dest='start_date', metavar="DATE", help='View entries after this date')
     reading.add_argument('-until', '-to', dest='end_date', metavar="DATE", help='View entries before this date')
+    reading.add_argument('-p', '-search', dest='search_plain', help='View entries containing a specific string')
     reading.add_argument('-on', dest='on_date', metavar="DATE", help='View entries on this date')
     reading.add_argument('-and', dest='strict', action="store_true", help='Filter by tags using AND (default: OR)')
     reading.add_argument('-starred', dest='starred', action="store_true", help='Show only starred entries')
@@ -66,7 +67,7 @@ def guess_mode(args, config):
     elif args.decrypt is not False or args.encrypt is not False or args.export is not False or any((args.short, args.tags, args.edit)):
         compose = False
         export = True
-    elif any((args.start_date, args.end_date, args.on_date, args.limit, args.strict, args.starred)):
+    elif any((args.start_date, args.end_date, args.on_date, args.limit, args.strict, args.starred, args.search_plain)):
         # Any sign of displaying stuff?
         compose = False
     elif args.text and all(word[0] in config['tagsymbols'] for word in " ".join(args.text).split()):
@@ -234,7 +235,8 @@ def run(manual_args=None):
                        start_date=args.start_date, end_date=args.end_date,
                        strict=args.strict,
                        short=args.short,
-                       starred=args.starred)
+                       starred=args.starred,
+                       search_plain=args.search_plain)
         journal.limit(args.limit)
 
     # Reading mode


### PR DESCRIPTION
This merge request replaces #448 , which wasn't rebased against branch `2.0-rc1`.

* The first commit fixes behave tests for `python3`.
* The second commit adds a feature to search the journal entries (their title and text body) by using the `-S` and `-search` CLI switches. (`-s` is already used for `--short`)

Fixes #384 
