### PR TITLE
Create encrypted journal

### DIFF
--- a/features/data/configs/multiple.yaml
+++ b/features/data/configs/multiple.yaml
@@ -9,6 +9,9 @@ journals:
   ideas: features/journals/nothing.journal
   simple: features/journals/simple.journal
   work: features/journals/work.journal
+  new_encrypted:
+    encrypt: true
+    journal: features/journals/new_encrypted.journal
 linewrap: 80
 password: ''
 tagsymbols: '@'

--- a/features/multiple_journals.feature
+++ b/features/multiple_journals.feature
@@ -42,5 +42,5 @@ Feature: Multiple journals
 
    Scenario: Don't crash if no file exists for a configured encrypted journal
         Given we use the config "multiple.yaml"
-        When we run "jrnl new_encrypted Adding first entry"
-        Then journal "new_encrypted" should have 1 entry
+        When we run "jrnl new_encrypted Adding first entry" and enter "these three eyes"
+	Then we should see the message "Journal 'new_encrypted' created"

--- a/features/multiple_journals.feature
+++ b/features/multiple_journals.feature
@@ -39,3 +39,8 @@ Feature: Multiple journals
         Given we use the config "bug343.yaml"
         When we run "jrnl a long day in the office"
         Then we should see the message "No default journal configured"
+
+   Scenario: Don't crash if no file exists for a configured encrypted journal
+        Given we use the config "multiple.yaml"
+        When we run "jrnl new_encrypted Adding first entry"
+        Then journal "new_encrypted" should have 1 entry

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -5,7 +5,13 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 import hashlib
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.backends import default_backend
+import sys
+import os
 import base64
+import getpass
+import logging
+
+log = logging.getLogger()
 
 
 def make_key(password):
@@ -26,6 +32,33 @@ class EncryptedJournal(Journal.Journal):
     def __init__(self, name='default', **kwargs):
         super(EncryptedJournal, self).__init__(name, **kwargs)
         self.config['encrypt'] = True
+
+    def open(self, filename=None):
+        """Opens the journal file defined in the config and parses it into a list of Entries.
+        Entries have the form (date, title, body)."""
+        filename = filename or self.config['journal']
+
+        if not os.path.exists(filename):
+            password = getpass.getpass("Enter password for new journal: ")
+            if password:
+                if util.yesno("Do you want to store the password in your keychain?", default=True):
+                    util.set_keychain(self.name, password)
+                else:
+                    util.set_keychain(self.name, None)
+                self.config['password'] = password
+                text = ""
+                self._store(filename, text)
+                util.prompt("[Journal '{0}' created at {1}]".format(self.name, filename))
+            else:
+                util.prompt("No password supplied for encrypted journal")
+                sys.exit(1)
+        else:
+            text = self._load(filename)
+        self.entries = self._parse(text)
+        self.sort()
+        log.debug("opened %s with %d entries", self.__class__.__name__, len(self))
+        return self
+
 
     def _load(self, filename, password=None):
         """Loads an encrypted journal from a file and tries to decrypt it.


### PR DESCRIPTION
This PR is unfinished so that others can assist on it. The behave test passes, but doesn't seem to take the entered string as a password for the newly encrypted journal. Instead, it's prompting for user input during the test.

Otherwise, this should resolve #635 .

The approach that I've taken is to overload the open method for EncryptedJournal. This involves some duplication, but avoids calling EncryptedJournal._create() without having a password available.