### PR TITLE
Fix usage notes

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,12 +35,12 @@ jrnl today at 3am: I just met Steve Buscemi in a bar! He looked funny.
 ```
 
 !!! note
-Most shell contains a certain number of reserved characters, such as `#`
-and `*`. Unbalanced quotes, parenthesis, and so on will also get into
-the way of your editing.
-For writing longer entries, just enter `jrnl`
-and hit `return`. Only then enter the text of your journal entry.
-Alternatively, `use an external editor <advanced>`).
+    Most shell contains a certain number of reserved characters, such as `#`
+    and `*`. Unbalanced quotes, parenthesis, and so on will also get into
+    the way of your editing.
+    For writing longer entries, just enter `jrnl`
+    and hit `return`. Only then enter the text of your journal entry.
+    Alternatively, `use an external editor <advanced>`).
 
 You can also import an entry directly from a file
 
@@ -76,9 +76,9 @@ The following options are equivalent:
 - `jrnl Best day of my life.*`
 
 !!! note
-Just make sure that the asterisk sign is **not** surrounded by
-whitespaces, e.g. `jrnl Best day of my life! *` will **not** work (the
-reason being that the `*` sign has a special meaning on most shells).
+    Just make sure that the asterisk sign is **not** surrounded by
+    whitespaces, e.g. `jrnl Best day of my life! *` will **not** work (the
+    reason being that the `*` sign has a special meaning on most shells).
 
 ## Viewing
 
@@ -127,9 +127,9 @@ You can change which symbols you'd like to use for tagging in the
 configuration.
 
 !!! note
-`jrnl @pinkie @WorldDomination` will switch to viewing mode because
-although **no** command line arguments are given, all the input strings
-look like tags - _jrnl_ will assume you want to filter by tag.
+    `jrnl @pinkie @WorldDomination` will switch to viewing mode because
+    although **no** command line arguments are given, all the input strings
+    look like tags - _jrnl_ will assume you want to filter by tag.
 
 ## Editing older entries
 


### PR DESCRIPTION
I indented the blocks of note text in the basic usage page. The note text shows up outside the block, visible on https://jrnl.sh/usage/. The changes were tested with `mkdocs`, and it all looks good. 

### Checklist
- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?