### PR TITLE
Switch to hashmark Markdown headers on export (Mk II)

### DIFF
--- a/features/exporting.feature
+++ b/features/exporting.feature
@@ -42,11 +42,9 @@ Feature: Exporting a Journal
         When we run "jrnl --export markdown"
         Then the output should be
         """
-        2015
-        ====
+        # 2015
 
-        April
-        -----
+        ## April
 
         ### 2015-04-14 13:23 Heading Test
 

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 from .text_exporter import TextExporter
+import os
 import re
 import sys
 from ..util import WARNING_COLOR, RESET_COLOR
@@ -30,17 +31,17 @@ class MarkdownExporter(TextExporter):
         previous_line = ''
         warn_on_heading_level = False
         for line in body.splitlines(True):
-            if re.match(r"#+ ", line):
+            if re.match(r"^#+ ", line):
                 """ATX style headings"""
                 newbody = newbody + previous_line + heading + line
-                if re.match(r"#######+ ", heading + line):
+                if re.match(r"^#######+ ", heading + line):
                     warn_on_heading_level = True
                 line = ''
-            elif re.match(r"=+$", line) and not re.match(r"^$", previous_line):
+            elif re.match(r"^=+$", line.rstrip()) and not re.match(r"^$", previous_line.strip()):
                 """Setext style H1"""
                 newbody = newbody + heading + "# " + previous_line
                 line = ''
-            elif re.match(r"-+$", line) and not re.match(r"^$", previous_line):
+            elif re.match(r"^-+$", line.rstrip()) and not re.match(r"^$", previous_line.strip()):
                 """Setext style H2"""
                 newbody = newbody + heading + "## " + previous_line
                 line = ''
@@ -69,9 +70,11 @@ class MarkdownExporter(TextExporter):
             if not e.date.year == year:
                 year = e.date.year
                 out.append("# " + str(year))
+                out.append("")
             if not e.date.month == month:
                 month = e.date.month
                 out.append("## " + e.date.strftime("%B"))
+                out.append("")
             out.append(cls.export_entry(e, False))
         result = "\n".join(out)
         return result

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -68,12 +68,10 @@ class MarkdownExporter(TextExporter):
         for e in journal.entries:
             if not e.date.year == year:
                 year = e.date.year
-                out.append(str(year))
-                out.append("=" * len(str(year)) + "\n")
+                out.append("# " + str(year))
             if not e.date.month == month:
                 month = e.date.month
-                out.append(e.date.strftime("%B"))
-                out.append('-' * len(e.date.strftime("%B")) + "\n")
+                out.append("## " + e.date.strftime("%B"))
             out.append(cls.export_entry(e, False))
         result = "\n".join(out)
         return result

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import, unicode_literals, print_function
 from .text_exporter import TextExporter
+import os
 import re
 import sys
 from ..util import WARNING_COLOR, ERROR_COLOR, RESET_COLOR
@@ -34,17 +35,17 @@ class YAMLExporter(TextExporter):
         previous_line = ''
         warn_on_heading_level = False
         for line in entry.body.splitlines(True):
-            if re.match(r"#+ ", line):
+            if re.match(r"^#+ ", line):
                 """ATX style headings"""
                 newbody = newbody + previous_line + heading + line
-                if re.match(r"#######+ ", heading + line):
+                if re.match(r"^#######+ ", heading + line):
                     warn_on_heading_level = True
                 line = ''
-            elif re.match(r"=+$", line) and not re.match(r"^$", previous_line):
+            elif re.match(r"^=+$", line.rstrip()) and not re.match(r"^$", previous_line.strip()):
                 """Setext style H1"""
                 newbody = newbody + heading + "# " + previous_line
                 line = ''
-            elif re.match(r"-+$", line) and not re.match(r"^$", previous_line):
+            elif re.match(r"^-+$", line.rstrip()) and not re.match(r"^$", previous_line.strip()):
                 """Setext style H2"""
                 newbody = newbody + heading + "## " + previous_line
                 line = ''


### PR DESCRIPTION
Re-create #506, re-based to the current 2.0-rc3 master branch.

Closes #487, Closes #506 

Switches from ATX to 'Hashmark' style Markdown headers for single file markdown exports.

(I tried to force-push to the branch to update #506, but just managed to close PR. Oops!)