### PR TITLE
Support Python 3.6+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 dist: xenial   # required for Python >= 3.7
 language: python
-python: "3.7"
+python:
+  - 3.6
+  - 3.7
 git:
   depth: false
 before_install:

--- a/poetry.lock
+++ b/poetry.lock
@@ -385,7 +385,7 @@ pytz = "*"
 
 [metadata]
 content-hash = "9896cf59c7552b6ad95219ee5555c7445a3fab39c2e4f4c6f3d991a36635e44b"
-python-versions = "^3.7"
+python-versions = ">=3.6.0, <3.8.0"
 
 [metadata.hashes]
 appdirs = ["9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92", "d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ homepage = "https://jrnl.sh"
 repository = "https://github.com/jrnl-org/jrnl"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.6.0, <3.8.0"
 pyxdg = "^0.26.0"
 cryptography = "^2.7"
 passlib = "^1.7"


### PR DESCRIPTION
As discussed in #615, we can and should support Python from version 3.6 and up. This PR:
 - adds all supported Python versions to Travis,
 - tells poetry and therefore pypi that 3.6+ is supported.