### PR TITLE
Fix crash while encrypting a journal on first run without saving password

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -103,7 +103,7 @@ def set_keychain(journal_name, password):
     if password is None:
         try:
             keyring.delete_password("jrnl", journal_name)
-        except RuntimeError:
+        except keyring.errors.PasswordDeleteError:
             pass
     else:
         keyring.set_password("jrnl", journal_name, password)


### PR DESCRIPTION
Fix for #788 - changes `RuntimeError` to `PasswordDeleteError`

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
