### PR TITLE
[Stacked on #706] Refactor password logic to prevent accidental password leakage

### DIFF
--- a/features/data/configs/bug153.yaml
+++ b/features/data/configs/bug153.yaml
@@ -6,7 +6,6 @@ highlight: true
 journals:
   default: features/journals/bug153.dayone
 linewrap: 80
-password: ''
 tagsymbols: '@'
 template: false
 timeformat: '%Y-%m-%d %H:%M'

--- a/features/data/configs/dayone.yaml
+++ b/features/data/configs/dayone.yaml
@@ -7,7 +7,6 @@ highlight: true
 journals:
   default: features/journals/dayone.dayone
 linewrap: 80
-password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
 indent_character: "|"

--- a/features/data/configs/empty_folder.yaml
+++ b/features/data/configs/empty_folder.yaml
@@ -7,7 +7,6 @@ highlight: true
 journals:
   default: features/journals/empty_folder
 linewrap: 80
-password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
 indent_character: "|"

--- a/features/data/configs/encrypted.yaml
+++ b/features/data/configs/encrypted.yaml
@@ -7,7 +7,6 @@ highlight: true
 journals:
   default: features/journals/encrypted.journal
 linewrap: 80
-password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
 indent_character: "|"

--- a/features/data/configs/markdown-headings-335.yaml
+++ b/features/data/configs/markdown-headings-335.yaml
@@ -7,7 +7,6 @@ template: false
 journals:
   default: features/journals/markdown-headings-335.journal
 linewrap: 80
-password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
 indent_character: "|"

--- a/features/data/configs/multiple.yaml
+++ b/features/data/configs/multiple.yaml
@@ -13,7 +13,6 @@ journals:
     encrypt: true
     journal: features/journals/new_encrypted.journal
 linewrap: 80
-password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
 indent_character: "|"

--- a/features/data/configs/tags-216.yaml
+++ b/features/data/configs/tags-216.yaml
@@ -7,7 +7,6 @@ template: false
 journals:
   default: features/journals/tags-216.journal
 linewrap: 80
-password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
 indent_character: "|"

--- a/features/data/configs/tags-237.yaml
+++ b/features/data/configs/tags-237.yaml
@@ -7,7 +7,6 @@ template: false
 journals:
   default: features/journals/tags-237.journal
 linewrap: 80
-password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
 indent_character: "|"

--- a/features/data/configs/tags.yaml
+++ b/features/data/configs/tags.yaml
@@ -7,7 +7,6 @@ template: false
 journals:
   default: features/journals/tags.journal
 linewrap: 80
-password: ''
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'
 indent_character: "|"

--- a/features/multiple_journals.feature
+++ b/features/multiple_journals.feature
@@ -48,4 +48,4 @@ Feature: Multiple journals
         these three eyes
         n
         """
-	Then we should see the message "Journal 'new_encrypted' created"
+	Then we should see the message "Encrypted journal 'new_encrypted' created"

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -41,6 +41,7 @@ class Journal:
         # Set up date parser
         self.search_tags = None  # Store tags we're highlighting
         self.name = name
+        self.entries = []
 
     def __len__(self):
         """Returns the number of entries"""
@@ -69,9 +70,9 @@ class Journal:
         filename = filename or self.config['journal']
 
         if not os.path.exists(filename):
+            self.create_file(filename)
             print(f"[Journal '{self.name}' created at {filename}]", file=sys.stderr)
-            self._create(filename)
-
+        
         text = self._load(filename)
         self.entries = self._parse(text)
         self.sort()
@@ -92,6 +93,11 @@ class Journal:
                 return False
         return True
 
+    @staticmethod
+    def create_file(filename):
+        with open(filename, "w"):
+            pass
+
     def _to_text(self):
         return "\n".join([str(e) for e in self.entries])
 
@@ -99,10 +105,6 @@ class Journal:
         raise NotImplementedError
 
     def _store(self, filename, text):
-        raise NotImplementedError
-
-    @classmethod
-    def _create(cls, filename):
         raise NotImplementedError
 
     def _parse(self, journal_txt):
@@ -270,11 +272,6 @@ class Journal:
 
 
 class PlainJournal(Journal):
-    @classmethod
-    def _create(cls, filename):
-        with open(filename, "a", encoding="utf-8"):
-            pass
-
     def _load(self, filename):
         with open(filename, "r", encoding="utf-8") as f:
             return f.read()


### PR DESCRIPTION
~~Stacked on #706 and #705, merge those before merging this PR. I can also rebase on master afterwards before merging to avoid duplicate commits.~~

After working with the passwords a bit in #706, I noticed how they were sometimes stored in the same dict as all the other journal specific configuration. I also noticed how some of the test files even had password fields in them. 

I was worried that real passwords would accidentally get written to the jrnl config file in the future (and subsequently leaked through peoples dotfile repositories...). To prevent that, I refactored a lot of the code to constrict the password handling logic only to the EncryptedJournal classes and away from the other configuration that gets saved to disk. 

However, I had to change the install progress a little bit to make this work. It will now not ask you for a password right away but rather if you want to encrypt or not. Only if you reply 'y' will it ask you for the password later on.

~~Currently this still breaks the install, which we do not have tests for by the way.~~

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
