### PR TITLE
Fix all skipped tests on Travis Windows builds by preserving newlines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 
 git:
   depth: false
+  autocrlf: false
 
 before_install:
   - date

--- a/features/core.feature
+++ b/features/core.feature
@@ -20,6 +20,7 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl -n 1"
         Then the output should contain "2013-07-23 09:00 A cold and stormy day."
 
+    @skip_win
     Scenario: Writing an empty entry from the editor
         Given we use the config "editor.yaml"
         When we open the editor and enter ""

--- a/features/core.feature
+++ b/features/core.feature
@@ -20,7 +20,6 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl -n 1"
         Then the output should contain "2013-07-23 09:00 A cold and stormy day."
 
-    @skip_win
     Scenario: Writing an empty entry from the editor
         Given we use the config "editor.yaml"
         When we open the editor and enter ""

--- a/features/dayone_regressions.feature
+++ b/features/dayone_regressions.feature
@@ -24,7 +24,6 @@ Feature: Zapped Dayone bugs stay dead!
             | I'm feeling sore because I forgot to stretch.
             """
 
-    @skip_win
     Scenario: Opening an folder that's not a DayOne folder gives a nice error message
         Given we use the config "empty_folder.yaml"
         When we run "jrnl Herro"

--- a/features/encryption.feature
+++ b/features/encryption.feature
@@ -12,7 +12,6 @@
             Then we should see the message "Journal decrypted"
             And the journal should have 2 entries
 
-        @skip_win
         Scenario: Encrypting a journal
             Given we use the config "basic.yaml"
             When we run "jrnl --encrypt" and enter
@@ -27,7 +26,6 @@
             Then the output should contain "Password"
             And the output should contain "2013-06-10 15:40 Life is good"
 
-        @skip_win
         Scenario: Mistyping your password
             Given we use the config "basic.yaml"
             When we run "jrnl --encrypt" and enter
@@ -45,7 +43,6 @@
             Then the output should contain "Password"
             And the output should contain "2013-06-10 15:40 Life is good"
 
-        @skip_win
         Scenario: Storing a password in Keychain
             Given we use the config "multiple.yaml"
             When we run "jrnl simple --encrypt" and enter

--- a/features/upgrade.feature
+++ b/features/upgrade.feature
@@ -1,6 +1,5 @@
 Feature: Upgrading Journals from 1.x.x to 2.x.x
 
-    @skip_win
     Scenario: Upgrade and parse journals with square brackets
         Given we use the config "upgrade_from_195.json"
         When we run "jrnl -9" and enter "Y"
@@ -12,7 +11,6 @@ Feature: Upgrading Journals from 1.x.x to 2.x.x
             """
         Then the journal should have 2 entries
 
-    @skip_win
     Scenario: Upgrading a journal encrypted with jrnl 1.x
         Given we use the config "encrypted_old.json"
         When we run "jrnl -n 1" and enter
@@ -24,7 +22,6 @@ Feature: Upgrading Journals from 1.x.x to 2.x.x
         Then the output should contain "Password"
         and the output should contain "2013-06-10 15:40 Life is good"
 
-    @skip_win
     Scenario: Upgrade and parse journals with little endian date format
         Given we use the config "upgrade_from_195_little_endian_dates.json"
         When we run "jrnl -9" and enter "Y"


### PR DESCRIPTION
We've been having trouble with Windows tests on Travis for a while, but I noticed some of them were passing on my local Windows machine today. Turns out I had the dreaded [autocrlf setting](https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings) set to false on my machine, whereas it defaults to true on Travis.

This PR tells Travis to keep the setting false, which prevents it from changing newlines when it checks out files. It also removes all the `skip_win` directives that were used to skip tests that were failing on Windows due to this issue.

### Checklist
- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your core changes, as applicable?
