### PR TITLE
Fix CI config to only deploy once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 dist: xenial   # required for Python >= 3.7
 os: linux
 language: python
-cache: pip
+
+cache:
+  - pip
 
 git:
   depth: false
@@ -22,6 +24,9 @@ aliases:
     os: osx
     language: shell
     osx_image: xcode11.2
+    cache:
+      directories:
+        - $HOME/.pyenv/versions
     before_install:
       - eval "$(pyenv init -)"
       - pyenv install -s $JRNL_PYTHON_VERSION
@@ -31,6 +36,11 @@ aliases:
   test_windows: &test_windows
     os: windows
     language: shell
+    cache:
+      directories:
+        - /c/Python36
+        - /c/Python37
+        - /c/Python38
     before_install:
       - choco install python --version $JRNL_PYTHON_VERSION
       - python -m pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,26 @@ os: linux
 language: python
 jobs:
   include:
-    - stage: "Test"
-      name: "Python 3.6 on Linux"
+    - stage: Test
+    - name: Python 3.6 on Linux
       python: 3.6
-    - name: "Python 3.7 on Linux"
+    - name: Python 3.7 on Linux
       python: 3.7
-    - name: "Python 3.7 on Linux, not UTC"
+    - name: Python 3.7 on Linux, not UTC
       python: 3.7
       env:
         - TZ=America/Edmonton
-    - name: "Python 3.8 on Linux"
+    - name: Python 3.8 on Linux
       python: 3.8
-    - name: "Python dev on Linux"
+    - name: Python nightly on Linux
       python: nightly
-    - name: "Python 3.7.4 on MacOS"
+    - name: Python 3.7.4 on MacOS
       os: osx
       osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
       before_install:
         - pip3 install poetry~=0.12.17  # 'pip' points to Python 2 on MacOS
-    - name: "Python 3.7.5 on Windows"
+    - name: Python 3.7 on Windows
       os: windows
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
@@ -32,7 +32,7 @@ jobs:
         - pip install poetry~=0.12.17
       env:
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
-    - stage: "Deploy"
+    - stage: Deploy
       if: branch = master AND tag IS present
       before_deploy:
         - poetry config http-basic.pypi "$PYPI_USER" "$PYPI_PASS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ jobs:
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
     - stage: "Deploy"
       before_deploy:
-        - poetry config http-basic.pypi $PYPI_USER $PYPI_PASS
-        - poetry version $TRAVIS_TAG
+        - poetry config http-basic.pypi "$PYPI_USER" "$PYPI_PASS"
+        - poetry version "$TRAVIS_TAG"
         - poetry build
       deploy:
         - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,28 @@
 dist: xenial   # required for Python >= 3.7
 os: linux
 language: python
+cache: pip
+
+git:
+  depth: false
+
+before_install:
+  - date
+  - pip install poetry~=0.12.17
+
+install:
+  - poetry install
+  - poetry run python --version
+
+script:
+  - poetry run behave
+
 jobs:
+  allow_failures:
+    - python: 3.8
+    - python: nightly
+    - os: windows
+
   include:
     - stage: Test
     - name: Python 3.6 on Linux
@@ -32,6 +53,7 @@ jobs:
         - pip install poetry~=0.12.17
       env:
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+
     - stage: Deploy
       if: branch = master AND tag IS present
       before_deploy:
@@ -48,19 +70,4 @@ jobs:
         - git add pyproject.toml
         - git commit -m "Incrementing version to ${TRAVIS_TAG}"
         - git push https://${GITHUB_TOKEN}@github.com/jrnl-org/jrnl.git master
-  allow_failures:
-    - python: 3.8
-    - python: nightly
-    - os: windows
-git:
-  depth: false
-cache: pip
-before_install:
-  - date
-  - pip install poetry~=0.12.17
-install:
-  - poetry install
-  - poetry run python --version
-script:
-  - poetry run behave
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ jobs:
       env:
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
     - stage: "Deploy"
+      if: branch = master AND tag IS present
       before_deploy:
         - poetry config http-basic.pypi "$PYPI_USER" "$PYPI_PASS"
         - poetry version "$TRAVIS_TAG"
@@ -40,10 +41,6 @@ jobs:
       deploy:
         - provider: script
           script: poetry publish
-          skip_cleanup: true
-          on:
-            branch: master
-            tags: true
       after_deploy:
         - git config --global user.email "jrnl.bot@gmail.com"
         - git config --global user.name "Jrnl Bot"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,25 @@ jobs:
         - pip install poetry~=0.12.17
       env:
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+    - stage: "Deploy"
+      before_deploy:
+        - poetry config http-basic.pypi $PYPI_USER $PYPI_PASS
+        - poetry version $TRAVIS_TAG
+        - poetry build
+      deploy:
+        - provider: script
+          script: poetry publish
+          skip_cleanup: true
+          on:
+            branch: master
+            tags: true
+      after_deploy:
+        - git config --global user.email "jrnl.bot@gmail.com"
+        - git config --global user.name "Jrnl Bot"
+        - git checkout master
+        - git add pyproject.toml
+        - git commit -m "Incrementing version to ${TRAVIS_TAG}"
+        - git push https://${GITHUB_TOKEN}@github.com/jrnl-org/jrnl.git master
   allow_failures:
     - python: 3.8
     - python: nightly
@@ -47,21 +66,4 @@ install:
   - poetry run python --version
 script:
   - poetry run behave
-before_deploy:
-  - poetry config http-basic.pypi $PYPI_USER $PYPI_PASS
-  - poetry version $TRAVIS_TAG
-  - poetry build
-deploy:
-  - provider: script
-    script: poetry publish
-    skip_cleanup: true
-    on:
-      branch: master
-      tags: true
-after_deploy:
-  - git config --global user.email "jrnl.bot@gmail.com"
-  - git config --global user.name "Jrnl Bot"
-  - git checkout master
-  - git add pyproject.toml
-  - git commit -m "Incrementing version to ${TRAVIS_TAG}"
-  - git push https://${GITHUB_TOKEN}@github.com/jrnl-org/jrnl.git master
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,48 +43,54 @@ jobs:
     - os: windows
 
   include:
-    - stage: Test
+    # Python 3.6 Tests
     - name: Python 3.6 on Linux
       python: 3.6
-    - name: Python 3.7 on Linux
-      python: 3.7
-    - name: Python 3.7 on Linux, not UTC
-      python: 3.7
-      env:
-        - TZ=America/Edmonton
-    - name: Python 3.8 on Linux
-      python: 3.8
-    - name: Python nightly on Linux
-      python: nightly
-
     - <<: *test_mac
       name: Python 3.6 on MacOS
       env:
         - JRNL_PYTHON_VERSION=3.6.8
-    - <<: *test_mac
-      name: Python 3.7 on MacOS
-      env:
-        - JRNL_PYTHON_VERSION=3.7.4
-    - <<: *test_mac
-      name: Python 3.8 on MacOS
-      env:
-        - JRNL_PYTHON_VERSION=3.8.0
-
     - <<: *test_windows
       name: Python 3.6 on Windows
       env:
         - JRNL_PYTHON_VERSION=3.6.8
         - PATH=/c/Python36:/c/Python36/Scripts:$PATH
+
+    # Python 3.7 Tests
+    - name: Python 3.7 on Linux
+      python: 3.7
+    - <<: *test_mac
+      name: Python 3.7 on MacOS
+      env:
+        - JRNL_PYTHON_VERSION=3.7.4
     - <<: *test_windows
       name: Python 3.7 on Windows
       env:
         - JRNL_PYTHON_VERSION=3.7.5
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+
+    # Python 3.8 Tests
+    - name: Python 3.8 on Linux
+      python: 3.8
+    - <<: *test_mac
+      name: Python 3.8 on MacOS
+      env:
+        - JRNL_PYTHON_VERSION=3.8.0
     - <<: *test_windows
       name: Python 3.8 on Windows
       env:
         - JRNL_PYTHON_VERSION=3.8.0
         - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+
+    # ... and beyond!
+    - name: Python nightly on Linux
+      python: nightly
+
+    # Specialty tests
+    - name: Python 3.7 on Linux, not UTC
+      python: 3.7
+      env:
+        - TZ=America/Edmonton
 
     - stage: Deploy
       if: branch = master AND tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ jobs:
       name: Python 3.7 on MacOS
       python: 3.7
       env:
-        - JRNL_PYTHON_VERSION=3.7.4
+        - JRNL_PYTHON_VERSION=3.7.5
     - <<: *test_windows
       name: Python 3.7 on Windows
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ dist: xenial   # required for Python >= 3.7
 language: python
 jobs:
   include:
-    - name: "Python 3.6 on Linux"
+    - stage: "Test"
+      name: "Python 3.6 on Linux"
       python: 3.6
     - name: "Python 3.7 on Linux"
       python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial   # required for Python >= 3.7
+os: linux
 language: python
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,8 +60,6 @@ before_install:
   - date
   - pip install poetry~=0.12.17
 install:
-  # we run `poetry version` here to appease poetry about '0.0.0-source'
-  - poetry version
   - poetry install
   - poetry run python --version
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,23 @@ git:
 
 before_install:
   - date
-  - pip install poetry~=0.12.17
 
 install:
+  - pip install poetry~=0.12.17
   - poetry install
   - poetry run python --version
 
 script:
   - poetry run behave
+
+aliases:
+  test_windows: &test_windows
+    os: windows
+    language: shell
+    before_install:
+      - choco install python --version $JRNL_PYTHON_VERSION
+      - python -m pip install --upgrade pip
+      - pip --version
 
 jobs:
   allow_failures:
@@ -41,18 +50,21 @@ jobs:
       os: osx
       osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
       language: shell       # 'language: python' is an error on Travis CI macOS
-      before_install:
-        - pip3 install poetry~=0.12.17  # 'pip' points to Python 2 on MacOS
-    - name: Python 3.7 on Windows
-      os: windows
-      language: shell       # 'language: python' is an error on Travis CI Windows
-      before_install:
-        - choco install python --version 3.7.5
-        - python -m pip install --upgrade pip
-        - pip --version
-        - pip install poetry~=0.12.17
+    - <<: *test_windows
+      name: Python 3.6 on Windows
       env:
+        - JRNL_PYTHON_VERSION=3.6.8
+        - PATH=/c/Python36:/c/Python36/Scripts:$PATH
+    - <<: *test_windows
+      name: Python 3.7 on Windows
+      env:
+        - JRNL_PYTHON_VERSION=3.7.5
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+    - <<: *test_windows
+      name: Python 3.8 on Windows
+      env:
+        - JRNL_PYTHON_VERSION=3.8.0
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
 
     - stage: Deploy
       if: branch = master AND tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ aliases:
       - pip --version
 
 jobs:
+  fast_finish: true
   allow_failures:
     - python: 3.8
     - python: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,12 @@ jobs:
       python: 3.6
     - <<: *test_mac
       name: Python 3.6 on MacOS
+      python: 3.6
       env:
         - JRNL_PYTHON_VERSION=3.6.8
     - <<: *test_windows
       name: Python 3.6 on Windows
+      python: 3.6
       env:
         - JRNL_PYTHON_VERSION=3.6.8
         - PATH=/c/Python36:/c/Python36/Scripts:$PATH
@@ -61,10 +63,12 @@ jobs:
       python: 3.7
     - <<: *test_mac
       name: Python 3.7 on MacOS
+      python: 3.7
       env:
         - JRNL_PYTHON_VERSION=3.7.4
     - <<: *test_windows
       name: Python 3.7 on Windows
+      python: 3.7
       env:
         - JRNL_PYTHON_VERSION=3.7.5
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
@@ -74,10 +78,12 @@ jobs:
       python: 3.8
     - <<: *test_mac
       name: Python 3.8 on MacOS
+      python: 3.8
       env:
         - JRNL_PYTHON_VERSION=3.8.0
     - <<: *test_windows
       name: Python 3.8 on Windows
+      python: 3.8
       env:
         - JRNL_PYTHON_VERSION=3.8.0
         - PATH=/c/Python38:/c/Python38/Scripts:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,16 @@ script:
   - poetry run behave
 
 aliases:
+  test_mac: &test_mac
+    os: osx
+    language: shell
+    osx_image: xcode11.2
+    before_install:
+      - eval "$(pyenv init -)"
+      - pyenv install -s $JRNL_PYTHON_VERSION
+      - pyenv global $JRNL_PYTHON_VERSION
+      - pip install --upgrade pip
+      - pip --version
   test_windows: &test_windows
     os: windows
     language: shell
@@ -46,10 +56,20 @@ jobs:
       python: 3.8
     - name: Python nightly on Linux
       python: nightly
-    - name: Python 3.7.4 on MacOS
-      os: osx
-      osx_image: xcode11.2  # Python 3.7.4 running on macOS 10.14.4
-      language: shell       # 'language: python' is an error on Travis CI macOS
+
+    - <<: *test_mac
+      name: Python 3.6 on MacOS
+      env:
+        - JRNL_PYTHON_VERSION=3.6.8
+    - <<: *test_mac
+      name: Python 3.7 on MacOS
+      env:
+        - JRNL_PYTHON_VERSION=3.7.4
+    - <<: *test_mac
+      name: Python 3.8 on MacOS
+      env:
+        - JRNL_PYTHON_VERSION=3.8.0
+
     - <<: *test_windows
       name: Python 3.6 on Windows
       env:


### PR DESCRIPTION
Closes #757

This also does the following:
- All tests run on Python 3.6, 3.7, and 3.8
- Each Python version runs on Linux, Mac and Windows
- Adds caching for Python versions installed by pyenv on mac, and choco on windows (speeds up builds considerably)

Todo (possibly in a separate PR):
- Add caching for `poetry install` (would shave off another minute or so per test suite)
- Look into why Windows python install is getting 503

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?