### PR TITLE
[Upgrade to 2.0] Expand User directory

### DIFF
--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -54,6 +54,8 @@ older versions of jrnl anymore.
             encrypt = config.get('encrypt')
             path = journal_conf
 
+        path = os.path.expanduser(path)
+
         if encrypt:
             encrypted_journals[journal_name] = path
         elif os.path.isdir(path):


### PR DESCRIPTION
It seems that `~` (meaning the user directory) must be explicitly expanded when used on the configuration to successfully upgrade.

I can't test this directly, as I don't have a Mac system locally. I don't think there are any applicable tests to be written.

c.f issue #689


### Checklist
- [ ] The code change is tested and works locally.
- [ ] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [ ] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
