### PR TITLE
[GH-738] preventing readline usage on Windows 

### DIFF
--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import readline
 import glob
 import getpass
 import os
@@ -14,6 +13,9 @@ from .util import UserAbort
 import yaml
 import logging
 import sys
+if "win32" not in sys.platform:
+    # readline is not included in Windows Active Python
+    import readline 
 
 DEFAULT_CONFIG_NAME = 'jrnl.yaml'
 DEFAULT_JOURNAL_NAME = 'journal.txt'
@@ -108,14 +110,10 @@ def load_or_install_jrnl():
 
 
 def install():
-    def autocomplete(text, state):
-        expansions = glob.glob(os.path.expanduser(os.path.expandvars(text)) + '*')
-        expansions = [e + "/" if os.path.isdir(e) else e for e in expansions]
-        expansions.append(None)
-        return expansions[state]
-    readline.set_completer_delims(' \t\n;')
-    readline.parse_and_bind("tab: complete")
-    readline.set_completer(autocomplete)
+    if "win32" not in sys.platform:
+        readline.set_completer_delims(' \t\n;')
+        readline.parse_and_bind("tab: complete")
+        readline.set_completer(autocomplete)
 
     # Where to create the journal?
     path_query = f'Path to your journal file (leave blank for {JOURNAL_FILE_PATH}): '
@@ -146,3 +144,9 @@ def install():
     if password:
         config['password'] = password
     return config
+
+def autocomplete(text, state):
+    expansions = glob.glob(os.path.expanduser(os.path.expandvars(text)) + '*')
+    expansions = [e + "/" if os.path.isdir(e) else e for e in expansions]
+    expansions.append(None)
+    return expansions[state]


### PR DESCRIPTION
This removes autocomplete for Windows users, thus preventing jrnl from crashing on Active Python, which has no readline module. It's only used when entering the path on the install step.

Related issue: #738 

### Checklist
- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your core changes, as applicable?
