### PR TITLE
Fix typo in encryption docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@
 - Reduce startup time by 55% [\#719](https://github.com/jrnl-org/jrnl/pull/719) ([maebert](https://github.com/maebert))
 - Refactor password logic to prevent accidental password leakage [\#708](https://github.com/jrnl-org/jrnl/pull/708) ([pspeter](https://github.com/pspeter))
 - Password confirmation [\#706](https://github.com/jrnl-org/jrnl/pull/706) ([pspeter](https://github.com/pspeter))
+- Pretty print journal entries [\#692](https://github.com/jrnl-org/jrnl/pull/692) ([alichtman](https://github.com/alichtman))
 
 **Build:**
 
+- Change PyPI auth method in build pipeline [\#807](https://github.com/jrnl-org/jrnl/pull/807) ([wren](https://github.com/wren))
 - Automagically update the changelog you see before your very eyes! [\#806](https://github.com/jrnl-org/jrnl/pull/806) ([wren](https://github.com/wren))
 - Update Black version and lock file to fix builds on develop branch [\#784](https://github.com/jrnl-org/jrnl/pull/784) ([wren](https://github.com/wren))
 - Run black formatter on codebase for standardization [\#778](https://github.com/jrnl-org/jrnl/pull/778) ([wren](https://github.com/wren))

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -60,7 +60,7 @@ If you are using `fish` instead of `bash` or `zsh`, you can get the same behavio
 adding this to your `fish` configuration:
 
 ``` sh
-abbr jrnl=" jrnl"
+abbr jrnl " jrnl"
 ```
 
 To delete existing `jrnl` commands from `fish`’s history, run


### PR DESCRIPTION
The fish config line `abbr jrnl=" jrnl"` becomes `abbr jrnl " jrnl"`.