### PR TITLE
Fix parsing Journals using a little-endian date format

### DIFF
--- a/features/custom_dates.feature
+++ b/features/custom_dates.feature
@@ -1,0 +1,35 @@
+Feature: Reading and writing to journal with custom date formats
+
+    Scenario: Loading a sample journal
+        Given we use the config "little_endian_dates.yaml"
+        When we run "jrnl -n 2"
+        Then we should get no error
+        And the output should be
+            """
+            09.06.2013 15:39 My first entry.
+            | Everything is alright
+
+            10.06.2013 15:40 Life is good.
+            | But I'm better.
+            """
+
+    Scenario: Writing an entry from command line
+        Given we use the config "little_endian_dates.yaml"
+        When we run "jrnl 2013-07-12: A cold and stormy day. I ate crisps on the sofa."
+        Then we should see the message "Entry added"
+        When we run "jrnl -n 1"
+        Then the output should contain "12.07.2013 09:00 A cold and stormy day."
+
+    Scenario: Filtering for dates
+        Given we use the config "little_endian_dates.yaml"
+        When we run "jrnl -on 2013-06-10 --short"
+        Then the output should be "10.06.2013 15:40 Life is good."
+        When we run "jrnl -on 'june 6 2013' --short"
+        Then the output should be "10.06.2013 15:40 Life is good."
+
+    Scenario: Writing an entry at the prompt
+        Given we use the config "little_endian_dates.yaml"
+        When we run "jrnl" and enter "2013-05-10: I saw Elvis. He's alive."
+        Then we should get no error
+        And the journal should contain "[10.05.2013 09:00] I saw Elvis."
+        And the journal should contain "He's alive."

--- a/features/data/configs/little_endian_dates.yaml
+++ b/features/data/configs/little_endian_dates.yaml
@@ -1,0 +1,12 @@
+default_hour: 9
+default_minute: 0
+editor: ""
+encrypt: false
+highlight: true
+journals:
+  default: features/journals/little_endian_dates.journal
+linewrap: 80
+tagsymbols: "@"
+template: false
+timeformat: "%d.%m.%Y %H:%M"
+indent_character: "|"

--- a/features/data/configs/upgrade_from_195_little_endian_dates.json
+++ b/features/data/configs/upgrade_from_195_little_endian_dates.json
@@ -1,0 +1,11 @@
+{
+"default_hour": 9,
+"timeformat": "%d.%m.%Y %H:%M",
+"linewrap": 80,
+"encrypt": false,
+"editor": "",
+"default_minute": 0,
+"highlight": true,
+"journals": {"default": "features/journals/simple_jrnl-1-9-5_little_endian_dates.journal"},
+"tagsymbols": "@"
+}

--- a/features/data/journals/little_endian_dates.journal
+++ b/features/data/journals/little_endian_dates.journal
@@ -1,0 +1,5 @@
+[09.06.2013 15:39] My first entry.
+Everything is alright
+
+[10.06.2013 15:40] Life is good.
+But I'm better.

--- a/features/data/journals/simple_jrnl-1-9-5_little_endian_dates.journal
+++ b/features/data/journals/simple_jrnl-1-9-5_little_endian_dates.journal
@@ -1,0 +1,13 @@
+10.06.2010 15:00 A life without chocolate is like a bad analogy.
+
+10.06.2013 15:40 He said "[this] is the best time to be alive".
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent malesuada
+quis est ac dignissim. Aliquam dignissim rutrum pretium. Phasellus pellentesque
+augue et venenatis facilisis.
+
+[03.08.2019 12:55] Some chat log or something
+
+Suspendisse potenti. Sed dignissim sed nisl eu consequat. Aenean ante ex,
+elementum ut interdum et, mattis eget lacus. In commodo nulla nec tellus
+placerat, sed ultricies metus bibendum. Duis eget venenatis erat. In at dolor
+dui.

--- a/features/upgrade.feature
+++ b/features/upgrade.feature
@@ -20,4 +20,15 @@ Feature: Upgrading Journals from 1.x.x to 2.x.x
             bad doggie no biscuit
             """
         Then we should see the message "Password"
-        and the output should contain "2013-06-10 15:40 Life is good"
+        And the output should contain "2013-06-10 15:40 Life is good"
+
+    Scenario: Upgrade and parse journals with little endian date format
+        Given we use the config "upgrade_from_195_little_endian_dates.json"
+        When we run "jrnl -9" and enter "Y"
+        Then the output should contain
+            """
+            10.06.2010 15:00 A life without chocolate is like a bad analogy.
+
+            10.06.2013 15:40 He said "[this] is the best time to be alive".
+            """
+        Then the journal should have 2 entries

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -122,7 +122,11 @@ class Journal(object):
         last_entry_pos = 0
         for match in date_blob_re.finditer(journal_txt):
             date_blob = match.groups()[0]
-            new_date = time.parse(date_blob)
+            try:
+                new_date = datetime.strptime(date_blob, self.config["timeformat"])
+            except ValueError:
+                new_date = time.parse(date_blob)
+
             if new_date:
                 if entries:
                     entries[-1].text = journal_txt[last_entry_pos:match.start()]


### PR DESCRIPTION
Fixes parts of #630 and one source of failure during upgrading to 2.0 (#664).

Ever since version 2.0, when parsing a journal file, jrnl would not use the custom date format string anymore. Instead, it relied on the dateutil library to get the parsing right. This change was made to allow people to change their date format without having to manually change their file. However, this broke some existing date formats like %d.%m.%Y, as it would falsely interpret the month as day and vice versa (when %d <= 12). This commit adds some tests using the little endian date format and fixes the behavior by trying to parse the dates using the custom format first, only falling back to dateutil when needed.

Note that this does not yet allow users to make new entries using the little endian format yet. It will still use the dateutil parser for this. As I usually create new entries with no timestamp or just "today" or "yesterday" as date, this is an okay trade-off for me, but still not ideal. At least upgrading and querying works again properly this way.