### PR TITLE
Adds JSON importing feature and HTML exporting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ If you just call `jrnl`, you will be prompted to compose your entry - but you ca
 
 Installation
 ------------
+Install _jrnl_ from source:
+
+    sudo python setup.py install
 
 Install _jrnl_ using pip:
 

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -109,3 +109,31 @@ class Entry:
             body=body,
             space=space
         )
+
+    def to_html(self):
+        html = "<!DOCTYPE html>\n"
+        html += "<html>\n"
+        html += "\t<head>\n"
+        html += "\t\t<style>\n"
+        html += "\t\t\tp{margin:0;}\n"
+        html += "\t\t\th2{margin:0}\n"
+        html += "\t\t\tbody{\n"
+        html += "\t\t\t\tbackground: #252a32;\n"
+        html += "\t\t\t\tmargin-top:5%;\n"
+        html += "\t\t\t\tmargin-bottom:5%;\n"
+        html += "\t\t\t\tmargin-left:5%;\n"
+        html += "\t\t\t\tmargin-right:5%;\n"
+        html += "\t\t\t}\n"
+        html += "\t\t</style>\n"
+        html += "\t</head>\n\n"
+        html += "\t<body>\n"
+        html += "\t\t<font color=\"white\">\n"
+        html += "\t\t\t<h1>Journal</h1>\n"
+        html += "\t\t\t<br>\n"
+        # date time title body
+        html +="\t\t\t\t<h2>" + self.date.strftime(self.journal.config['timeformat']) + "\t" + str(self.title) + "</h2>\n"
+        html +="\t\t\t\t<p class=\"tab\">" + str(self.body) + "</p>\n\t\t\t<br>\n\t\t\t<br>\n"
+        html +="\t\t</font>\n"
+        html +="\t</body>\n"
+        html +="</html>"
+        return html

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -47,7 +47,7 @@ def parse_args(args=None):
     exporting.add_argument('--short', dest='short', action="store_true", help='Show only titles or line containing the search tags')
     exporting.add_argument('--tags', dest='tags', action="store_true", help='Returns a list of all tags and number of occurences')
     exporting.add_argument('--import-json', metavar='FILEPATH', dest='import_json', help='Import a journal from a JSON file.', default=False, const=None)
-    exporting.add_argument('--export', metavar='TYPE', dest='export', choices=['text', 'txt', 'markdown', 'md', 'json'], help='Export your journal. TYPE can be json, markdown, or text.', default=False, const=None)
+    exporting.add_argument('--export', metavar='TYPE', dest='export', choices=['text', 'txt', 'markdown', 'md', 'json', 'html'], help='Export your journal. TYPE can be json, markdown, html, or text.', default=False, const=None)
     exporting.add_argument('-o', metavar='OUTPUT', dest='output', help='Optionally specifies output file when using --export. If OUTPUT is a directory, exports each entry into an individual file instead.', default=False, const=None)
     exporting.add_argument('--encrypt', metavar='FILENAME', dest='encrypt', help='Encrypts your existing journal with a new password', nargs='?', default=False, const=None)
     exporting.add_argument('--decrypt', metavar='FILENAME', dest='decrypt', help='Decrypts your journal and stores it in plain text', nargs='?', default=False, const=None)

--- a/jrnl/exporters.py
+++ b/jrnl/exporters.py
@@ -66,9 +66,38 @@ def to_txt(journal):
     return journal.pprint()
 
 
+def to_html(journal):
+    html = "<!DOCTYPE html>\n"
+    html += "<html>\n"
+    html += "\t<head>\n"
+    html += "\t\t<style>\n"
+    html += "\t\t\tp{margin:0;}\n"
+    html += "\t\t\th2{margin:0}\n"
+    html += "\t\t\tbody{\n"
+    html += "\t\t\t\tbackground: #252a32;\n"
+    html += "\t\t\t\tmargin-top:5%;\n"
+    html += "\t\t\t\tmargin-bottom:5%;\n"
+    html += "\t\t\t\tmargin-left:5%;\n"
+    html += "\t\t\t\tmargin-right:5%;\n"
+    html += "\t\t\t}\n"
+    html += "\t\t</style>\n"
+    html += "\t</head>\n\n"
+    html += "\t<body>\n"
+    html += "\t\t<font color=\"white\">\n"
+    html += "\t\t\t<h1>Journal</h1>\n"
+    html += "\t\t\t<br>\n"
+    for element in journal.entries:
+        # date time title body
+        html += "\t\t\t\t<h2>" + str(element.date) + "\t" + element.title + "</h2>\n"
+        html += "\t\t\t\t<p class=\"tab\">" + element.body + "</p>\n\t\t\t<br>\n\t\t\t<br>\n"
+    html += "\t\t</font>\n"
+    html += "\t</body>\n"
+    html += "</html>"
+    return html
+
 def export(journal, format, output=None):
     """Exports the journal to various formats.
-    format should be one of json, txt, text, md, markdown.
+    format should be one of json, txt, text, md, markdown, html.
     If output is None, returns a unicode representation of the output.
     If output is a directory, exports entries into individual files.
     Otherwise, exports to the given output file.
@@ -78,10 +107,11 @@ def export(journal, format, output=None):
         "txt": to_txt,
         "text": to_txt,
         "md": to_md,
-        "markdown": to_md
+        "markdown": to_md,
+        "html": to_html
     }
     if format not in maps:
-        return "[ERROR: can't export to '{0}'. Valid options are 'md', 'txt', and 'json']".format(format)
+        return "[ERROR: can't export to '{0}'. Valid options are 'md', 'txt', 'html', and 'json']".format(format)
     if output and os.path.isdir(output):  # multiple files
         return write_files(journal, output, format)
     else:
@@ -109,6 +139,8 @@ def write_files(journal, path, format):
             content = e.to_md()
         elif format in ('txt', 'text'):
             content = e.__unicode__()
+        elif format == 'html':
+            content = e.to_html()
         with codecs.open(full_path, "w", "utf-8") as f:
             f.write(content)
     return "[Journal exported individual files in {0}]".format(path)

--- a/jrnl/exporters.py
+++ b/jrnl/exporters.py
@@ -75,7 +75,7 @@ def to_html(journal):
     html += "\t\t\th2{margin:0}\n"
     html += "\t\t\tbody{\n"
     html += "\t\t\t\tfont-family: sans-serif;\n"
-    html += "\t\t\t\tbackground: #252a32;\n"
+    html += "\t\t\t\tbackground: #1B2C3E;\n"
     html += "\t\t\t\tmargin-top:5%;\n"
     html += "\t\t\t\tmargin-bottom:5%;\n"
     html += "\t\t\t\tmargin-left:5%;\n"

--- a/jrnl/exporters.py
+++ b/jrnl/exporters.py
@@ -87,10 +87,15 @@ def to_html(journal):
     html += "\t\t<font color=\"white\">\n"
     html += "\t\t\t<h1>Journal</h1>\n"
     html += "\t\t\t<br>\n"
-    for element in journal.entries:
+    iterator = 0
+    while iterator < len(journal.entries):
         # date time title body
+        element = journal.entries[iterator]
         html += "\t\t\t\t<h2>" + str(element.date) + "\t" + element.title + "</h2>\n"
-        html += "\t\t\t\t<p class=\"tab\">" + element.body + "</p>\n\t\t\t<br>\n\t\t\t<br>\n"
+        html += "\t\t\t\t<p class=\"tab\">" + element.body.strip() + "</p>\n"
+        if iterator < (len(journal.entries) - 1):
+            html += "\t\t\t<br>\n\t\t\t<br>\n"
+        iterator += 1
     html += "\t\t</font>\n"
     html += "\t</body>\n"
     html += "</html>"

--- a/jrnl/exporters.py
+++ b/jrnl/exporters.py
@@ -74,6 +74,7 @@ def to_html(journal):
     html += "\t\t\tp{margin:0;}\n"
     html += "\t\t\th2{margin:0}\n"
     html += "\t\t\tbody{\n"
+    html += "\t\t\t\tfont-family: sans-serif;\n"
     html += "\t\t\t\tbackground: #252a32;\n"
     html += "\t\t\t\tmargin-top:5%;\n"
     html += "\t\t\t\tmargin-bottom:5%;\n"

--- a/jrnl/importers.py
+++ b/jrnl/importers.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+import os
+import json
+import sys
+from . import util
+
+def import_json(path, jrnl_config):
+    json_data = util.load_and_fix_json(path, "JSON")
+
+    new_jrnl = open(jrnl_config["journal"], "w")
+    for element in json_data["entries"]:
+        new_jrnl.write(
+            element["date"] + 
+            " " +
+            element["time"] + 
+            " " +
+            element["title"] + 
+            "\n" +
+            element["body"]
+        )
+    new_jrnl.close()

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -93,36 +93,34 @@ def yesno(prompt, default=True):
     raw = py23_input(prompt)
     return {'y': True, 'n': False}.get(raw.lower(), default)
 
-def load_and_fix_json(json_path):
+def load_and_fix_json(json_path, target_file):
     """Tries to load a json object from a file.
     If that fails, tries to fix common errors (no or extra , at end of the line).
     """
     with open(json_path) as f:
         json_str = f.read()
-        log.debug('Configuration file %s read correctly', json_path)
-    config =  None
+        log.debug('%s file %s read correctly', target_file, json_path)
+    data = None
     try:
         return json.loads(json_str)
     except ValueError as e:
-        log.debug('Could not parse configuration %s: %s', json_str, e,
-                exc_info=True)
+        log.debug('Could not parse %s %s: %s', target_file, json_str, e, exc_info=True)
         # Attempt to fix extra ,
         json_str = re.sub(r",[ \n]*}", "}", json_str)
         # Attempt to fix missing ,
         json_str = re.sub(r"([^{,]) *\n *(\")", r"\1,\n \2", json_str)
         try:
-            log.debug('Attempting to reload automatically fixed configuration file %s', 
-                    json_str)
-            config = json.loads(json_str)
+            log.debug('Attempting to reload automatically fixed %s file %s', target_file, json_str)
+            data = json.loads(json_str)
             with open(json_path, 'w') as f:
-                json.dump(config, f, indent=2)
-                log.debug('Fixed configuration saved in file %s', json_path)
-            prompt("[Some errors in your jrnl config have been fixed for you.]")
-            return config
+                json.dump(data, f, indent=2)
+                log.debug('Fixed %s saved in file %s', target_file, json_path)
+            prompt("[Some errors in your {0} file have been fixed for you.]".format(target_file))
+            return data
         except ValueError as e:
-            log.debug('Could not load fixed configuration: %s', e, exc_info=True)
-            prompt("[There seems to be something wrong with your jrnl config at {0}: {1}]".format(json_path, e.message))
-            prompt("[Entry was NOT added to your journal]")
+            log.debug('Could not load fixed %s: %s', target_file, e, exc_info=True)
+            prompt("[There seems to be something wrong with your {0} file at {1}: {2}]".format(target_file, json_path, e.message))
+            prompt("[Journal was NOT modified]")
             sys.exit(1)
 
 def get_text_from_editor(config, template=""):


### PR DESCRIPTION
I realized after exporting my journal to a JSON file and accidentally deleting the original journal, there wasn't an option in the jrnl CLI to import my JSON file back into a journal except by doing so manually. This pull request adds an option in the jrnl CLI to import from a JSON formatted file.

Additionally, I wanted a way to export my journal to a static webpage with minimal/no client-side dependencies that I know will look "ok"/"pretty". So this pull request also adds another option to the jrnl CLI that gives the user an option to export their jrnl to a light HTML file with inlined CSS; the intent is that the user can export their journal and drop it straight into a static content server (i.e. Apache webserver) without any extra work to make it look presentable

I did not make any changes related to the jrnl application version, Travis, etc. etc. as I wanted to leave that to the upstream maintainer (@maebert) to decide whether these changes are appropriate to merge into the jrnl application. If they are, I'd like to see if these additions can be pushed out to the jrnl being served through the pip repositories too.