### PR TITLE
reduce the number of days an issue can be open with no activity before marked stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 60
+daysUntilStale: 30
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale


### PR DESCRIPTION
We will increase this again later, but we want to clean out the backlog of old issues
sooner, if possible. This will allow us to do that.