### PR TITLE
Change pyYAML required version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "six>=1.10.0",
         "cryptography>=1.4",
         "tzlocal>=1.2",
-        "pyyaml>=3.11",
+        "pyyaml>=5.1",
         "keyring>=7.3",
         "passlib>=1.6.2",
         "pyxdg>=0.25",


### PR DESCRIPTION
FullLoader only available from v5.1 : https://pyyaml.org/wiki/PyYAML#history
In a lower version of pyYAML FullLoader  doesn't exist and jrnl doesn't work. 