### PR TITLE
Fix for tests not handling successive input prompts

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -43,7 +43,10 @@ Feature: Basic reading and writing to a journal
 
     Scenario: Writing an entry at the prompt
         Given we use the config "basic.yaml"
-        When we run "jrnl" and enter "25 jul 2013: I saw Elvis. He's alive."
+        When we run "jrnl" and enter
+        """
+        25 jul 2013: I saw Elvis. He's alive.
+        """
         Then we should get no error
         and the journal should contain "[2013-07-25 09:00] I saw Elvis."
         and the journal should contain "He's alive."

--- a/features/custom_dates.feature
+++ b/features/custom_dates.feature
@@ -29,7 +29,10 @@ Feature: Reading and writing to journal with custom date formats
 
     Scenario: Writing an entry at the prompt
         Given we use the config "little_endian_dates.yaml"
-        When we run "jrnl" and enter "2013-05-10: I saw Elvis. He's alive."
+        When we run "jrnl" and enter
+        """
+        2013-05-10: I saw Elvis. He's alive.
+        """
         Then we should get no error
         And the journal should contain "[10.05.2013 09:00] I saw Elvis."
         And the journal should contain "He's alive."

--- a/features/encryption.feature
+++ b/features/encryption.feature
@@ -1,13 +1,19 @@
     Feature: Encrypted journals
         Scenario: Loading an encrypted journal
             Given we use the config "encrypted.yaml"
-            When we run "jrnl -n 1" and enter "bad doggie no biscuit"
+            When we run "jrnl -n 1" and enter
+            """
+            bad doggie no biscuit
+            """
             Then the output should contain "Password"
             And the output should contain "2013-06-10 15:40 Life is good"
 
         Scenario: Decrypting a journal
             Given we use the config "encrypted.yaml"
-            When we run "jrnl --decrypt" and enter "bad doggie no biscuit"
+            When we run "jrnl --decrypt" and enter
+            """"
+            bad doggie no biscuit
+            """
             Then the config for journal "default" should have "encrypt" set to "bool:False"
             Then we should see the message "Journal decrypted"
             And the journal should have 2 entries
@@ -23,7 +29,10 @@
             """
             Then we should see the message "Journal encrypted"
             And the config for journal "default" should have "encrypt" set to "bool:True"
-            When we run "jrnl -n 1" and enter "swordfish"
+            When we run "jrnl -n 1" and enter
+            """
+            swordfish
+            """
             Then the output should contain "Password"
             And the output should contain "2013-06-10 15:40 Life is good"
 
@@ -41,7 +50,10 @@
             Then we should see the message "Passwords did not match"
             And we should see the message "Journal encrypted"
             And the config for journal "default" should have "encrypt" set to "bool:True"
-            When we run "jrnl -n 1" and enter "swordfish"
+            When we run "jrnl -n 1" and enter
+            """
+            swordfish
+            """
             Then the output should contain "Password"
             And the output should contain "2013-06-10 15:40 Life is good"
 

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -126,7 +126,7 @@ def run_with_input(context, command, inputs=""):
     if context.text:
         text = iter(context.text.split("\n"))
     else:
-        text = iter([inputs])
+        text = iter(inputs.split(" "))
 
     args = ushlex(command)[1:]
 


### PR DESCRIPTION
Refactor enabling behave to properly handle multiple successive inputs.

Previously a test with successive prompts wouldn't correctly iterate over the mock inputs, treating them as a single input.  Single letter inputs are correctly parsed and iterated over. See tests in #796

Refactored some existing tests to be correctly handled as text.

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
