### PR TITLE
Update changelog in prep for auto changelog generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,127 @@
-Changelog
-=========
+# Changelog
 
-## 2.0
+## Unreleased
 
-* Cryptographic backend changed from PyCrypto to cryptography.io
-* Config now respects XDG conventions and may move accordingly
-* Config now saved as YAML
-* Config name changed from `journals.jrnl_name.journal` to `journals.jrnl_name.path`
+[Full Changelog](https://github.com/jrnl-org/jrnl/compare/v2.1.1...HEAD)
 
-### 1.9 (July 21, 2014)
+**Implemented enhancements:**
+
+- Full text search \(case insensitive\) with "-contains" [\#740](https://github.com/jrnl-org/jrnl/pull/740) ([empireshades](https://github.com/empireshades))
+- Reduce startup time by 55% [\#719](https://github.com/jrnl-org/jrnl/pull/719) ([maebert](https://github.com/maebert))
+- Refactor password logic to prevent accidental password leakage [\#708](https://github.com/jrnl-org/jrnl/pull/708) ([pspeter](https://github.com/pspeter))
+- Password confirmation [\#706](https://github.com/jrnl-org/jrnl/pull/706) ([pspeter](https://github.com/pspeter))
+
+**Build:**
+
+- Update Black version and lock file to fix builds on develop branch [\#784](https://github.com/jrnl-org/jrnl/pull/784) ([wren](https://github.com/wren))
+- Run black formatter on codebase for standardization [\#778](https://github.com/jrnl-org/jrnl/pull/778) ([wren](https://github.com/wren))
+- Skip Broken Windows Tests [\#772](https://github.com/jrnl-org/jrnl/pull/772) ([wren](https://github.com/wren))
+- Black Formatter [\#769](https://github.com/jrnl-org/jrnl/pull/769) ([MinchinWeb](https://github.com/MinchinWeb))
+- Update lock file and testing suite for Python 3.8 [\#765](https://github.com/jrnl-org/jrnl/pull/765) ([wren](https://github.com/wren))
+- Fix CI config to only deploy once [\#761](https://github.com/jrnl-org/jrnl/pull/761) ([wren](https://github.com/wren))
+- More Travis-CI Testing [\#759](https://github.com/jrnl-org/jrnl/pull/759) ([MinchinWeb](https://github.com/MinchinWeb))
+
+**Updated documentation:**
+
+- Remove merge marker in recipes.md [\#782](https://github.com/jrnl-org/jrnl/pull/782) ([markphelps](https://github.com/markphelps))
+- Fix merge conflict left-over [\#767](https://github.com/jrnl-org/jrnl/pull/767) ([thejspr](https://github.com/thejspr))
+- Display header in docs on mobile devices [\#763](https://github.com/jrnl-org/jrnl/pull/763) ([maebert](https://github.com/maebert))
+
+## [v2.1.1](https://pypi.org/project/jrnl/v2.1.1/) (2019-11-26)
+
+[Full Changelog](https://github.com/jrnl-org/jrnl/compare/v2.1.1-beta...v2.1.1)
+
+**Implemented enhancements:**
+
+- Support Python 3.6+ [\#710](https://github.com/jrnl-org/jrnl/pull/710) ([pspeter](https://github.com/pspeter))
+- Drop Python 2 support, add mocks in tests [\#705](https://github.com/jrnl-org/jrnl/pull/705) ([pspeter](https://github.com/pspeter))
+
+**Fixed bugs:**
+
+- Prevent readline usage on Windows, which was causing Active Python crashes on install [\#751](https://github.com/jrnl-org/jrnl/pull/751) ([micahellison](https://github.com/micahellison))
+- Exit jrnl if no text entered into editor [\#744](https://github.com/jrnl-org/jrnl/pull/744) ([alichtman](https://github.com/alichtman))
+- Fix crash when no keyring backend available [\#699](https://github.com/jrnl-org/jrnl/pull/699) ([pspeter](https://github.com/pspeter))
+- Fix parsing Journals using a little-endian date format [\#694](https://github.com/jrnl-org/jrnl/pull/694) ([pspeter](https://github.com/pspeter))
+
+**Updated documentation:**
+
+- Update developer documentation [\#752](https://github.com/jrnl-org/jrnl/pull/752) ([micahellison](https://github.com/micahellison))
+- Create templates for issues and pull requests [\#679](https://github.com/jrnl-org/jrnl/pull/679) ([C0DK](https://github.com/C0DK))
+- Smaller doc fixes [\#649](https://github.com/jrnl-org/jrnl/pull/649) ([maebert](https://github.com/maebert))
+- Move to mkdocs [\#611](https://github.com/jrnl-org/jrnl/pull/611) ([maebert](https://github.com/maebert))
+
+## [v2.1.post2](https://pypi.org/project/jrnl/v2.1.post2/) (2019-11-11)
+
+[Full Changelog](https://github.com/jrnl-org/jrnl/compare/v2.1-beta6...v2.1.post2)
+
+**Fixed bugs:**
+
+- Expand paths that use ~ to full path [\#704](https://github.com/jrnl-org/jrnl/pull/704) ([MinchinWeb](https://github.com/MinchinWeb))
+
+**Build:**
+
+- Separate local dev from pipeline releases [\#684](https://github.com/jrnl-org/jrnl/pull/684) ([wren](https://github.com/wren))
+- Update version handling in source and travis deployments [\#683](https://github.com/jrnl-org/jrnl/pull/683) ([wren](https://github.com/wren))
+- Use Poetry for dependency management and deployments [\#612](https://github.com/jrnl-org/jrnl/pull/612) ([maebert](https://github.com/maebert))
+
+**Updated documentation:**
+
+- Fix typos, spelling [\#734](https://github.com/jrnl-org/jrnl/pull/734) ([MinchinWeb](https://github.com/MinchinWeb))
+
+## [v2.0.1](https://pypi.org/project/jrnl/v2.0.1/) (2019-09-26)
+
+[Full Changelog](https://github.com/jrnl-org/jrnl/compare/v2.0.1-beta...v2.0.1)
+
+**Implemented enhancements:**
+
+- Switch to hashmark Markdown headers on export \(Mk II\) [\#639](https://github.com/jrnl-org/jrnl/pull/639) ([MinchinWeb](https://github.com/MinchinWeb))
+- Add '-not' flag for excluding tags from filter [\#637](https://github.com/jrnl-org/jrnl/pull/637) ([jprof](https://github.com/jprof))
+- Handle KeyboardInterrupt when installing journal [\#550](https://github.com/jrnl-org/jrnl/pull/550) ([silenc3r](https://github.com/silenc3r))
+
+**Fixed bugs:**
+
+- Change pyYAML required version [\#660](https://github.com/jrnl-org/jrnl/pull/660) ([etnnth](https://github.com/etnnth))
+
+**Updated documentation:**
+
+- Fix references to Sphinx in CONTRIBUTING.md [\#655](https://github.com/jrnl-org/jrnl/pull/655) ([maebert](https://github.com/maebert))
+
+## [v2.0.0](https://pypi.org/project/jrnl/v2.0.0/) (2019-08-24)
+
+[Full Changelog](https://github.com/jrnl-org/jrnl/compare/v2.0-rc4...v2.0.0)
+
+**Implemented enhancements:**
+- Change cryptographic backend from PyCrypto to cryptography.io
+- Config now respects XDG conventions and may move accordingly
+- Config name changed from `journals.jrnl_name.journal` to `journals.jrnl_name.path`
+
+**Fixed bugs:**
+
+- Confirm that each journal can be parsed during upgrade, and abort upgrade if not [\#650](https://github.com/jrnl-org/jrnl/pull/650) ([micahellison](https://github.com/micahellison))
+- Escape dates in square brackets [\#644](https://github.com/jrnl-org/jrnl/pull/644) ([wren](https://github.com/wren))
+- Create encrypted journal [\#641](https://github.com/jrnl-org/jrnl/pull/641) ([gregorybodnar](https://github.com/gregorybodnar))
+- Resolve issues around unreadable dates to allow markdown footnotes and prevent accidental deletion [\#623](https://github.com/jrnl-org/jrnl/pull/623) ([micahellison](https://github.com/micahellison))
+- Update crypto module \#610 [\#621](https://github.com/jrnl-org/jrnl/pull/621) ([wren](https://github.com/wren))
+- Fix issue \#584 YAMLLoadWarning [\#585](https://github.com/jrnl-org/jrnl/pull/585) ([wren](https://github.com/wren))
+
+**Deprecated:**
+
+- Deprecate Python 2 [\#624](https://github.com/jrnl-org/jrnl/pull/624) ([micahellison](https://github.com/micahellison))
+- Config now saved as YAML (no more JSON)
+
+**Build:**
+
+- change pinned label to a super cool emoji ⭐️ [\#646](https://github.com/jrnl-org/jrnl/pull/646) ([wren](https://github.com/wren))
+- Update Travis build badge and restore pypi badges [\#603](https://github.com/jrnl-org/jrnl/pull/603) ([micahellison](https://github.com/micahellison))
+
+**Updated documentation:**
+
+- Mention lack of Day One support and relevant history in readme [\#608](https://github.com/jrnl-org/jrnl/pull/608) ([micahellison](https://github.com/micahellison))
+- Add a code of conduct file \(rather than adding to contributing\) [\#604](https://github.com/jrnl-org/jrnl/pull/604) ([wren](https://github.com/wren))
+- Update docs to reflect merging jrnl-plus fork back upstream [\#601](https://github.com/jrnl-org/jrnl/pull/601) ([micahellison](https://github.com/micahellison))
+- Add instructions for VS Code [\#544](https://github.com/jrnl-org/jrnl/pull/544) ([emceeaich](https://github.com/emceeaich))
+
+## v1.9 (2014-07-21)
 
 * __1.9.5__ Multi-word tags for DayOne Journals
 * __1.9.4__ Fixed: Order of journal entries in file correct after --edit'ing
@@ -17,7 +130,7 @@ Changelog
 * __1.9.1__ Fixed: Dates in the future can be parsed as well.
 * __1.9.0__ Improved: Greatly improved date parsing. Also added an `-on` option for filtering
 
-### 1.8 (May 22, 2014)
+## v1.8 (2014-05-22)
 
 * __1.8.7__ Fixed: -from and -to filters are inclusive (thanks to @grplyler)
 * __1.8.6__ Improved: Tags like @C++ and @OS/2 work, too (thanks to @chaitan94)
@@ -28,7 +141,7 @@ Changelog
 * __1.8.1__ Minor bug fixes
 * __1.8.0__ Official support for python 3.4
 
-### 1.7 (December 22, 2013)
+## v1.7 (2013-12-22)
 
 * __1.7.22__ Fixed an issue with writing files when exporting entries containing non-ascii characters.
 * __1.7.21__ jrnl now uses PKCS#7 padding.
@@ -54,7 +167,7 @@ Changelog
 * __1.7.0__ Edit encrypted or DayOne journals with `jrnl --edit`.
 
 
-### 1.6 (November 5, 2013)
+## v1.6 (2013-11-05)
 
 * __1.6.6__ -v prints the current version, also better strings for windows users. Furthermore, jrnl/jrnl.py moved to jrnl/cli.py
 * __1.6.5__ Allows composing multi-line entries on the command line or importing files
@@ -64,7 +177,7 @@ Changelog
 * __1.6.1__ Attempts to fix broken config files automatically
 * __1.6.0__ Passwords are now saved in the key-chain. The `password` field in `.jrnl_config` is soft-deprecated.
 
-### 1.5 (August 6, 2013)
+## v1.5 (2013-08-06)
 
 * __1.5.7__ The `~` in journal config paths will now expand properly to e.g. `/Users/maebert`
 * __1.5.6__ Fixed: Fixed a bug where on OS X, the timezone could only be accessed on administrator accounts.
@@ -75,23 +188,23 @@ Changelog
 * __1.5.1__ Fixed: Fixed a bug introduced in 1.5.0 that caused the entire journal to be printed after composing an entry
 * __1.5.0__ Exporting, encrypting and displaying tags now takes your filter options into account. So you could export everything before May 2012: `jrnl -to 'may 2012' --export json`. Or encrypt all entries tagged with `@work` into a new journal: `jrnl @work --encrypt work_journal.txt`. Or display all tags of posts where Bob is also tagged: `jrnl @bob --tags`
 
-### 1.4 (July 22, 2013)
+## v1.4 (2013-07-22)
 
 * __1.4.2__ Fixed: Tagging works again
 * __1.4.0__ Unifies encryption between Python 2 and 3. If you have problems reading encrypted journals afterwards, first decrypt your journal with the __old__ jrnl version (install with `pip install jrnl==1.3.1`, then `jrnl --decrypt`), upgrade jrnl (`pip install jrnl --upgrade`) and encrypt it again (`jrnl --encrypt`).
 
-### 1.3 (July 17, 2013)
+## v1.3 (2013-07-17)
 
 * __1.3.2__ Everything that is not direct output of jrnl will be written stderr to improve integration
 * __1.3.0__ Export to multiple files
 * __1.3.0__ Feature to export to given output file
 
-### 1.2 (July 15, 2013)
+## v1.2 (2013-07-15)
 
 * __1.2.0__ Fixed: Timezone support for DayOne
 
 
-### 1.1 (June 9, 2013)
+## v1.1 (2013-06-09)
 
 * __1.1.1__ Fixed: Unicode and Python3 issues resolved.
 * __1.1.0__
@@ -99,7 +212,7 @@ Changelog
     * Nicer error message when there is a syntactical error in your config file.
     * Unicode support
 
-### 1.0 (March 4, 2013)
+## v1.0 (2013-03-04)
 
 * __1.0.5__ Backwards compatibility with `parsedatetime` 0.8.7
 * __1.0.4__
@@ -122,7 +235,7 @@ Changelog
     * Fixed: A bug where jrnl would not add entries without timestamp
     * Fixed: Support for parsedatetime 1.x
 
-### 0.3 (May 24, 2012)
+## v0.3 (2012-05-24)
 
 * __0.3.2__ Converts `\n` to new lines (if using directly on a command line, make sure to wrap your entry with quotes).
 * __0.3.1__
@@ -135,7 +248,7 @@ Changelog
     * Fixed: Bug where composed entry is lost when the journal file fails to load
     * Changed directory structure and install scripts (removing the necessity to make an alias from `jrnl` to `jrnl.py`)
 
-### 0.2 (April 16, 2012)
+## v0.2 (2012-04-16)
 
 * __0.2.4__
     * Fixed: Parsing of new lines in journal files and entries
@@ -153,7 +266,7 @@ Changelog
     * Encrypts using CBC
     * Fixed: `key` has been renamed to `password` in config to avoid confusion. (The key use to encrypt and decrypt a journal is the SHA256-hash of the password.)
 
-### 0.1 (April 13, 2012)
+## v0.1 (2012-04-13)
 
 
 * __0.1.1__
@@ -166,6 +279,7 @@ Changelog
     * Filtering by tags and dates
     * Fixed: Now using dedicated classes for Journals and entries
 
-### 0.0 (March 29, 2012)
+## v0.0 (2012-03-29)
 
 * __0.0.1__ Composing entries works. That's pretty much it.
+


### PR DESCRIPTION
Starts work on #724

Getting ready to implement the auto-changelog generator is easier if we
are caught up with the old changes. This was generated by running the
generator locally (with some manual tweaking of the results).

Huge shout out to @micahellison for going through and updating all of 
the PR titles to sound nice for the new changelog.