### PR TITLE
[GH-614] resolving issues around unreadable dates

### DIFF
--- a/features/data/configs/brackets.yaml
+++ b/features/data/configs/brackets.yaml
@@ -1,0 +1,12 @@
+default_hour: 9
+default_minute: 0
+editor: ""
+encrypt: false
+highlight: true
+journals:
+  default: features/journals/brackets.journal
+linewrap: 80
+tagsymbols: "@"
+template: false
+timeformat: "%Y-%m-%d %H:%M"
+indent_character: "|"

--- a/features/data/configs/mostlyreadabledates.yaml
+++ b/features/data/configs/mostlyreadabledates.yaml
@@ -1,0 +1,12 @@
+default_hour: 9
+default_minute: 0
+editor: ""
+encrypt: false
+highlight: true
+journals:
+  default: features/journals/mostlyreadabledates.journal
+linewrap: 80
+tagsymbols: "@"
+template: false
+timeformat: "%Y-%m-%d %H:%M"
+indent_character: "|"

--- a/features/data/configs/unreadabledates.yaml
+++ b/features/data/configs/unreadabledates.yaml
@@ -1,0 +1,12 @@
+default_hour: 9
+default_minute: 0
+editor: ""
+encrypt: false
+highlight: true
+journals:
+  default: features/journals/unreadabledates.journal
+linewrap: 80
+tagsymbols: "@"
+template: false
+timeformat: "%Y-%m-%d %H:%M"
+indent_character: "|"

--- a/features/data/journals/brackets.journal
+++ b/features/data/journals/brackets.journal
@@ -1,0 +1,2 @@
+[2019-07-08 05:42] Entry subject
+[1] line starting with 1

--- a/features/data/journals/mostlyreadabledates.journal
+++ b/features/data/journals/mostlyreadabledates.journal
@@ -1,0 +1,8 @@
+[2019-07-18 14:23] Entry subject
+Time machines are possible. I know, because I've built one in my garage.
+
+[2019-07-19 14:23] Entry subject
+I'm going to activate the machine. Nobody knows what comes next after this. Or before this?
+
+[2019-07 14:23] Entry subject
+I've crossed so many timelines. Is there any going back?

--- a/features/data/journals/unreadabledates.journal
+++ b/features/data/journals/unreadabledates.journal
@@ -1,0 +1,5 @@
+[ashasd7zdskhz7asdkjasd] Entry subject
+I've lost track of time.
+
+[sadfhakjsdf88sdf7sdff] Entry subject
+Time has no meaning.

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -53,3 +53,22 @@ Feature: Zapped bugs should stay dead.
             2013-06-10 15:40 He said "[this] is the best time to be alive".
             """
 
+    Scenario: Integers in square brackets should not be read as dates 
+        Given we use the config "brackets.yaml"
+        When we run "jrnl -1"
+        Then the output should contain "[1] line starting with 1"
+
+    Scenario: Journals with unreadable dates should still be viewable 
+        Given we use the config "unreadabledates.yaml"
+        When we run "jrnl -2"
+        Then the output should contain "I've lost track of time."
+        Then the output should contain "Time has no meaning."
+
+    Scenario: Journals with readable dates AND unreadable dates should still contain all data.
+        Given we use the config "mostlyreadabledates.yaml"
+        When we run "jrnl -3"
+        Then the output should contain "Time machines are possible."
+        When we run "jrnl -1"
+        Then the output should contain "I'm going to activate the machine."
+        Then the output should contain "I've crossed so many timelines. Is there any going back?"
+

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -99,8 +99,14 @@ class Journal(object):
 
     def _parse(self, journal_txt):
         """Parses a journal that's stored in a string and returns a list of entries"""
+
+        # Return empty array if the journal is blank
+        if not journal_txt:
+            return []
+
         # Initialise our current entry
         entries = []
+
         date_blob_re = re.compile("(?:^|\n)\[([^\\]]+)\] ")
         last_entry_pos = 0
         for match in date_blob_re.finditer(journal_txt):
@@ -111,9 +117,14 @@ class Journal(object):
                     entries[-1].text = journal_txt[last_entry_pos:match.start()]
                 last_entry_pos = match.end()
                 entries.append(Entry.Entry(self, date=new_date))
-        # Finish the last entry
-        if entries:
-            entries[-1].text = journal_txt[last_entry_pos:]
+
+        
+        # If no entries were found, treat all the existing text as an entry made now
+        if not entries:
+            entries.append(Entry.Entry(self, date=time.parse("now")))
+
+        # Fill in the text of the last entry
+        entries[-1].text = journal_txt[last_entry_pos:]
 
         for entry in entries:
             entry._parse_text()

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -19,6 +19,10 @@ def parse(date_str, inclusive=False, default_hour=None, default_minute=None):
     elif isinstance(date_str, datetime):
         return date_str
 
+    # Don't try to parse anything with 6 or less characters. It's probably a markdown footnote
+    if len(date_str) <= 6:
+        return None
+
     default_date = DEFAULT_FUTURE if inclusive else DEFAULT_PAST
     date = None
     year_present = False


### PR DESCRIPTION
This adds a few changes to the way jrnl reads dates and entries:
- Assume any value in brackets but 6 characters or less isn't a date but is instead part of the current entry. This is useful for markdown footnotes as mentioned in GH-614
- If a journal has only unreadable dates, assume that it's one entry (instead of ignoring its contents completely, which could lead to deletion in future jrnl calls)