### PR TITLE
remove py2 remnants and use mocks in tests

### DIFF
--- a/features/encryption.feature
+++ b/features/encryption.feature
@@ -2,7 +2,7 @@
         Scenario: Loading an encrypted journal
             Given we use the config "encrypted.yaml"
             When we run "jrnl -n 1" and enter "bad doggie no biscuit"
-            Then we should see the message "Password"
+            Then the output should contain "Password"
             and the output should contain "2013-06-10 15:40 Life is good"
 
         Scenario: Decrypting a journal
@@ -14,16 +14,16 @@
 
         Scenario: Encrypting a journal
             Given we use the config "basic.yaml"
-            When we run "jrnl --encrypt" and enter "swordfish"
+            When we run "jrnl --encrypt" and enter "swordfish" and "n"
             Then we should see the message "Journal encrypted"
             and the config for journal "default" should have "encrypt" set to "bool:True"
             When we run "jrnl -n 1" and enter "swordfish"
-            Then we should see the message "Password"
+            Then the output should contain "Password"
             and the output should contain "2013-06-10 15:40 Life is good"
 
         Scenario: Storing a password in Keychain
             Given we use the config "multiple.yaml"
-            When we run "jrnl simple --encrypt" and enter "sabertooth"
+            When we run "jrnl simple --encrypt" and enter "sabertooth" and "y"
             When we set the keychain password of "simple" to "sabertooth"
             Then the config for journal "simple" should have "encrypt" set to "bool:True"
             When we run "jrnl simple -n 1"

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,24 +1,14 @@
-from behave import *
 import shutil
 import os
-import jrnl
-try:
-    from io import StringIO
-except ImportError:
-    from cStringIO import StringIO
+
 
 def before_scenario(context, scenario):
     """Before each scenario, backup all config and journal test data."""
-    context.messages = StringIO()
-    jrnl.util.STDERR = context.messages
-    jrnl.util.TEST = True
-
     # Clean up in case something went wrong
     for folder in ("configs", "journals"):
         working_dir = os.path.join("features", folder)
         if os.path.exists(working_dir):
             shutil.rmtree(working_dir)
-
 
     for folder in ("configs", "journals"):
         original = os.path.join("features", "data", folder)
@@ -32,10 +22,9 @@ def before_scenario(context, scenario):
             else:
                 shutil.copy2(source, working_dir)
 
+
 def after_scenario(context, scenario):
     """After each scenario, restore all test data and remove working_dirs."""
-    context.messages.close()
-    context.messages = None
     for folder in ("configs", "journals"):
         working_dir = os.path.join("features", folder)
         if os.path.exists(working_dir):

--- a/features/multiple_journals.feature
+++ b/features/multiple_journals.feature
@@ -42,5 +42,5 @@ Feature: Multiple journals
 
    Scenario: Don't crash if no file exists for a configured encrypted journal
         Given we use the config "multiple.yaml"
-        When we run "jrnl new_encrypted Adding first entry" and enter "these three eyes"
+        When we run "jrnl new_encrypted Adding first entry" and enter "these three eyes" and "y"
 	Then we should see the message "Journal 'new_encrypted' created"

--- a/features/upgrade.feature
+++ b/features/upgrade.feature
@@ -13,11 +13,11 @@ Feature: Upgrading Journals from 1.x.x to 2.x.x
 
     Scenario: Upgrading a journal encrypted with jrnl 1.x
         Given we use the config "encrypted_old.json"
-        When we run "jrnl -n 1" and enter 
+        When we run "jrnl -n 1" and enter
             """
             Y
             bad doggie no biscuit
             bad doggie no biscuit
             """
-        Then we should see the message "Password"
+        Then the output should contain "Password"
         and the output should contain "2013-06-10 15:40 Life is good"

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
 from . import Entry
 from . import Journal
@@ -25,7 +24,7 @@ class DayOne(Journal.Journal):
     def __init__(self, **kwargs):
         self.entries = []
         self._deleted_entries = []
-        super(DayOne, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def open(self):
         filenames = [os.path.join(self.config['journal'], "entries", f) for f in os.listdir(os.path.join(self.config['journal'], "entries"))]
@@ -106,7 +105,7 @@ class DayOne(Journal.Journal):
                 current_entry.modified = False
                 current_entry.uuid = m.group(1).lower()
             else:
-                date_blob_re = re.compile("^\[[^\\]]+\] ")
+                date_blob_re = re.compile("^\\[[^\\]]+\\] ")
                 date_blob = date_blob_re.findall(line)
                 if date_blob:
                     date_blob = date_blob[0]

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 from . import Entry
 from . import Journal
 from . import time as jrnl_time
@@ -83,7 +82,7 @@ class DayOne(Journal.Journal):
     def editable_str(self):
         """Turns the journal into a string of entries that can be edited
         manually and later be parsed with eslf.parse_editable_str."""
-        return "\n".join(["# {0}\n{1}".format(e.uuid, e.__unicode__()) for e in self.entries])
+        return "\n".join(["# {0}\n{1}".format(e.uuid, str(e)) for e in self.entries])
 
     def parse_editable_str(self, edited):
         """Parses the output of self.editable_str and updates its entries."""

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -82,7 +82,7 @@ class DayOne(Journal.Journal):
     def editable_str(self):
         """Turns the journal into a string of entries that can be edited
         manually and later be parsed with eslf.parse_editable_str."""
-        return "\n".join(["# {0}\n{1}".format(e.uuid, str(e)) for e in self.entries])
+        return "\n".join([f"# {e.uuid}\n{str(e)}" for e in self.entries])
 
     def parse_editable_str(self, edited):
         """Parses the output of self.editable_str and updates its entries."""

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -29,7 +29,7 @@ def make_key(password):
 
 class EncryptedJournal(Journal.Journal):
     def __init__(self, name='default', **kwargs):
-        super(EncryptedJournal, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
         self.config['encrypt'] = True
 
     def open(self, filename=None):
@@ -47,7 +47,7 @@ class EncryptedJournal(Journal.Journal):
                 self.config['password'] = password
                 text = ""
                 self._store(filename, text)
-                print("[Journal '{0}' created at {1}]".format(self.name, filename), file=sys.stderr)
+                print(f"[Journal '{self.name}' created at {filename}]", file=sys.stderr)
             else:
                 print("No password supplied for encrypted journal", file=sys.stderr)
                 sys.exit(1)
@@ -97,7 +97,7 @@ class LegacyEncryptedJournal(Journal.LegacyJournal):
     """Legacy class to support opening journals encrypted with the jrnl 1.x
     standard. You'll not be able to save these journals anymore."""
     def __init__(self, name='default', **kwargs):
-        super(LegacyEncryptedJournal, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
         self.config['encrypt'] = True
 
     def _load(self, filename, password=None):

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -8,14 +8,13 @@ from cryptography.hazmat.backends import default_backend
 import sys
 import os
 import base64
-import getpass
 import logging
 
 log = logging.getLogger()
 
 
 def make_key(password):
-    password = util.bytes(password)
+    password = password.encode("utf-8")
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),
         length=32,
@@ -48,9 +47,9 @@ class EncryptedJournal(Journal.Journal):
                 self.config['password'] = password
                 text = ""
                 self._store(filename, text)
-                util.prompt("[Journal '{0}' created at {1}]".format(self.name, filename))
+                print("[Journal '{0}' created at {1}]".format(self.name, filename), file=sys.stderr)
             else:
-                util.prompt("No password supplied for encrypted journal")
+                print("No password supplied for encrypted journal", file=sys.stderr)
                 sys.exit(1)
         else:
             text = self._load(filename)
@@ -58,7 +57,6 @@ class EncryptedJournal(Journal.Journal):
         self.sort()
         log.debug("opened %s with %d entries", self.__class__.__name__, len(self))
         return self
-
 
     def _load(self, filename, password=None):
         """Loads an encrypted journal from a file and tries to decrypt it.

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import unicode_literals
 import re
 import textwrap
 from datetime import datetime
@@ -52,13 +51,13 @@ class Entry:
     @staticmethod
     def tag_regex(tagsymbols):
         pattern = r'(?u)(?:^|\s)([{tags}][-+*#/\w]+)'.format(tags=tagsymbols)
-        return re.compile(pattern, re.UNICODE)
+        return re.compile(pattern)
 
     def _parse_tags(self):
         tagsymbols = self.journal.config['tagsymbols']
         return set(tag.lower() for tag in re.findall(Entry.tag_regex(tagsymbols), self.text))
 
-    def __unicode__(self):
+    def __str__(self):
         """Returns a string representation of the entry to be written into a journal file."""
         date_str = self.date.strftime(self.journal.config['timeformat'])
         title = "[{}] {}".format(date_str, self.title.rstrip("\n "))

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
 import re
 import textwrap
@@ -50,12 +49,12 @@ class Entry:
 
     @staticmethod
     def tag_regex(tagsymbols):
-        pattern = r'(?u)(?:^|\s)([{tags}][-+*#/\w]+)'.format(tags=tagsymbols)
+        pattern = fr'(?u)(?:^|\s)([{tagsymbols}][-+*#/\w]+)'
         return re.compile(pattern)
 
     def _parse_tags(self):
         tagsymbols = self.journal.config['tagsymbols']
-        return set(tag.lower() for tag in re.findall(Entry.tag_regex(tagsymbols), self.text))
+        return {tag.lower() for tag in re.findall(Entry.tag_regex(tagsymbols), self.text)}
 
     def __str__(self):
         """Returns a string representation of the entry to be written into a journal file."""
@@ -105,7 +104,7 @@ class Entry:
             )
 
     def __repr__(self):
-        return "<Entry '{0}' on {1}>".format(self.title.strip(), self.date.strftime("%Y-%m-%d %H:%M"))
+        return "<Entry '{}' on {}>".format(self.title.strip(), self.date.strftime("%Y-%m-%d %H:%M"))
 
     def __hash__(self):
         return hash(self.__repr__())

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -23,7 +23,7 @@ class Tag:
         return self.name
 
     def __repr__(self):
-        return "<Tag '{}'>".format(self.name)
+        return f"<Tag '{self.name}'>"
 
 
 class Journal:

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -5,7 +5,6 @@ from . import util
 from . import time
 import os
 import sys
-import codecs
 import re
 from datetime import datetime
 import logging
@@ -268,15 +267,15 @@ class Journal:
 class PlainJournal(Journal):
     @classmethod
     def _create(cls, filename):
-        with codecs.open(filename, "a", "utf-8"):
+        with open(filename, "a", encoding="utf-8"):
             pass
 
     def _load(self, filename):
-        with codecs.open(filename, "r", "utf-8") as f:
+        with open(filename, "r", encoding="utf-8") as f:
             return f.read()
 
     def _store(self, filename, text):
-        with codecs.open(filename, 'w', "utf-8") as f:
+        with open(filename, 'w', encoding="utf-8") as f:
             f.write(text)
 
 
@@ -285,7 +284,7 @@ class LegacyJournal(Journal):
     standard. Main difference here is that in 1.x, timestamps were not cuddled
     by square brackets. You'll not be able to save these journals anymore."""
     def _load(self, filename):
-        with codecs.open(filename, "r", "utf-8") as f:
+        with open(filename, "r", encoding="utf-8") as f:
             return f.read()
 
     def _parse(self, journal_txt):

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -224,7 +224,7 @@ class Journal:
         raw = raw.replace('\\n ', '\n').replace('\\n', '\n')
         starred = False
         # Split raw text into title and body
-        sep = re.search("\n|[\\?!.]+ +\n?", raw)
+        sep = re.search(r"\n|[?!.]+ +\n?", raw)
         first_line = raw[:sep.end()].strip() if sep else raw
         starred = False
 

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
 from . import Entry
 from . import util
@@ -71,7 +70,7 @@ class Journal:
         filename = filename or self.config['journal']
 
         if not os.path.exists(filename):
-            print("[Journal '{0}' created at {1}]".format(self.name, filename), file=sys.stderr)
+            print(f"[Journal '{self.name}' created at {filename}]", file=sys.stderr)
             self._create(filename)
 
         text = self._load(filename)
@@ -117,7 +116,7 @@ class Journal:
         # Initialise our current entry
         entries = []
 
-        date_blob_re = re.compile("(?:^|\n)\[([^\\]]+)\] ")
+        date_blob_re = re.compile("(?:^|\n)\\[([^\\]]+)\\] ")
         last_entry_pos = 0
         for match in date_blob_re.finditer(journal_txt):
             date_blob = match.groups()[0]
@@ -162,7 +161,7 @@ class Journal:
         return self.pprint()
 
     def __repr__(self):
-        return "<Journal with {0} entries>".format(len(self.entries))
+        return f"<Journal with {len(self.entries)} entries>"
 
     def sort(self):
         """Sorts the Journal's entries by date"""
@@ -182,7 +181,7 @@ class Journal:
                 for entry in self.entries
                 for tag in set(entry.tags)]
         # To be read: [for entry in journal.entries: for tag in set(entry.tags): tag]
-        tag_counts = set([(tags.count(tag), tag) for tag in tags])
+        tag_counts = {(tags.count(tag), tag) for tag in tags}
         return [Tag(tag, count=count) for count, tag in sorted(tag_counts)]
 
     def filter(self, tags=[], start_date=None, end_date=None, starred=False, strict=False, short=False, exclude=[]):
@@ -199,8 +198,8 @@ class Journal:
 
         exclude is a list of the tags which should not appear in the results.
         entry is kept if any tag is present, unless they appear in exclude."""
-        self.search_tags = set([tag.lower() for tag in tags])
-        excluded_tags = set([tag.lower() for tag in exclude])
+        self.search_tags = {tag.lower() for tag in tags}
+        excluded_tags = {tag.lower() for tag in exclude}
         end_date = time.parse(end_date, inclusive=True)
         start_date = time.parse(start_date)
 
@@ -225,7 +224,7 @@ class Journal:
         raw = raw.replace('\\n ', '\n').replace('\\n', '\n')
         starred = False
         # Split raw text into title and body
-        sep = re.search("\n|[\?!.]+ +\n?", raw)
+        sep = re.search("\n|[\\?!.]+ +\n?", raw)
         first_line = raw[:sep.end()].strip() if sep else raw
         starred = False
 
@@ -322,7 +321,7 @@ class LegacyJournal(Journal):
                 # escaping for the new format).
                 line = new_date_format_regex.sub(r' \1', line)
                 if current_entry:
-                    current_entry.text += line + u"\n"
+                    current_entry.text += line + "\n"
 
         # Append last entry
         if current_entry:
@@ -347,7 +346,7 @@ def open_journal(name, config, legacy=False):
             return DayOneJournal.DayOne(**config).open()
         else:
             print(
-                u"[Error: {0} is a directory, but doesn't seem to be a DayOne journal either.".format(config['journal']),
+                f"[Error: {config['journal']} is a directory, but doesn't seem to be a DayOne journal either.",
                 file=sys.stderr
             )
 

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 from . import Entry
 from . import util
 from . import time
@@ -15,7 +14,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class Tag(object):
+class Tag:
     def __init__(self, name, count=0):
         self.name = name
         self.count = count
@@ -27,7 +26,7 @@ class Tag(object):
         return "<Tag '{}'>".format(self.name)
 
 
-class Journal(object):
+class Journal:
     def __init__(self, name='default', **kwargs):
         self.config = {
             'journal': "journal.txt",
@@ -72,7 +71,7 @@ class Journal(object):
         filename = filename or self.config['journal']
 
         if not os.path.exists(filename):
-            util.prompt("[Journal '{0}' created at {1}]".format(self.name, filename))
+            print("[Journal '{0}' created at {1}]".format(self.name, filename), file=sys.stderr)
             self._create(filename)
 
         text = self._load(filename)
@@ -96,7 +95,7 @@ class Journal(object):
         return True
 
     def _to_text(self):
-        return "\n".join([e.__unicode__() for e in self.entries])
+        return "\n".join([str(e) for e in self.entries])
 
     def _load(self, filename):
         raise NotImplementedError
@@ -140,9 +139,6 @@ class Journal(object):
             entry._parse_text()
         return entries
 
-    def __unicode__(self):
-        return self.pprint()
-
     def pprint(self, short=False):
         """Prettyprints the journal's entries"""
         sep = "\n"
@@ -153,7 +149,7 @@ class Journal(object):
                     tagre = re.compile(re.escape(tag), re.IGNORECASE)
                     pp = re.sub(tagre,
                                 lambda match: util.colorize(match.group(0)),
-                                pp, re.UNICODE)
+                                pp)
             else:
                 pp = re.sub(
                     Entry.Entry.tag_regex(self.config['tagsymbols']),
@@ -161,6 +157,9 @@ class Journal(object):
                     pp
                 )
         return pp
+
+    def __str__(self):
+        return self.pprint()
 
     def __repr__(self):
         return "<Journal with {0} entries>".format(len(self.entries))
@@ -254,7 +253,7 @@ class Journal(object):
     def editable_str(self):
         """Turns the journal into a string of entries that can be edited
         manually and later be parsed with eslf.parse_editable_str."""
-        return "\n".join([e.__unicode__() for e in self.entries])
+        return "\n".join([str(e) for e in self.entries])
 
     def parse_editable_str(self, edited):
         """Parses the output of self.editable_str and updates it's entries."""
@@ -347,8 +346,9 @@ def open_journal(name, config, legacy=False):
             from . import DayOneJournal
             return DayOneJournal.DayOne(**config).open()
         else:
-            util.prompt(
-                u"[Error: {0} is a directory, but doesn't seem to be a DayOne journal either.".format(config['journal'])
+            print(
+                u"[Error: {0} is a directory, but doesn't seem to be a DayOne journal either.".format(config['journal']),
+                file=sys.stderr
             )
 
             sys.exit(1)

--- a/jrnl/__init__.py
+++ b/jrnl/__init__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
 import pkg_resources
 

--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 from . import cli
 
 

--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # encoding: utf-8
-from __future__ import absolute_import, unicode_literals
 from . import cli
 
 

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -144,7 +144,7 @@ def run(manual_args=None):
     try:
         config = install.load_or_install_jrnl()
     except UserAbort as err:
-        print("\n{}".format(err), file=sys.stderr)
+        print(f"\n{err}", file=sys.stderr)
         sys.exit(1)
 
     if args.ls:

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
 """
     jrnl
@@ -89,7 +88,7 @@ def encrypt(journal, filename=None):
     if util.yesno("Do you want to store the password in your keychain?", default=True):
         util.set_keychain(journal.name, journal.config['password'])
 
-    print("Journal encrypted to {0}.".format(filename or new_journal.config['journal']), file=sys.stderr)
+    print("Journal encrypted to {}.".format(filename or new_journal.config['journal']), file=sys.stderr)
 
 
 def decrypt(journal, filename=None):
@@ -100,12 +99,12 @@ def decrypt(journal, filename=None):
     new_journal = Journal.PlainJournal(filename, **journal.config)
     new_journal.entries = journal.entries
     new_journal.write(filename)
-    print("Journal decrypted to {0}.".format(filename or new_journal.config['journal']), file=sys.stderr)
+    print("Journal decrypted to {}.".format(filename or new_journal.config['journal']), file=sys.stderr)
 
 
 def list_journals(config):
     """List the journals specified in the configuration file"""
-    result = "Journals defined in {}\n".format(install.CONFIG_FILE_PATH)
+    result = f"Journals defined in {install.CONFIG_FILE_PATH}\n"
     ml = min(max(len(k) for k in config['journals']), 20)
     for journal, cfg in config['journals'].items():
         result += " * {:{}} -> {}\n".format(journal, ml, cfg['journal'] if isinstance(cfg, dict) else cfg)
@@ -137,7 +136,7 @@ def run(manual_args=None):
     args = parse_args(manual_args)
     configure_logger(args.debug)
     if args.version:
-        version_str = "{0} version {1}".format(jrnl.__title__, jrnl.__version__)
+        version_str = f"{jrnl.__title__} version {jrnl.__version__}"
         print(version_str)
         sys.exit(0)
 
@@ -158,7 +157,7 @@ def run(manual_args=None):
     # use this!
     journal_name = args.text[0] if (args.text and args.text[0] in config['journals']) else 'default'
 
-    if journal_name is not 'default':
+    if journal_name != 'default':
         args.text = args.text[1:]
     elif "default" not in config['journals']:
         print("No default journal configured.", file=sys.stderr)
@@ -193,8 +192,8 @@ def run(manual_args=None):
             if config['template']:
                 try:
                     template = open(config['template']).read()
-                except IOError:
-                    print("[Could not read template at '']".format(config['template']), file=sys.stderr)
+                except OSError:
+                    print(f"[Could not read template at '{config['template']}']", file=sys.stderr)
                     sys.exit(1)
             raw = util.get_text_from_editor(config, template)
         else:
@@ -213,7 +212,7 @@ def run(manual_args=None):
     try:
         journal = Journal.open_journal(journal_name, config)
     except KeyboardInterrupt:
-        print("[Interrupted while opening journal]".format(journal_name), file=sys.stderr)
+        print(f"[Interrupted while opening journal]", file=sys.stderr)
         sys.exit(1)
 
     # Import mode
@@ -225,7 +224,7 @@ def run(manual_args=None):
         raw = " ".join(args.text).strip()
         log.debug('Appending raw line "%s" to journal "%s"', raw, journal_name)
         journal.new_entry(raw)
-        print("[Entry added to {0} journal]".format(journal_name), file=sys.stderr)
+        print(f"[Entry added to {journal_name} journal]", file=sys.stderr)
         journal.write()
 
     if not mode_compose:
@@ -283,11 +282,11 @@ def run(manual_args=None):
         num_edited = len([e for e in journal.entries if e.modified])
         prompts = []
         if num_deleted:
-            prompts.append("{0} {1} deleted".format(num_deleted, "entry" if num_deleted == 1 else "entries"))
+            prompts.append("{} {} deleted".format(num_deleted, "entry" if num_deleted == 1 else "entries"))
         if num_edited:
-            prompts.append("{0} {1} modified".format(num_edited, "entry" if num_deleted == 1 else "entries"))
+            prompts.append("{} {} modified".format(num_edited, "entry" if num_deleted == 1 else "entries"))
         if prompts:
-            print("[{0}]".format(", ".join(prompts).capitalize()), file=sys.stderr)
+            print("[{}]".format(", ".join(prompts).capitalize()), file=sys.stderr)
         journal.entries += other_entries
         journal.sort()
         journal.write()

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -7,8 +7,6 @@
     license: MIT, see LICENSE for more details.
 """
 
-from __future__ import unicode_literals
-from __future__ import absolute_import
 from . import Journal
 from . import util
 from . import install
@@ -91,7 +89,7 @@ def encrypt(journal, filename=None):
     if util.yesno("Do you want to store the password in your keychain?", default=True):
         util.set_keychain(journal.name, journal.config['password'])
 
-    util.prompt("Journal encrypted to {0}.".format(filename or new_journal.config['journal']))
+    print("Journal encrypted to {0}.".format(filename or new_journal.config['journal']), file=sys.stderr)
 
 
 def decrypt(journal, filename=None):
@@ -102,7 +100,7 @@ def decrypt(journal, filename=None):
     new_journal = Journal.PlainJournal(filename, **journal.config)
     new_journal.entries = journal.entries
     new_journal.write(filename)
-    util.prompt("Journal decrypted to {0}.".format(filename or new_journal.config['journal']))
+    print("Journal decrypted to {0}.".format(filename or new_journal.config['journal']), file=sys.stderr)
 
 
 def list_journals(config):
@@ -138,20 +136,19 @@ def configure_logger(debug=False):
 def run(manual_args=None):
     args = parse_args(manual_args)
     configure_logger(args.debug)
-    args.text = [p.decode('utf-8') if util.PY2 and not isinstance(p, unicode) else p for p in args.text]
     if args.version:
         version_str = "{0} version {1}".format(jrnl.__title__, jrnl.__version__)
-        print(util.py2encode(version_str))
+        print(version_str)
         sys.exit(0)
 
     try:
         config = install.load_or_install_jrnl()
     except UserAbort as err:
-        util.prompt("\n{}".format(err))
+        print("\n{}".format(err), file=sys.stderr)
         sys.exit(1)
 
     if args.ls:
-        util.prnt(list_journals(config))
+        print(list_journals(config))
         sys.exit(0)
 
     log.debug('Using configuration "%s"', config)
@@ -164,8 +161,8 @@ def run(manual_args=None):
     if journal_name is not 'default':
         args.text = args.text[1:]
     elif "default" not in config['journals']:
-        util.prompt("No default journal configured.")
-        util.prompt(list_journals(config))
+        print("No default journal configured.", file=sys.stderr)
+        print(list_journals(config), file=sys.stderr)
         sys.exit(1)
 
     config = util.scope_config(config, journal_name)
@@ -175,12 +172,12 @@ def run(manual_args=None):
         try:
             args.limit = int(args.text[0].lstrip("-"))
             args.text = args.text[1:]
-        except:
+        except ValueError:
             pass
 
     log.debug('Using journal "%s"', journal_name)
     mode_compose, mode_export, mode_import = guess_mode(args, config)
-
+    
     # How to quit writing?
     if "win32" in sys.platform:
         _exit_multiline_code = "on a blank line, press Ctrl+Z and then Enter"
@@ -190,21 +187,22 @@ def run(manual_args=None):
     if mode_compose and not args.text:
         if not sys.stdin.isatty():
             # Piping data into jrnl
-            raw = util.py23_read()
+            raw = sys.stdin.read()
         elif config['editor']:
             template = ""
             if config['template']:
                 try:
                     template = open(config['template']).read()
-                except:
-                    util.prompt("[Could not read template at '']".format(config['template']))
+                except IOError:
+                    print("[Could not read template at '']".format(config['template']), file=sys.stderr)
                     sys.exit(1)
             raw = util.get_text_from_editor(config, template)
         else:
             try:
-                raw = util.py23_read("[Compose Entry; " + _exit_multiline_code + " to finish writing]\n")
+                print("[Compose Entry; " + _exit_multiline_code + " to finish writing]\n", file=sys.stderr)
+                raw = sys.stdin.read()
             except KeyboardInterrupt:
-                util.prompt("[Entry NOT saved to journal.]")
+                print("[Entry NOT saved to journal.]", file=sys.stderr)
                 sys.exit(0)
         if raw:
             args.text = [raw]
@@ -215,7 +213,7 @@ def run(manual_args=None):
     try:
         journal = Journal.open_journal(journal_name, config)
     except KeyboardInterrupt:
-        util.prompt("[Interrupted while opening journal]".format(journal_name))
+        print("[Interrupted while opening journal]".format(journal_name), file=sys.stderr)
         sys.exit(1)
 
     # Import mode
@@ -225,11 +223,9 @@ def run(manual_args=None):
     # Writing mode
     elif mode_compose:
         raw = " ".join(args.text).strip()
-        if util.PY2 and type(raw) is not unicode:
-            raw = raw.decode(sys.getfilesystemencoding())
         log.debug('Appending raw line "%s" to journal "%s"', raw, journal_name)
         journal.new_entry(raw)
-        util.prompt("[Entry added to {0} journal]".format(journal_name))
+        print("[Entry added to {0} journal]".format(journal_name), file=sys.stderr)
         journal.write()
 
     if not mode_compose:
@@ -246,14 +242,14 @@ def run(manual_args=None):
 
     # Reading mode
     if not mode_compose and not mode_export and not mode_import:
-        print(util.py2encode(journal.pprint()))
+        print(journal.pprint())
 
     # Various export modes
     elif args.short:
-        print(util.py2encode(journal.pprint(short=True)))
+        print(journal.pprint(short=True))
 
     elif args.tags:
-        print(util.py2encode(plugins.get_exporter("tags").export(journal)))
+        print(plugins.get_exporter("tags").export(journal))
 
     elif args.export is not False:
         exporter = plugins.get_exporter(args.export)
@@ -275,7 +271,8 @@ def run(manual_args=None):
 
     elif args.edit:
         if not config['editor']:
-            util.prompt("[{1}ERROR{2}: You need to specify an editor in {0} to use the --edit function.]".format(install.CONFIG_FILE_PATH, ERROR_COLOR, RESET_COLOR))
+            print("[{1}ERROR{2}: You need to specify an editor in {0} to use the --edit function.]"
+                  .format(install.CONFIG_FILE_PATH, ERROR_COLOR, RESET_COLOR), file=sys.stderr)
             sys.exit(1)
         other_entries = [e for e in old_entries if e not in journal.entries]
         # Edit
@@ -290,7 +287,7 @@ def run(manual_args=None):
         if num_edited:
             prompts.append("{0} {1} modified".format(num_edited, "entry" if num_deleted == 1 else "entries"))
         if prompts:
-            util.prompt("[{0}]".format(", ".join(prompts).capitalize()))
+            print("[{0}]".format(", ".join(prompts).capitalize()), file=sys.stderr)
         journal.entries += other_entries
         journal.sort()
         journal.write()

--- a/jrnl/export.py
+++ b/jrnl/export.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
 from .util import ERROR_COLOR, RESET_COLOR
 from .util import slugify
@@ -35,12 +34,12 @@ class Exporter:
         try:
             with codecs.open(path, "w", "utf-8") as f:
                 f.write(self.export_journal(journal))
-                return "[Journal exported to {0}]".format(path)
-        except IOError as e:
-            return "[{2}ERROR{3}: {0} {1}]".format(e.filename, e.strerror, ERROR_COLOR, RESET_COLOR)
+                return f"[Journal exported to {path}]"
+        except OSError as e:
+            return f"[{ERROR_COLOR}ERROR{RESET_COLOR}: {e.filename} {e.strerror}]"
 
     def make_filename(self, entry):
-        return entry.date.strftime("%Y-%m-%d_{0}.{1}".format(slugify(entry.title), self.extension))
+        return entry.date.strftime("%Y-%m-%d_{}.{}".format(slugify(entry.title), self.extension))
 
     def write_files(self, journal, path):
         """Exports a journal into individual files for each entry."""
@@ -49,9 +48,9 @@ class Exporter:
                 full_path = os.path.join(path, self.make_filename(entry))
                 with codecs.open(full_path, "w", "utf-8") as f:
                     f.write(self.export_entry(entry))
-            except IOError as e:
-                return "[{2}ERROR{3}: {0} {1}]".format(e.filename, e.strerror, ERROR_COLOR, RESET_COLOR)
-        return "[Journal exported to {0}]".format(path)
+            except OSError as e:
+                return f"[{ERROR_COLOR}ERROR{RESET_COLOR}: {e.filename} {e.strerror}]"
+        return f"[Journal exported to {path}]"
 
     def export(self, journal, format="text", output=None):
         """Exports to individual files if output is an existing path, or into

--- a/jrnl/export.py
+++ b/jrnl/export.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 from .util import ERROR_COLOR, RESET_COLOR
-from .util import slugify, u
-from .template import Template
+from .util import slugify
+from .plugins.template import Template
 import os
 import codecs
 
 
-class Exporter(object):
+class Exporter:
     """This Exporter can convert entries and journals into text files."""
     def __init__(self, format):
         with open("jrnl/templates/" + format + ".template") as f:
@@ -17,8 +16,8 @@ class Exporter(object):
             self.template = Template(body)
 
     def export_entry(self, entry):
-        """Returns a unicode representation of a single entry."""
-        return entry.__unicode__()
+        """Returns a string representation of a single entry."""
+        return str(entry)
 
     def _get_vars(self, journal):
         return {
@@ -28,7 +27,7 @@ class Exporter(object):
         }
 
     def export_journal(self, journal):
-        """Returns a unicode representation of an entire journal."""
+        """Returns a string representation of an entire journal."""
         return self.template.render_block("journal", **self._get_vars(journal))
 
     def write_file(self, journal, path):
@@ -41,7 +40,7 @@ class Exporter(object):
             return "[{2}ERROR{3}: {0} {1}]".format(e.filename, e.strerror, ERROR_COLOR, RESET_COLOR)
 
     def make_filename(self, entry):
-        return entry.date.strftime("%Y-%m-%d_{0}.{1}".format(slugify(u(entry.title)), self.extension))
+        return entry.date.strftime("%Y-%m-%d_{0}.{1}".format(slugify(entry.title), self.extension))
 
     def write_files(self, journal, path):
         """Exports a journal into individual files for each entry."""
@@ -57,7 +56,7 @@ class Exporter(object):
     def export(self, journal, format="text", output=None):
         """Exports to individual files if output is an existing path, or into
         a single file if output is a file name, or returns the exporter's
-        representation as unicode if output is None."""
+        representation as string if output is None."""
         if output and os.path.isdir(output):  # multiple files
             return self.write_files(journal, output)
         elif output:                          # single file

--- a/jrnl/export.py
+++ b/jrnl/export.py
@@ -4,7 +4,6 @@ from .util import ERROR_COLOR, RESET_COLOR
 from .util import slugify
 from .plugins.template import Template
 import os
-import codecs
 
 
 class Exporter:
@@ -32,7 +31,7 @@ class Exporter:
     def write_file(self, journal, path):
         """Exports a journal into a single file."""
         try:
-            with codecs.open(path, "w", "utf-8") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 f.write(self.export_journal(journal))
                 return f"[Journal exported to {path}]"
         except OSError as e:
@@ -46,7 +45,7 @@ class Exporter:
         for entry in journal.entries:
             try:
                 full_path = os.path.join(path, self.make_filename(entry))
-                with codecs.open(full_path, "w", "utf-8") as f:
+                with open(full_path, "w", encoding="utf-8") as f:
                     f.write(self.export_entry(entry))
             except OSError as e:
                 return f"[{ERROR_COLOR}ERROR{RESET_COLOR}: {e.filename} {e.strerror}]"

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
-from __future__ import absolute_import
 import readline
 import glob
 import getpass
@@ -69,7 +67,7 @@ def upgrade_config(config):
         for key in missing_keys:
             config[key] = default_config[key]
         save_config(config)
-        print("[Configuration updated to newest version at {}]".format(CONFIG_FILE_PATH), file=sys.stderr)
+        print(f"[Configuration updated to newest version at {CONFIG_FILE_PATH}]", file=sys.stderr)
 
 
 def save_config(config):
@@ -120,7 +118,7 @@ def install():
     readline.set_completer(autocomplete)
 
     # Where to create the journal?
-    path_query = 'Path to your journal file (leave blank for {}): '.format(JOURNAL_FILE_PATH)
+    path_query = f'Path to your journal file (leave blank for {JOURNAL_FILE_PATH}): '
     journal_path = input(path_query).strip() or JOURNAL_FILE_PATH
     default_config['journals']['default'] = os.path.expanduser(os.path.expandvars(journal_path))
 

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -69,7 +69,7 @@ def upgrade_config(config):
         for key in missing_keys:
             config[key] = default_config[key]
         save_config(config)
-        print("[Configuration updated to newest version at {}]".format(CONFIG_FILE_PATH))
+        print("[Configuration updated to newest version at {}]".format(CONFIG_FILE_PATH), file=sys.stderr)
 
 
 def save_config(config):
@@ -91,10 +91,10 @@ def load_or_install_jrnl():
         try:
             upgrade.upgrade_jrnl_if_necessary(config_path)
         except upgrade.UpgradeValidationException:
-            util.prompt("Aborting upgrade.")
-            util.prompt("Please tell us about this problem at the following URL:")
-            util.prompt("https://github.com/jrnl-org/jrnl/issues/new?title=UpgradeValidationException")
-            util.prompt("Exiting.")
+            print("Aborting upgrade.", file=sys.stderr)
+            print("Please tell us about this problem at the following URL:", file=sys.stderr)
+            print("https://github.com/jrnl-org/jrnl/issues/new?title=UpgradeValidationException", file=sys.stderr)
+            print("Exiting.", file=sys.stderr)
             sys.exit(1)
 
         upgrade_config(config)
@@ -121,7 +121,7 @@ def install():
 
     # Where to create the journal?
     path_query = 'Path to your journal file (leave blank for {}): '.format(JOURNAL_FILE_PATH)
-    journal_path = util.py23_input(path_query).strip() or JOURNAL_FILE_PATH
+    journal_path = input(path_query).strip() or JOURNAL_FILE_PATH
     default_config['journals']['default'] = os.path.expanduser(os.path.expandvars(journal_path))
 
     path = os.path.split(default_config['journals']['default'])[0]  # If the folder doesn't exist, create it
@@ -139,7 +139,7 @@ def install():
         else:
             util.set_keychain("default", None)
         EncryptedJournal._create(default_config['journals']['default'], password)
-        print("Journal will be encrypted.")
+        print("Journal will be encrypted.", file=sys.stderr)
     else:
         PlainJournal._create(default_config['journals']['default'])
 

--- a/jrnl/plugins/__init__.py
+++ b/jrnl/plugins/__init__.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
-
 from .text_exporter import TextExporter
 from .jrnl_importer import JRNLImporter
 from .json_exporter import JSONExporter

--- a/jrnl/plugins/__init__.py
+++ b/jrnl/plugins/__init__.py
@@ -13,8 +13,8 @@ from .template_exporter import __all__ as template_exporters
 __exporters =[JSONExporter, MarkdownExporter, TagExporter, TextExporter, XMLExporter, YAMLExporter] + template_exporters
 __importers =[JRNLImporter]
 
-__exporter_types = dict([(name, plugin) for plugin in __exporters for name in plugin.names])
-__importer_types = dict([(name, plugin) for plugin in __importers for name in plugin.names])
+__exporter_types = {name: plugin for plugin in __exporters for name in plugin.names}
+__importer_types = {name: plugin for plugin in __importers for name in plugin.names}
 
 EXPORT_FORMATS = sorted(__exporter_types.keys())
 IMPORT_FORMATS = sorted(__importer_types.keys())

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -26,5 +26,5 @@ class JRNLImporter:
                 sys.exit(0)
         journal.import_(other_journal_txt)
         new_cnt = len(journal.entries)
-        print("[{0} imported to {1} journal]".format(new_cnt - old_cnt, journal.name), file=sys.stderr)
+        print("[{} imported to {} journal]".format(new_cnt - old_cnt, journal.name), file=sys.stderr)
         journal.write()

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import codecs
 import sys
 from .. import util
 
@@ -16,7 +15,7 @@ class JRNLImporter:
         old_cnt = len(journal.entries)
         old_entries = journal.entries
         if input:
-            with codecs.open(input, "r", "utf-8") as f:
+            with open(input, "r", encoding="utf-8") as f:
                 other_journal_txt = f.read()
         else:
             try:

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 import codecs
 import sys
 from .. import util
 
-class JRNLImporter(object):
+class JRNLImporter:
     """This plugin imports entries from other jrnl files."""
     names = ["jrnl"]
 
@@ -21,11 +20,11 @@ class JRNLImporter(object):
                 other_journal_txt = f.read()
         else:
             try:
-                other_journal_txt = util.py23_read()
+                other_journal_txt = sys.stdin.read()
             except KeyboardInterrupt:
-                util.prompt("[Entries NOT imported into journal.]")
+                print("[Entries NOT imported into journal.]", file=sys.stderr)
                 sys.exit(0)
         journal.import_(other_journal_txt)
         new_cnt = len(journal.entries)
-        util.prompt("[{0} imported to {1} journal]".format(new_cnt - old_cnt, journal.name))
+        print("[{0} imported to {1} journal]".format(new_cnt - old_cnt, journal.name), file=sys.stderr)
         journal.write()

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -34,7 +34,7 @@ class JSONExporter(TextExporter):
         """Returns a json representation of an entire journal."""
         tags = get_tags_count(journal)
         result = {
-            "tags": dict((tag, count) for count, tag in tags),
+            "tags": {tag: count for count, tag in tags},
             "entries": [cls.entry_to_dict(e) for e in journal.entries]
         }
         return json.dumps(result, indent=2)

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 from .text_exporter import TextExporter
 import json
 from .util import get_tags_count

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -50,15 +50,11 @@ class MarkdownExporter(TextExporter):
         newbody = newbody + previous_line   # add very last line
 
         if warn_on_heading_level is True:
-            print("{}WARNING{}: Headings increased past H6 on export - {} {}".format(WARNING_COLOR, RESET_COLOR, date_str, entry.title), file=sys.stderr)
+            print(f"{WARNING_COLOR}WARNING{RESET_COLOR}: "
+                  f"Headings increased past H6 on export - {date_str} {entry.title}",
+                  file=sys.stderr)
 
-        return "{md} {date} {title}\n{body} {space}".format(
-            md=heading,
-            date=date_str,
-            title=entry.title,
-            body=newbody,
-            space=""
-        )
+        return f"{heading} {date_str} {entry.title}\n{newbody} "
 
     @classmethod
     def export_journal(cls, journal):

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals, print_function
 from .text_exporter import TextExporter
 import os
 import re

--- a/jrnl/plugins/tag_exporter.py
+++ b/jrnl/plugins/tag_exporter.py
@@ -25,5 +25,5 @@ class TagExporter(TextExporter):
         elif min(tag_counts)[0] == 0:
             tag_counts = filter(lambda x: x[0] > 1, tag_counts)
             result += '[Removed tags that appear only once.]\n'
-        result += "\n".join("{0:20} : {1}".format(tag, n) for n, tag in sorted(tag_counts, reverse=True))
+        result += "\n".join("{:20} : {}".format(tag, n) for n, tag in sorted(tag_counts, reverse=True))
         return result

--- a/jrnl/plugins/tag_exporter.py
+++ b/jrnl/plugins/tag_exporter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 from .text_exporter import TextExporter
 from .util import get_tags_count
 

--- a/jrnl/plugins/template.py
+++ b/jrnl/plugins/template.py
@@ -13,7 +13,7 @@ BLOCK_RE = r"{% *block +(.+?) *%}((?:.|\n)+?){% *endblock *%}"
 INCLUDE_RE = r"{% *include +(.+?) *%}"
 
 
-class Template(object):
+class Template:
     def __init__(self, template):
         self.template = template
         self.clean_template = None

--- a/jrnl/plugins/template_exporter.py
+++ b/jrnl/plugins/template_exporter.py
@@ -34,7 +34,7 @@ def __exporter_from_file(template_file):
     """Create a template class from a file"""
     name = os.path.basename(template_file).replace(".template", "")
     template = Template.from_file(template_file)
-    return type(str(f"{name.title(}Exporter")), (GenericTemplateExporter, ), {
+    return type(str(f"{name.title()}Exporter"), (GenericTemplateExporter, ), {
         "names": [name],
         "extension": template.extension,
         "template": template

--- a/jrnl/plugins/template_exporter.py
+++ b/jrnl/plugins/template_exporter.py
@@ -34,7 +34,7 @@ def __exporter_from_file(template_file):
     """Create a template class from a file"""
     name = os.path.basename(template_file).replace(".template", "")
     template = Template.from_file(template_file)
-    return type(str("{}Exporter".format(name.title())), (GenericTemplateExporter, ), {
+    return type(str(f"{name.title(}Exporter")), (GenericTemplateExporter, ), {
         "names": [name],
         "extension": template.extension,
         "template": template

--- a/jrnl/plugins/template_exporter.py
+++ b/jrnl/plugins/template_exporter.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
-
 from .text_exporter import TextExporter
 from .template import Template
 import os
@@ -14,7 +12,7 @@ class GenericTemplateExporter(TextExporter):
 
     @classmethod
     def export_entry(cls, entry):
-        """Returns a unicode representation of a single entry."""
+        """Returns a string representation of a single entry."""
         vars = {
             'entry': entry,
             'tags': entry.tags
@@ -23,7 +21,7 @@ class GenericTemplateExporter(TextExporter):
 
     @classmethod
     def export_journal(cls, journal):
-        """Returns a unicode representation of an entire journal."""
+        """Returns a string representation of an entire journal."""
         vars = {
             'journal': journal,
             'entries': journal.entries,

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -28,9 +28,9 @@ class TextExporter:
         try:
             with codecs.open(path, "w", "utf-8") as f:
                 f.write(cls.export_journal(journal))
-                return "[Journal exported to {0}]".format(path)
+                return f"[Journal exported to {path}]"
         except IOError as e:
-            return "[{2}ERROR{3}: {0} {1}]".format(e.filename, e.strerror, ERROR_COLOR, RESET_COLOR)
+            return f"[{ERROR_COLOR}ERROR{RESET_COLOR}: {e.filename} {e.strerror}]"
 
     @classmethod
     def make_filename(cls, entry):

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -1,26 +1,25 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 import codecs
-from ..util import u, slugify
+from ..util import slugify
 import os
 from ..util import ERROR_COLOR, RESET_COLOR
 
 
-class TextExporter(object):
+class TextExporter:
     """This Exporter can convert entries and journals into text files."""
     names = ["text", "txt"]
     extension = "txt"
 
     @classmethod
     def export_entry(cls, entry):
-        """Returns a unicode representation of a single entry."""
-        return entry.__unicode__()
+        """Returns a string representation of a single entry."""
+        return str(entry)
 
     @classmethod
     def export_journal(cls, journal):
-        """Returns a unicode representation of an entire journal."""
+        """Returns a string representation of an entire journal."""
         return "\n".join(cls.export_entry(entry) for entry in journal)
 
     @classmethod
@@ -35,7 +34,7 @@ class TextExporter(object):
 
     @classmethod
     def make_filename(cls, entry):
-        return entry.date.strftime("%Y-%m-%d_{0}.{1}".format(slugify(u(entry.title)), cls.extension))
+        return entry.date.strftime("%Y-%m-%d_{0}.{1}".format(slugify(str(entry.title)), cls.extension))
 
     @classmethod
     def write_files(cls, journal, path):
@@ -53,7 +52,7 @@ class TextExporter(object):
     def export(cls, journal, output=None):
         """Exports to individual files if output is an existing path, or into
         a single file if output is a file name, or returns the exporter's
-        representation as unicode if output is None."""
+        representation as string if output is None."""
         if output and os.path.isdir(output):  # multiple files
             return cls.write_files(journal, output)
         elif output:                          # single file

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -34,7 +34,7 @@ class TextExporter:
 
     @classmethod
     def make_filename(cls, entry):
-        return entry.date.strftime("%Y-%m-%d_{0}.{1}".format(slugify(str(entry.title)), cls.extension))
+        return entry.date.strftime("%Y-%m-%d_{}.{}".format(slugify(str(entry.title)), cls.extension))
 
     @classmethod
     def write_files(cls, journal, path):
@@ -46,7 +46,7 @@ class TextExporter:
                     f.write(cls.export_entry(entry))
             except IOError as e:
                 return "[{2}ERROR{3}: {0} {1}]".format(e.filename, e.strerror, ERROR_COLOR, RESET_COLOR)
-        return "[Journal exported to {0}]".format(path)
+        return "[Journal exported to {}]".format(path)
 
     @classmethod
     def export(cls, journal, output=None):

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import codecs
 from ..util import slugify
 import os
 from ..util import ERROR_COLOR, RESET_COLOR
@@ -26,7 +25,7 @@ class TextExporter:
     def write_file(cls, journal, path):
         """Exports a journal into a single file."""
         try:
-            with codecs.open(path, "w", "utf-8") as f:
+            with open(path, "w", encoding="utf-8") as f:
                 f.write(cls.export_journal(journal))
                 return f"[Journal exported to {path}]"
         except IOError as e:
@@ -42,7 +41,7 @@ class TextExporter:
         for entry in journal.entries:
             try:
                 full_path = os.path.join(path, cls.make_filename(entry))
-                with codecs.open(full_path, "w", "utf-8") as f:
+                with open(full_path, "w", encoding="utf-8") as f:
                     f.write(cls.export_entry(entry))
             except IOError as e:
                 return "[{2}ERROR{3}: {0} {1}]".format(e.filename, e.strerror, ERROR_COLOR, RESET_COLOR)

--- a/jrnl/plugins/util.py
+++ b/jrnl/plugins/util.py
@@ -10,7 +10,7 @@ def get_tags_count(journal):
             for entry in journal.entries
             for tag in set(entry.tags)]
     # To be read: [for entry in journal.entries: for tag in set(entry.tags): tag]
-    tag_counts = set([(tags.count(tag), tag) for tag in tags])
+    tag_counts = {(tags.count(tag), tag) for tag in tags}
     return tag_counts
 
 

--- a/jrnl/plugins/xml_exporter.py
+++ b/jrnl/plugins/xml_exporter.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 from .json_exporter import JSONExporter
 from .util import get_tags_count
-from ..util import u
 from xml.dom import minidom
 
 
@@ -20,7 +18,7 @@ class XMLExporter(JSONExporter):
         entry_el = doc_el.createElement('entry')
         for key, value in cls.entry_to_dict(entry).items():
             elem = doc_el.createElement(key)
-            elem.appendChild(doc_el.createTextNode(u(value)))
+            elem.appendChild(doc_el.createTextNode(value))
             entry_el.appendChild(elem)
         if not doc:
             doc_el.appendChild(entry_el)
@@ -33,8 +31,8 @@ class XMLExporter(JSONExporter):
         entry_el = doc.createElement('entry')
         entry_el.setAttribute('date', entry.date.isoformat())
         if hasattr(entry, "uuid"):
-            entry_el.setAttribute('uuid', u(entry.uuid))
-        entry_el.setAttribute('starred', u(entry.starred))
+            entry_el.setAttribute('uuid', entry.uuid)
+        entry_el.setAttribute('starred', entry.starred)
         entry_el.appendChild(doc.createTextNode(entry.fulltext))
         return entry_el
 
@@ -49,7 +47,7 @@ class XMLExporter(JSONExporter):
         for count, tag in tags:
             tag_el = doc.createElement('tag')
             tag_el.setAttribute('name', tag)
-            count_node = doc.createTextNode(u(count))
+            count_node = doc.createTextNode(str(count))
             tag_el.appendChild(count_node)
             tags_el.appendChild(tag_el)
         for entry in journal.entries:

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals, print_function
 from .text_exporter import TextExporter
 import os
 import re
@@ -27,7 +26,7 @@ class YAMLExporter(TextExporter):
 
         tagsymbols = entry.journal.config['tagsymbols']
         # see also Entry.Entry.rag_regex
-        multi_tag_regex = re.compile(r'(?u)^\s*([{tags}][-+*#/\w]+\s*)+$'.format(tags=tagsymbols), re.UNICODE)
+        multi_tag_regex = re.compile(r'(?u)^\s*([{tags}][-+*#/\w]+\s*)+$'.format(tags=tagsymbols))
 
         '''Increase heading levels in body text'''
         newbody = ''

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -17,7 +17,8 @@ class YAMLExporter(TextExporter):
     def export_entry(cls, entry, to_multifile=True):
         """Returns a markdown representation of a single entry, with YAML front matter."""
         if to_multifile is False:
-            print("{}ERROR{}: YAML export must be to individual files. Please specify a directory to export to.".format("\033[31m", "\033[0m", file=sys.stderr))
+            print("{}ERROR{}: YAML export must be to individual files. "
+                  "Please specify a directory to export to.".format("\033[31m", "\033[0m"), file=sys.stderr)
             return
 
         date_str = entry.date.strftime(entry.journal.config['timeformat'])

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -51,7 +51,7 @@ def parse(date_str, inclusive=False, default_hour=None, default_minute=None):
         except TypeError:
             return None
 
-    if flag is 1:  # Date found, but no time. Use the default time.
+    if flag == 1:  # Date found, but no time. Use the default time.
         date = datetime(*date[:3], hour=default_hour or 0, minute=default_minute or 0)
     else:
         date = datetime(*date[:6])

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -10,7 +10,7 @@ import codecs
 
 
 def backup(filename, binary=False):
-    print("  Created a backup at {}.backup".format(filename), file=sys.stderr)
+    print(f"  Created a backup at {filename}.backup", file=sys.stderr)
     filename = os.path.expanduser(os.path.expandvars(filename))
     with open(filename, 'rb' if binary else 'r') as original:
         contents = original.read()
@@ -63,12 +63,12 @@ older versions of jrnl anymore.
 
     longest_journal_name = max([len(journal) for journal in config['journals']])
     if encrypted_journals:
-        print("\nFollowing encrypted journals will be upgraded to jrnl {}:".format(__version__), file=sys.stderr)
+        print(f"\nFollowing encrypted journals will be upgraded to jrnl {__version__}:", file=sys.stderr)
         for journal, path in encrypted_journals.items():
             print("    {:{pad}} -> {}".format(journal, path, pad=longest_journal_name), file=sys.stderr)
 
     if plain_journals:
-        print("\nFollowing plain text journals will upgraded to jrnl {}:".format(__version__), file=sys.stderr)
+        print(f"\nFollowing plain text journals will upgraded to jrnl {__version__}:", file=sys.stderr)
         for journal, path in plain_journals.items():
             print("    {:{pad}} -> {}".format(journal, path, pad=longest_journal_name), file=sys.stderr)
 
@@ -85,13 +85,13 @@ older versions of jrnl anymore.
         raise UserAbort("jrnl NOT upgraded, exiting.")
 
     for journal_name, path in encrypted_journals.items():
-        print("\nUpgrading encrypted '{}' journal stored in {}...".format(journal_name, path), file=sys.stderr)
+        print(f"\nUpgrading encrypted '{journal_name}' journal stored in {path}...", file=sys.stderr)
         backup(path, binary=True)
         old_journal = Journal.open_journal(journal_name, util.scope_config(config, journal_name), legacy=True)
         all_journals.append(EncryptedJournal.from_journal(old_journal))
 
     for journal_name, path in plain_journals.items():
-        print("\nUpgrading plain text '{}' journal stored in {}...".format(journal_name, path), file=sys.stderr)
+        print(f"\nUpgrading plain text '{journal_name}' journal stored in {path}...", file=sys.stderr)
         backup(path)
         old_journal = Journal.open_journal(journal_name, util.scope_config(config, journal_name), legacy=True)
         all_journals.append(Journal.PlainJournal.from_journal(old_journal))
@@ -114,7 +114,7 @@ older versions of jrnl anymore.
     print("\nUpgrading config...", file=sys.stderr)
     backup(config_path)
 
-    print("\nWe're all done here and you can start enjoying jrnl 2.".format(config_path), file=sys.stderr)
+    print("\nWe're all done here and you can start enjoying jrnl 2.", file=sys.stderr)
 
 
 class UpgradeValidationException(Exception):

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import, unicode_literals
+import sys
 
 from . import __version__
 from . import Journal
@@ -10,7 +10,7 @@ import codecs
 
 
 def backup(filename, binary=False):
-    util.prompt("  Created a backup at {}.backup".format(filename))
+    print("  Created a backup at {}.backup".format(filename), file=sys.stderr)
     filename = os.path.expanduser(os.path.expandvars(filename))
     with open(filename, 'rb' if binary else 'r') as original:
         contents = original.read()
@@ -26,7 +26,7 @@ def upgrade_jrnl_if_necessary(config_path):
 
     config = util.load_config(config_path)
 
-    util.prompt("""Welcome to jrnl {}.
+    print("""Welcome to jrnl {}.
 
 It looks like you've been using an older version of jrnl until now. That's
 okay - jrnl will now upgrade your configuration and journal files. Afterwards
@@ -63,19 +63,19 @@ older versions of jrnl anymore.
 
     longest_journal_name = max([len(journal) for journal in config['journals']])
     if encrypted_journals:
-        util.prompt("\nFollowing encrypted journals will be upgraded to jrnl {}:".format(__version__))
+        print("\nFollowing encrypted journals will be upgraded to jrnl {}:".format(__version__), file=sys.stderr)
         for journal, path in encrypted_journals.items():
-            util.prompt("    {:{pad}} -> {}".format(journal, path, pad=longest_journal_name))
+            print("    {:{pad}} -> {}".format(journal, path, pad=longest_journal_name), file=sys.stderr)
 
     if plain_journals:
-        util.prompt("\nFollowing plain text journals will upgraded to jrnl {}:".format(__version__))
+        print("\nFollowing plain text journals will upgraded to jrnl {}:".format(__version__), file=sys.stderr)
         for journal, path in plain_journals.items():
-            util.prompt("    {:{pad}} -> {}".format(journal, path, pad=longest_journal_name))
+            print("    {:{pad}} -> {}".format(journal, path, pad=longest_journal_name), file=sys.stderr)
 
     if other_journals:
-        util.prompt("\nFollowing journals will be not be touched:")
+        print("\nFollowing journals will be not be touched:", file=sys.stderr)
         for journal, path in other_journals.items():
-            util.prompt("    {:{pad}} -> {}".format(journal, path, pad=longest_journal_name))
+            print("    {:{pad}} -> {}".format(journal, path, pad=longest_journal_name), file=sys.stderr)
 
     try:
         cont = util.yesno("\nContinue upgrading jrnl?", default=False)
@@ -85,13 +85,13 @@ older versions of jrnl anymore.
         raise UserAbort("jrnl NOT upgraded, exiting.")
 
     for journal_name, path in encrypted_journals.items():
-        util.prompt("\nUpgrading encrypted '{}' journal stored in {}...".format(journal_name, path))
+        print("\nUpgrading encrypted '{}' journal stored in {}...".format(journal_name, path), file=sys.stderr)
         backup(path, binary=True)
         old_journal = Journal.open_journal(journal_name, util.scope_config(config, journal_name), legacy=True)
         all_journals.append(EncryptedJournal.from_journal(old_journal))
 
     for journal_name, path in plain_journals.items():
-        util.prompt("\nUpgrading plain text '{}' journal stored in {}...".format(journal_name, path))
+        print("\nUpgrading plain text '{}' journal stored in {}...".format(journal_name, path), file=sys.stderr)
         backup(path)
         old_journal = Journal.open_journal(journal_name, util.scope_config(config, journal_name), legacy=True)
         all_journals.append(Journal.PlainJournal.from_journal(old_journal))
@@ -100,8 +100,9 @@ older versions of jrnl anymore.
     failed_journals = [j for j in all_journals if not j.validate_parsing()]
 
     if len(failed_journals) > 0:
-        util.prompt("\nThe following journal{} failed to upgrade:\n{}".format(
-            's' if len(failed_journals) > 1 else '', "\n".join(j.name for j in failed_journals))
+        print("\nThe following journal{} failed to upgrade:\n{}".format(
+            's' if len(failed_journals) > 1 else '', "\n".join(j.name for j in failed_journals)),
+            file=sys.stderr
         )
 
         raise UpgradeValidationException
@@ -110,10 +111,11 @@ older versions of jrnl anymore.
     for j in all_journals:
         j.write()
 
-    util.prompt("\nUpgrading config...")
+    print("\nUpgrading config...", file=sys.stderr)
     backup(config_path)
 
-    util.prompt("\nWe're all done here and you can start enjoying jrnl 2.".format(config_path))
+    print("\nWe're all done here and you can start enjoying jrnl 2.".format(config_path), file=sys.stderr)
+
 
 class UpgradeValidationException(Exception):
     """Raised when the contents of an upgraded journal do not match the old journal"""

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -6,7 +6,6 @@ from . import util
 from .EncryptedJournal import EncryptedJournal
 from .util import UserAbort
 import os
-import codecs
 
 
 def backup(filename, binary=False):
@@ -19,7 +18,7 @@ def backup(filename, binary=False):
 
 
 def upgrade_jrnl_if_necessary(config_path):
-    with codecs.open(config_path, "r", "utf-8") as f:
+    with open(config_path, "r", encoding="utf-8") as f:
         config_file = f.read()
     if not config_file.strip().startswith("{"):
         return

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# encoding: utf-8
 
 import sys
 import os

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -10,7 +10,6 @@ if "win32" in sys.platform:
 import re
 import tempfile
 import subprocess
-import codecs
 import unicodedata
 import shlex
 import logging
@@ -106,14 +105,14 @@ def scope_config(config, journal_name):
 
 def get_text_from_editor(config, template=""):
     filehandle, tmpfile = tempfile.mkstemp(prefix="jrnl", text=True, suffix=".txt")
-    with codecs.open(tmpfile, 'w', "utf-8") as f:
+    with open(tmpfile, 'w', encoding="utf-8") as f:
         if template:
             f.write(template)
     try:
         subprocess.call(shlex.split(config['editor'], posix="win" not in sys.platform) + [tmpfile])
     except AttributeError:
         subprocess.call(config['editor'] + [tmpfile])
-    with codecs.open(tmpfile, "r", "utf-8") as f:
+    with open(tmpfile, "r", encoding="utf-8") as f:
         raw = f.read()
     os.close(filehandle)
     os.remove(tmpfile)

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -125,7 +125,7 @@ def get_text_from_editor(config, template=""):
 
 def colorize(string):
     """Returns the string wrapped in cyan ANSI escape"""
-    return u"\033[36m{}\033[39m".format(string)
+    return f"\033[36m{string}\033[39m"
 
 
 def slugify(string):

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -77,7 +77,7 @@ def set_keychain(journal_name, password):
 
 
 def yesno(prompt, default=True):
-    prompt = f"{prompt.strip()} {'[Y/n]' if default else '[y/N]'}"
+    prompt = f"{prompt.strip()} {'[Y/n]' if default else '[y/N]'} "
     response = input(prompt)
     return {"y": True, "n": False}.get(response.lower(), default)
 


### PR DESCRIPTION
This PR should completely remove all the Python 2 compatibility features and other leftovers.
Closes #701, closes #615, fixes #700, might fix #667.

I also removed the wonky testing utilities in jrnl.utils and instead used unittest.mock.patch to simulate user inputs in the tests. It's a bit unusual as well this way, but at least we don't have to mess with replacing std.stdin and sys.stderr and what not. If somebody knows a simpler way to simulate user input that works with builtins.input, getpass.getpass as well as sys.stdin.read, let me know.

This is a bit of a bigger PR, but the tests all pass.

## Todo
- [x] Remove from \_\_future\_\_ imports
- [x] Switch util functions to builtins print()/input() 
- [x] Rework tests to mock user input
- [x] Remove all mentions of unicode
- [x] Change str.format() to f-strings
- [x] Change codecs.open to builtins.open

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
