### PR TITLE
Support JRNLRC environment variable to specify configuration file

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -8,6 +8,8 @@ Configuration File
 
 You can configure the way jrnl behaves in a configuration file. By default, this is ``~/.jrnl_config``. If you have the ``XDG_CONFIG_HOME`` variable set, the configuration file will be saved under ``$XDG_CONFIG_HOME/jrnl``.
 
+The default path can be overridden with the ``JRNLRC`` environment variable. This can be useful if you want to keep project specific configurations and automatically switch to them using e.g. ``direnv``.
+
 .. note::
 
     On Windows, The configuration file is typically found at ``C:\Users\[Your Username]\.jrnl_config``.

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -19,10 +19,12 @@ DEFAULT_CONFIG_NAME = 'jrnl.yaml'
 DEFAULT_JOURNAL_NAME = 'journal.txt'
 XDG_RESOURCE = 'jrnl'
 
+ENV_JRNLRC = os.environ.get('JRNLRC')
+
 USER_HOME = os.path.expanduser('~')
 
 CONFIG_PATH = xdg.BaseDirectory.save_config_path(XDG_RESOURCE) or USER_HOME
-CONFIG_FILE_PATH = os.path.join(CONFIG_PATH, DEFAULT_CONFIG_NAME)
+CONFIG_FILE_PATH = ENV_JRNLRC or os.path.join(CONFIG_PATH, DEFAULT_CONFIG_NAME)
 CONFIG_FILE_PATH_FALLBACK = os.path.join(USER_HOME, ".jrnl_config")
 
 JOURNAL_PATH = xdg.BaseDirectory.save_data_path(XDG_RESOURCE) or USER_HOME


### PR DESCRIPTION
This allows switching configurations using e.g. direnv.