### PR TITLE
Close temp file before passing it to editor to prevent file locking issues in Windows

### DIFF
--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -142,21 +142,26 @@ def scope_config(config, journal_name):
 
 def get_text_from_editor(config, template=""):
     filehandle, tmpfile = tempfile.mkstemp(prefix="jrnl", text=True, suffix=".txt")
+    os.close(filehandle)
+
     with open(tmpfile, "w", encoding="utf-8") as f:
         if template:
             f.write(template)
+
     try:
         subprocess.call(
             shlex.split(config["editor"], posix="win" not in sys.platform) + [tmpfile]
         )
     except AttributeError:
         subprocess.call(config["editor"] + [tmpfile])
+
     with open(tmpfile, "r", encoding="utf-8") as f:
         raw = f.read()
-    os.close(filehandle)
     os.remove(tmpfile)
+
     if not raw:
         print("[Nothing saved to file]", file=sys.stderr)
+
     return raw
 
 


### PR DESCRIPTION
When jrnl creates a temp file to pass to the user's custom editor, it doesn't close that temp file first. This doesn't seem to be an issue on *nix, but in Windows, this makes editing impossible because the editor can't get a write lock on the file.

### Checklist
- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable? - no! I can't think of how to write any for this. Suggestions welcome.

Fixes #790