### PR TITLE
Adding :new: label to github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: bug, :new:
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for jrnl
 title: ''
-labels: enhancement
+labels: enhancement, :new:
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -2,7 +2,7 @@
 name: Support Request
 about: Get help with jrnl
 title: ''
-labels: support
+labels: support, :new:
 assignees: ''
 
 ---


### PR DESCRIPTION
- Modifying issue templates to include a ":new:" label
- This makes it easier to categorize and take action on new issues
- Issues stop being "new" when they're resolved and/or added to a milestone
*
### Checklist
- [n/a] The code change is tested and works locally.
- [n/a] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your core changes, as applicable?
