### PR TITLE
Add UTC support for failing DayOne tests

### DIFF
--- a/features/dayone.feature
+++ b/features/dayone.feature
@@ -1,7 +1,5 @@
 Feature: Dayone specific implementation details.
 
-    # fails when system time is UTC (as on Travis-CI)
-    @skip
     Scenario: Loading a DayOne Journal
         Given we use the config "dayone.yaml"
         When we run "jrnl -from 'feb 2013'"
@@ -15,7 +13,7 @@ Feature: Dayone specific implementation details.
             2013-07-17 11:38 This entry is starred!
             """
 
-    # fails when system time is UTC (as on Travis-CI)
+    # broken still
     @skip
     Scenario: Entries without timezone information will be interpreted as in the current timezone
         Given we use the config "dayone.yaml"
@@ -23,7 +21,6 @@ Feature: Dayone specific implementation details.
         Then we should get no error
         and the output should contain "2013-01-17T18:37Z" in the local time
 
-    @skip
     Scenario: Writing into Dayone
         Given we use the config "dayone.yaml"
         When we run "jrnl 01 may 1979: Being born hurts."
@@ -33,8 +30,6 @@ Feature: Dayone specific implementation details.
             1979-05-01 09:00 Being born hurts.
             """
 
-    # fails when system time is UTC (as on Travis-CI)
-    @skip
     Scenario: Loading tags from a DayOne Journal
         Given we use the config "dayone.yaml"
         When we run "jrnl --tags"
@@ -44,8 +39,6 @@ Feature: Dayone specific implementation details.
             @play                : 1
             """
 
-    # fails when system time is UTC (as on Travis-CI)
-    @skip
     Scenario: Saving tags from a DayOne Journal
         Given we use the config "dayone.yaml"
         When we run "jrnl A hard day at @work"
@@ -56,8 +49,6 @@ Feature: Dayone specific implementation details.
             @play                : 1
             """
 
-    # fails when system time is UTC (as on Travis-CI)
-    @skip
     Scenario: Filtering by tags from a DayOne Journal
         Given we use the config "dayone.yaml"
         When we run "jrnl @work"
@@ -66,8 +57,6 @@ Feature: Dayone specific implementation details.
             2013-05-17 11:39 This entry has tags!
             """
 
-    # fails when system time is UTC (as on Travis-CI)
-    @skip
     Scenario: Exporting dayone to json
         Given we use the config "dayone.yaml"
         When we run "jrnl --export json"

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -52,16 +52,11 @@ class DayOne(Journal.Journal):
                     except (KeyError, pytz.exceptions.UnknownTimeZoneError):
                         timezone = tzlocal.get_localzone()
                     date = dict_entry["Creation Date"]
-                    try:
+                    # convert the date to UTC rather than keep messing with
+                    # timezones
+                    if timezone.zone != "UTC":
                         date = date + timezone.utcoffset(date, is_dst=False)
-                    except TypeError:
-                        # The above converts the date to UTC. However, if the
-                        # timezone is already in UTC, you can't call
-                        # timezone.utcoffset() with the is_dst parameter
-                        # ("utcoffset() got an unexpected keyword argument
-                        # 'is_dst'"), but we already have our date in UTC, so
-                        # nothing more needs to be done.
-                        pass
+
                     entry = Entry.Entry(
                         self,
                         date,

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -52,7 +52,16 @@ class DayOne(Journal.Journal):
                     except (KeyError, pytz.exceptions.UnknownTimeZoneError):
                         timezone = tzlocal.get_localzone()
                     date = dict_entry["Creation Date"]
-                    date = date + timezone.utcoffset(date, is_dst=False)
+                    try:
+                        date = date + timezone.utcoffset(date, is_dst=False)
+                    except TypeError:
+                        # The above converts the date to UTC. However, if the
+                        # timezone is already in UTC, you can't call
+                        # timezone.utcoffset() with the is_dst parameter
+                        # ("utcoffset() got an unexpected keyword argument
+                        # 'is_dst'"), but we already have our date in UTC, so
+                        # nothing more needs to be done.
+                        pass
                     entry = Entry.Entry(
                         self,
                         date,


### PR DESCRIPTION
Travis-CI (typically) runs in UTC, and UTC behaves weird compared to other timezones. This adds UTC support to the DayOne parts of the code.

Thus this re-enables the (most of) DayOne tests (all of which broke previously, because of UTC), building on #742 .

The code change is pulled from #350.

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
