### PR TITLE
Fzf recipe

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -81,7 +81,7 @@ Select a previous entry to display
 
 .. code-block:: sh
 
-    jrnl -on "$(jrnl --short | fzf | cut -d' ' -f1,2)"
+    jrnl -on "$(jrnl --short | fzf --ansi --tac | cut -d' ' -f1,2)"
 
 External editors
 ----------------

--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -74,6 +74,14 @@ Another nice solution that allows you to define individual prompts comes from `J
     log_question 'What did I achieve today?'
     log_question 'What did I make progress with?'
 
+Filtering with FZF
+~~~~~~~~~~~~~~~~~~
+
+Select a previous entry to display
+
+.. code-block:: sh
+
+    jrnl -on "$(jrnl --short | fzf | cut -d' ' -f1,2)"
 
 External editors
 ----------------


### PR DESCRIPTION
Add a recipe that uses [fzf](https://github.com/junegunn/fzf) as a real-time filter to select an entry from `jrnl --short` and display the full entry.

In this trivial example, an error will be returned if fzf is aborted with no selection, since `jrnl -on` expects an argument. A more complete shell function can guard against that, which I do in my fish shell version. I'm tempted to leave this as simple and flawed because it works well enough and can be typed by hand.