### PR TITLE
Explain how fish can be configured to exclude jrnl commands from history by default

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -56,10 +56,14 @@ setopt HIST_IGNORE_SPACE
 alias jrnl=" jrnl"
 ```
 
-The fish shell does not support automatically preventing logging like
-this. To prevent `jrnl` commands being logged by fish, you must make
-sure to type a space before every `jrnl` command you enter. To delete
-existing `jrnl` commands from fish’s history, run
+If you are using `fish` instead of `bash` or `zsh`, you can get the same behaviour by
+adding this to your `fish` configuration:
+
+``` sh
+abbr jrnl=" jrnl"
+```
+
+To delete existing `jrnl` commands from `fish`’s history, run
 `history delete --prefix 'jrnl '`.
 
 ## Manual decryption


### PR DESCRIPTION
This change only affects documentation. Previous text explained that it was not possible to automatically prevent `jrnl` commands from being recorder by the `fish` shell (other than manually adding a leading space). New text instructs how to achieve this automatically with an abbreviation in the configuration of the `fish` shell.