### PR TITLE
More Travis-CI Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial   # required for Python >= 3.7
-language: python
 jobs:
   include:
     - name: "Python 3.6 on Linux"
@@ -8,26 +7,30 @@ jobs:
       python: 3.7
     - name: "Python 3.8 on Linux"
       python: 3.8
-    - name: "Python, developmental version, on Linux"
+    - name: "Python dev on Linux"
       python: nightly
     - name: "Python 3.7.4 on MacOS"
       os: osx
       osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
+      before_install:
+        - pip3 install poetry~=0.12.17
     - name: "Python 3.8.0 on Windows"
       os: windows
       langage: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
         - choco install python --version 3.8.0
         - python -m pip install --upgrade pip
+        - pip install poetry~=0.12.17
   allow_failures:
     - python: 3.8
     - python: nightly
 git:
   depth: false
 cache: pip
-install:
+before_install:
   - pip install poetry~=0.12.17
+install:
   # we run `poetry version` here to appease poetry about '0.0.0-source'
   - poetry version
   - poetry install

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,16 @@ jobs:
       language: shell       # 'language: python' is an error on Travis CI macOS
       before_install:
         - pip3 install poetry~=0.12.17  # 'pip' points to Python 2 on MacOS
-    - name: "Python 3.8.0 on Windows"
+    - name: "Python 3.7.5 on Windows"
       os: windows
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
-        - choco install python --version 3.8.0
+        - choco install python --version 3.7.5
         - python -m pip install --upgrade pip
+        - pip --version
         - pip install poetry~=0.12.17
       env:
-        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - PATH=/c/Python37:/c/Python37/Scripts:$PATH
   allow_failures:
     - python: 3.8
     - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
   allow_failures:
     - python: 3.8
     - python: nightly
+    - os: windows
 git:
   depth: false
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,33 @@
 dist: xenial   # required for Python >= 3.7
 language: python
-python:
-  - 3.6
-  - 3.7
+jobs:
+  include:
+    - name: "Python 3.6 on Linux"
+      python: 3.6
+    - name: "Python 3.7 on Linux"
+      python: 3.7
+    - name: "Python 3.8 on Linux"
+      python: 3.8
+    - name: "Python, developmental version, on Linux"
+      python: nightly
+    - name: "Python 3.7.4 on MacOS"
+      os: osx
+      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
+      language: shell       # 'language: python' is an error on Travis CI macOS
+    - name: "Python 3.8.0 on Windows"
+      os: windows
+      langage: shell       # 'language: python' is an error on Travis CI Windows
+      before_install:
+        - choco install python --version 3.8.0
+        - python -m pip install --upgrade pip
+  allow_failures:
+    - python: 3.8
+    - python: nightly
 git:
   depth: false
-before_install:
-  - pip install poetry~=0.12.17
+cache: pip
 install:
+  - pip install poetry~=0.12.17
   # we run `poetry version` here to appease poetry about '0.0.0-source'
   - poetry version
   - poetry install

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,10 @@ jobs:
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
         - choco install python --version 3.8.0
-        - refreshenv  # add Python to PATH
         - python -m pip install --upgrade pip
         - pip install poetry~=0.12.17
+      env:
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
   allow_failures:
     - python: 3.8
     - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,31 @@
 dist: xenial   # required for Python >= 3.7
+language: python
 jobs:
   include:
     - name: "Python 3.6 on Linux"
-      language: python
       python: 3.6
     - name: "Python 3.7 on Linux"
-      language: python
       python: 3.7
+    - name: "Python 3.7 on Linux, not UTC"
+      python: 3.7
+      env:
+        - TZ=America/Edmonton
     - name: "Python 3.8 on Linux"
-      language: python
       python: 3.8
     - name: "Python dev on Linux"
-      language: python
       python: nightly
     - name: "Python 3.7.4 on MacOS"
       os: osx
       osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
       before_install:
-        - pip3 install poetry~=0.12.17
+        - pip3 install poetry~=0.12.17  # 'pip' points to Python 2 on MacOS
     - name: "Python 3.8.0 on Windows"
       os: windows
-      langage: shell       # 'language: python' is an error on Travis CI Windows
+      language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
         - choco install python --version 3.8.0
+        - refreshenv  # add Python to PATH
         - python -m pip install --upgrade pip
         - pip install poetry~=0.12.17
   allow_failures:
@@ -33,13 +35,14 @@ git:
   depth: false
 cache: pip
 before_install:
+  - date
   - pip install poetry~=0.12.17
 install:
   # we run `poetry version` here to appease poetry about '0.0.0-source'
   - poetry version
   - poetry install
-script:
   - poetry run python --version
+script:
   - poetry run behave
 before_deploy:
   - poetry config http-basic.pypi $PYPI_USER $PYPI_PASS

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,16 @@ dist: xenial   # required for Python >= 3.7
 jobs:
   include:
     - name: "Python 3.6 on Linux"
+      language: python
       python: 3.6
     - name: "Python 3.7 on Linux"
+      language: python
       python: 3.7
     - name: "Python 3.8 on Linux"
+      language: python
       python: 3.8
     - name: "Python dev on Linux"
+      language: python
       python: nightly
     - name: "Python 3.7.4 on MacOS"
       os: osx

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -164,7 +164,7 @@ def has_error(context):
 
 @then('we should get no error')
 def no_error(context):
-    assert context.exit_status is 0, context.exit_status
+    assert context.exit_status == 0, context.exit_status
 
 
 @then('the output should be parsable as json')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ homepage = "https://jrnl.sh"
 repository = "https://github.com/jrnl-org/jrnl"
 
 [tool.poetry.dependencies]
-python = ">=3.6.0, <3.8.0"
+python = ">=3.6.0, <3.9.0"
 pyxdg = "^0.26.0"
 cryptography = "^2.7"
 passlib = "^1.7"


### PR DESCRIPTION
This is to expand the Travis testing. Specifically, it adds:

- Python 3.8 (on Linux) as an "allowable failure". See #739. It looks like an easy fix to get this working. Once working, this can removed from the allowable failure list.
- the developmental version of Python (on Linux), as an allowable failure. This is designed as a forward-looking test to help us be aware of anything in the next Python version that might break `jrnl`. It also has the bonus of helping the Python core devs by exposing the cutting edge Python code to lots of real life Python code.
- a test not in UTC. When I was re-adding the DayOne tests (#742), I discovered that the code path changes depending on if the timezone is UTC or now. However, I expect few user's machines are set to UTC, so it seems like an oversight to to only test in UTC.
- MacOS. Because why not? Runs under Python 3.7.4. We have had MacOS-specific bugs in the past (see #130).
- Windows, as an allowable failure. This is currently tested under Python 3.7, as on Python 3.8 `poetry` tries to install `cryptography` as a locally-built wheel (rather than a wheel downloaded from PyPI), which fails. This test currently times out after 10 minutes, as one of the `behave` steps is to open the editor and get text, and I think it is *really* opening the editor, rather than pretending to. This is odd, because it doesn't do this on my local machine.... c.f. #619

I haven't implemented it here, but the format of Travis should make it simple to add stages to the testing sequence, for example to run all the code through `black` or check that the dependencies have all been updated.



### Checklist
- (n/a) The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
