### PR TITLE
Password confirmation

### DIFF
--- a/features/encryption.feature
+++ b/features/encryption.feature
@@ -3,29 +3,55 @@
             Given we use the config "encrypted.yaml"
             When we run "jrnl -n 1" and enter "bad doggie no biscuit"
             Then the output should contain "Password"
-            and the output should contain "2013-06-10 15:40 Life is good"
+            And the output should contain "2013-06-10 15:40 Life is good"
 
         Scenario: Decrypting a journal
             Given we use the config "encrypted.yaml"
             When we run "jrnl --decrypt" and enter "bad doggie no biscuit"
             Then the config for journal "default" should have "encrypt" set to "bool:False"
             Then we should see the message "Journal decrypted"
-            and the journal should have 2 entries
+            And the journal should have 2 entries
 
         Scenario: Encrypting a journal
             Given we use the config "basic.yaml"
-            When we run "jrnl --encrypt" and enter "swordfish" and "n"
+            When we run "jrnl --encrypt" and enter
+            """
+            swordfish
+            swordfish
+            n
+            """
             Then we should see the message "Journal encrypted"
-            and the config for journal "default" should have "encrypt" set to "bool:True"
+            And the config for journal "default" should have "encrypt" set to "bool:True"
             When we run "jrnl -n 1" and enter "swordfish"
             Then the output should contain "Password"
-            and the output should contain "2013-06-10 15:40 Life is good"
+            And the output should contain "2013-06-10 15:40 Life is good"
+
+        Scenario: Mistyping your password
+            Given we use the config "basic.yaml"
+            When we run "jrnl --encrypt" and enter
+            """
+            swordfish
+            sordfish
+            swordfish
+            swordfish
+            n
+            """
+            Then we should see the message "Passwords did not match"
+            And we should see the message "Journal encrypted"
+            And the config for journal "default" should have "encrypt" set to "bool:True"
+            When we run "jrnl -n 1" and enter "swordfish"
+            Then the output should contain "Password"
+            And the output should contain "2013-06-10 15:40 Life is good"
 
         Scenario: Storing a password in Keychain
             Given we use the config "multiple.yaml"
-            When we run "jrnl simple --encrypt" and enter "sabertooth" and "y"
+            When we run "jrnl simple --encrypt" and enter
+            """
+            sabertooth
+            sabertooth
+            y
+            """
             When we set the keychain password of "simple" to "sabertooth"
             Then the config for journal "simple" should have "encrypt" set to "bool:True"
             When we run "jrnl simple -n 1"
-            Then we should not see the message "Password"
-            and the output should contain "2013-06-10 15:40 Life is good"
+            Then the output should contain "2013-06-10 15:40 Life is good"

--- a/features/multiple_journals.feature
+++ b/features/multiple_journals.feature
@@ -42,5 +42,10 @@ Feature: Multiple journals
 
    Scenario: Don't crash if no file exists for a configured encrypted journal
         Given we use the config "multiple.yaml"
-        When we run "jrnl new_encrypted Adding first entry" and enter "these three eyes" and "y"
+        When we run "jrnl new_encrypted Adding first entry" and enter
+        """
+        these three eyes
+        these three eyes
+        n
+        """
 	Then we should see the message "Journal 'new_encrypted' created"

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -38,7 +38,7 @@ class EncryptedJournal(Journal.Journal):
         filename = filename or self.config['journal']
 
         if not os.path.exists(filename):
-            password = util.getpass("Enter password for new journal: ")
+            password = util.create_password()
             if password:
                 if util.yesno("Do you want to store the password in your keychain?", default=True):
                     util.set_keychain(self.name, password)

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -78,7 +78,7 @@ def encrypt(journal, filename=None):
     """ Encrypt into new file. If filename is not set, we encrypt the journal file itself. """
     from . import EncryptedJournal
 
-    journal.config['password'] = util.getpass("Enter new password: ")
+    journal.config['password'] = util.create_password()
     journal.config['encrypt'] = True
 
     new_journal = EncryptedJournal.EncryptedJournal(None, **journal.config)

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -37,12 +37,18 @@ class UserAbort(Exception):
     pass
 
 
-getpass = gp.getpass
+def create_password():
+    while True:
+        pw = gp.getpass("Enter password for new journal: ")
+        if pw == gp.getpass("Enter password again: "):
+            return pw
+
+        print("Passwords did not match, please try again", file=sys.stderr)
 
 
 def get_password(validator, keychain=None, max_attempts=3):
     pwd_from_keychain = keychain and get_keychain(keychain)
-    password = pwd_from_keychain or getpass()
+    password = pwd_from_keychain or gp.getpass()
     result = validator(password)
     # Password is bad:
     if result is None and pwd_from_keychain:


### PR DESCRIPTION
~~Stacked on #705.~~ Rebased on Master.

When creating a new password (using --encrypt), jrnl will now ask you to repeat the password. It will only encrypt it after you entered the same password correctly twice.
I've read some people complaining about permanently encrypting their journal because they mistyped their password, this should prevent that.

This does not work during the install yet, but will in #708. 

Fixes #481. 

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
