### PR TITLE
Display header in docs on mobile devices

### DIFF
--- a/docs/assets/theme.css
+++ b/docs/assets/theme.css
@@ -45,9 +45,17 @@ p {
 /* No-one likes lines that are 400 characters long. */
 div.rst-content {max-width: 54em;}
 
-.wy-side-nav-search, .wy-nav-top, .wy-menu-vertical li.current {
+.wy-side-nav-search, .wy-menu-vertical li.current {
   background-color: transparent;
 }
+.wy-nav-top {
+  background-image: linear-gradient(-211deg, #95699C 0%, #604385 100%);
+}
+
+.wy-nav-top .fa-bars {
+  line-height: 50px;
+}
+
 .wy-side-nav-search a.icon-home {
   width: 100%;
   max-width: 250px;


### PR DESCRIPTION
Fixes #760.

Headers were not visible because of a transparent background. This commit will give the header the same gradient treatment as the sidebar, which will expose the hamburger menu - tapping the menu shows the sidebar for navigation.

![image](https://user-images.githubusercontent.com/1047165/69889650-06bb5480-12a7-11ea-8d97-5ab57b66660d.png)

![image](https://user-images.githubusercontent.com/1047165/69889703-46823c00-12a7-11ea-8ff1-95438720bec7.png)

### Checklist
- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
