### PR TITLE
[GH-741] adding test for bug that displays all entries -on today

### DIFF
--- a/features/regression.feature
+++ b/features/regression.feature
@@ -62,3 +62,10 @@ Feature: Zapped bugs should stay dead.
         Then the output should contain "I'm going to activate the machine."
         Then the output should contain "I've crossed so many timelines. Is there any going back?"
 
+    Scenario: Viewing today's entries does not print the entire journal
+        # https://github.com/jrnl-org/jrnl/issues/741
+        Given we use the config "basic.yaml"
+        When we run "jrnl -on today"
+        Then the output should not contain "Life is good"
+        Then the output should not contain "But I'm better."
+


### PR DESCRIPTION
Adding a test for a newer bug GH-741 which displays the whole journal when the user runs `jrnl -on today`

PR #665 in 2.1.2 fixes this issue very nicely (thank you @notbalanced) but I wanted to ensure that this very specific test case is included.

### Checklist
- [X] The code change is tested and works locally.
- [ ] Tests pass. Your PR cannot be merged unless tests pass (tests don't pass now but will once 2.1.2 is merged in) 
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [X] Have you written new tests for your core changes, as applicable?
