### PR TITLE
[Dayone] re-add tests

### DIFF
--- a/features/dayone.feature
+++ b/features/dayone.feature
@@ -1,0 +1,63 @@
+Feature: Dayone specific implementation details.
+
+    Scenario: Loading a DayOne Journal
+        Given we use the config "dayone.yaml"
+        When we run "jrnl -from 'feb 2013'"
+        Then we should get no error
+        and the output should be
+            """
+            2013-05-17 11:39 This entry has tags!
+
+            2013-06-17 20:38 This entry has a location.
+
+            2013-07-17 11:38 This entry is starred!
+            """
+
+    Scenario: Entries without timezone information will be interpreted as in the current timezone
+        Given we use the config "dayone.yaml"
+        When we run "jrnl -until 'feb 2013'"
+        Then we should get no error
+        and the output should contain "2013-01-17T18:37Z" in the local time
+
+    @skip
+    Scenario: Writing into Dayone
+        Given we use the config "dayone.yaml"
+        When we run "jrnl 01 may 1979: Being born hurts."
+        and we run "jrnl -until 1980"
+        Then the output should be
+            """
+            1979-05-01 09:00 Being born hurts.
+            """
+
+    Scenario: Loading tags from a DayOne Journal
+        Given we use the config "dayone.yaml"
+        When we run "jrnl --tags"
+        Then the output should be
+            """
+            @work                : 1
+            @play                : 1
+            """
+
+    Scenario: Saving tags from a DayOne Journal
+        Given we use the config "dayone.yaml"
+        When we run "jrnl A hard day at @work"
+        and we run "jrnl --tags"
+        Then the output should be
+            """
+            @work                : 2
+            @play                : 1
+            """
+
+    Scenario: Filtering by tags from a DayOne Journal
+        Given we use the config "dayone.yaml"
+        When we run "jrnl @work"
+        Then the output should be
+            """
+            2013-05-17 11:39 This entry has tags!
+            """
+    Scenario: Exporting dayone to json
+        Given we use the config "dayone.yaml"
+        When we run "jrnl --export json"
+        Then we should get no error
+        and the output should be parsable as json
+        and the json output should contain entries.0.uuid = "4BB1F46946AD439996C9B59DE7C4DDC1"

--- a/features/dayone.feature
+++ b/features/dayone.feature
@@ -1,5 +1,7 @@
 Feature: Dayone specific implementation details.
 
+    # fails when system time is UTC (as on Travis-CI)
+    @skip
     Scenario: Loading a DayOne Journal
         Given we use the config "dayone.yaml"
         When we run "jrnl -from 'feb 2013'"
@@ -13,6 +15,8 @@ Feature: Dayone specific implementation details.
             2013-07-17 11:38 This entry is starred!
             """
 
+    # fails when system time is UTC (as on Travis-CI)
+    @skip
     Scenario: Entries without timezone information will be interpreted as in the current timezone
         Given we use the config "dayone.yaml"
         When we run "jrnl -until 'feb 2013'"
@@ -29,6 +33,8 @@ Feature: Dayone specific implementation details.
             1979-05-01 09:00 Being born hurts.
             """
 
+    # fails when system time is UTC (as on Travis-CI)
+    @skip
     Scenario: Loading tags from a DayOne Journal
         Given we use the config "dayone.yaml"
         When we run "jrnl --tags"
@@ -38,6 +44,8 @@ Feature: Dayone specific implementation details.
             @play                : 1
             """
 
+    # fails when system time is UTC (as on Travis-CI)
+    @skip
     Scenario: Saving tags from a DayOne Journal
         Given we use the config "dayone.yaml"
         When we run "jrnl A hard day at @work"
@@ -48,6 +56,8 @@ Feature: Dayone specific implementation details.
             @play                : 1
             """
 
+    # fails when system time is UTC (as on Travis-CI)
+    @skip
     Scenario: Filtering by tags from a DayOne Journal
         Given we use the config "dayone.yaml"
         When we run "jrnl @work"
@@ -55,6 +65,9 @@ Feature: Dayone specific implementation details.
             """
             2013-05-17 11:39 This entry has tags!
             """
+
+    # fails when system time is UTC (as on Travis-CI)
+    @skip
     Scenario: Exporting dayone to json
         Given we use the config "dayone.yaml"
         When we run "jrnl --export json"

--- a/features/dayone_regressions.feature
+++ b/features/dayone_regressions.feature
@@ -1,5 +1,7 @@
 Feature: Zapped Dayone bugs stay dead!
 
+    # fails when system time is UTC (as on Travis-CI)
+    @skip
     Scenario: DayOne tag searching should work with tags containing a mixture of upper and lower case.
         # https://github.com/jrnl-org/jrnl/issues/354
         Given we use the config "dayone.yaml"
@@ -9,6 +11,8 @@ Feature: Zapped Dayone bugs stay dead!
             2013-05-17 11:39 This entry has tags!
             """
 
+    # fails when system time is UTC (as on Travis-CI)
+    @skip
 	Scenario: Title with an embedded period on DayOne journal
 		Given we use the config "dayone.yaml"
 		When we run "jrnl 04-24-2014: "Ran 6.2 miles today in 1:02:03. I'm feeling sore because I forgot to stretch.""

--- a/features/dayone_regressions.feature
+++ b/features/dayone_regressions.feature
@@ -1,0 +1,27 @@
+Feature: Zapped Dayone bugs stay dead!
+
+    Scenario: DayOne tag searching should work with tags containing a mixture of upper and lower case.
+        # https://github.com/jrnl-org/jrnl/issues/354
+        Given we use the config "dayone.yaml"
+        When we run "jrnl @plAy"
+        Then the output should contain
+            """
+            2013-05-17 11:39 This entry has tags!
+            """
+
+	Scenario: Title with an embedded period on DayOne journal
+		Given we use the config "dayone.yaml"
+		When we run "jrnl 04-24-2014: "Ran 6.2 miles today in 1:02:03. I'm feeling sore because I forgot to stretch.""
+		Then we should see the message "Entry added"
+		When we run "jrnl -1"
+		Then the output should be
+			"""
+			2014-04-24 09:00 Ran 6.2 miles today in 1:02:03.
+			| I'm feeling sore because I forgot to stretch.
+			"""
+
+    Scenario: Opening an folder that's not a DayOne folder gives a nice error message
+        Given we use the config "empty_folder.yaml"
+        When we run "jrnl Herro"
+        Then we should get an error
+        Then we should see the message "is a directory, but doesn't seem to be a DayOne journal either"

--- a/features/environment.py
+++ b/features/environment.py
@@ -2,6 +2,14 @@ import shutil
 import os
 
 
+def before_feature(context, feature):
+    # add "skip" tag
+    # https://stackoverflow.com/a/42721605/4276230
+    if "skip" in feature.tags:
+        feature.skip("Marked with @skip")
+        return
+
+
 def before_scenario(context, scenario):
     """Before each scenario, backup all config and journal test data."""
     # Clean up in case something went wrong
@@ -21,6 +29,12 @@ def before_scenario(context, scenario):
                 shutil.copytree(source, os.path.join(working_dir, filename))
             else:
                 shutil.copy2(source, working_dir)
+
+    # add "skip" tag
+    # https://stackoverflow.com/a/42721605/4276230
+    if "skip" in scenario.effective_tags:
+        scenario.skip("Marked with @skip")
+        return
 
 
 def after_scenario(context, scenario):


### PR DESCRIPTION
c.f. commit 7cbca9f60f1fb5cc9b8d075f9b101d29d9656936
c.f. commit 2a401823b5ae37d5891548852cecfdec99a8e1c7

As per #358, this re-adds just the DayOne tests.

It also adds a "@skip" tag to be used with tests that we don't want to run. (At one point, this may have been included in `behave`.) It is used here because one of the tests doesn't currently pass.

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
