### PR TITLE
[WIP] [Travis] manually upgrade virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ git:
 
 before_install:
   - date
+  - pip install --upgrade virtualenv
 
 install:
   - pip install poetry~=0.12.17


### PR DESCRIPTION
This is a test...

to fix issues with dev version of Python 3.9, try to manually upgrade virturalenv from the get-go.

See #793 
