### PR TITLE
#631 Escape data in square brackets

### DIFF
--- a/features/data/journals/simple_jrnl-1-9-5.journal
+++ b/features/data/journals/simple_jrnl-1-9-5.journal
@@ -1,3 +1,13 @@
 2010-06-10 15:00 A life without chocolate is like a bad analogy.
 
 2013-06-10 15:40 He said "[this] is the best time to be alive".
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent malesuada
+quis est ac dignissim. Aliquam dignissim rutrum pretium. Phasellus pellentesque
+augue et venenatis facilisis.
+
+[2019-08-03 12:55] Some chat log or something
+
+Suspendisse potenti. Sed dignissim sed nisl eu consequat. Aenean ante ex,
+elementum ut interdum et, mattis eget lacus. In commodo nulla nec tellus
+placerat, sed ultricies metus bibendum. Duis eget venenatis erat. In at dolor
+dui.

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -43,15 +43,16 @@ Feature: Zapped bugs should stay dead.
             | Hope to get a lot of traffic.
             """
 
-	Scenario: Upgrade and parse journals with square brackets
-		Given we use the config "upgrade_from_195.json"
-		When we run "jrnl -2" and enter "Y"
-		Then the output should contain
+    Scenario: Upgrade and parse journals with square brackets
+        Given we use the config "upgrade_from_195.json"
+        When we run "jrnl -9" and enter "Y"
+        Then the output should contain
             """
             2010-06-10 15:00 A life without chocolate is like a bad analogy.
 
             2013-06-10 15:40 He said "[this] is the best time to be alive".
             """
+        Then the journal should have 2 entries
 
     Scenario: Integers in square brackets should not be read as dates 
         Given we use the config "brackets.yaml"

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -118,7 +118,6 @@ class Journal(object):
                 last_entry_pos = match.end()
                 entries.append(Entry.Entry(self, date=new_date))
 
-        
         # If no entries were found, treat all the existing text as an entry made now
         if not entries:
             entries.append(Entry.Entry(self, date=time.parse("now")))
@@ -218,7 +217,11 @@ class Journal(object):
         if not date:
             colon_pos = first_line.find(": ")
             if colon_pos > 0:
-                date = time.parse(raw[:colon_pos], default_hour=self.config['default_hour'], default_minute=self.config['default_minute'])
+                date = time.parse(
+                    raw[:colon_pos],
+                    default_hour=self.config['default_hour'],
+                    default_minute=self.config['default_minute']
+                )
                 if date:  # Parsed successfully, strip that from the raw text
                     starred = raw[:colon_pos].strip().endswith("*")
                     raw = raw[colon_pos + 1:].strip()
@@ -325,7 +328,10 @@ def open_journal(name, config, legacy=False):
             from . import DayOneJournal
             return DayOneJournal.DayOne(**config).open()
         else:
-            util.prompt(u"[Error: {0} is a directory, but doesn't seem to be a DayOne journal either.".format(config['journal']))
+            util.prompt(
+                u"[Error: {0} is a directory, but doesn't seem to be a DayOne journal either.".format(config['journal'])
+            )
+
             sys.exit(1)
 
     if not config['encrypt']:

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -283,6 +283,7 @@ class LegacyJournal(Journal):
         # Initialise our current entry
         entries = []
         current_entry = None
+        new_date_format_regex = re.compile(r'(^\[[^\]]+\].*?$)')
         for line in journal_txt.splitlines():
             line = line.rstrip()
             try:
@@ -302,7 +303,9 @@ class LegacyJournal(Journal):
                 current_entry = Entry.Entry(self, date=new_date, text=line[date_length + 1:], starred=starred)
             except ValueError:
                 # Happens when we can't parse the start of the line as an date.
-                # In this case, just append line to our body.
+                # In this case, just append line to our body (after some
+                # escaping for the new format).
+                line = new_date_format_regex.sub(r' \1', line)
                 if current_entry:
                     current_entry.text += line + u"\n"
 


### PR DESCRIPTION
Lines that have dates in square brackets at the start of the line were confusing
the new date format. With this update, LegacyJournal now looks for those lines
and escapes them by simply adding a space at the start of the line.

A space seems like the least intrusive way to escape entries of this format.