### PR TITLE
new version output

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -140,7 +140,7 @@ def run(manual_args=None):
     configure_logger(args.debug)
     args.text = [p.decode('utf-8') if util.PY2 and not isinstance(p, unicode) else p for p in args.text]
     if args.version:
-        version_str = "{0} version {1} (Python {3})".format(jrnl.__title__, jrnl.__version__, sys.version)
+        version_str = "{0} version {1} (Python {2})".format(jrnl.__title__, jrnl.__version__, sys.version)
         print(util.py2encode(version_str))
         sys.exit(0)
 

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -140,7 +140,7 @@ def run(manual_args=None):
     configure_logger(args.debug)
     args.text = [p.decode('utf-8') if util.PY2 and not isinstance(p, unicode) else p for p in args.text]
     if args.version:
-        version_str = "{0} version {1}".format(jrnl.__title__, jrnl.__version__)
+        version_str = "{0} version {1} (Python {3})".format(jrnl.__title__, jrnl.__version__, sys.version)
         print(util.py2encode(version_str))
         sys.exit(0)
 


### PR DESCRIPTION
I've changed the output of `jrnl -v` as mentioned in https://github.com/jrnl-org/jrnl/pull/679 - I haven't modified the tests, as i want to make sure you are okay with the representation before hand. 

### Checklist
- [x] The code change is tested and works locally.
- [ ] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
