### PR TITLE
Fix crashing unicode Travis tests on Windows and fail build if Windows tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ jobs:
   fast_finish: true
   allow_failures:
     - python: nightly
-    - os: windows
 
   include:
     - name: Lint, via Black
@@ -74,6 +73,7 @@ jobs:
       env:
         - JRNL_PYTHON_VERSION=3.6.8
         - PATH=/c/Python36:/c/Python36/Scripts:$PATH
+        - PYTHONIOENCODING=UTF-8
 
     # Python 3.7 Tests
     - name: Python 3.7 on Linux
@@ -89,6 +89,7 @@ jobs:
       env:
         - JRNL_PYTHON_VERSION=3.7.5
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+        - PYTHONIOENCODING=UTF-8
 
     # Python 3.8 Tests
     - name: Python 3.8 on Linux
@@ -104,6 +105,7 @@ jobs:
       env:
         - JRNL_PYTHON_VERSION=3.8.0
         - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - PYTHONIOENCODING=UTF-8
 
     # ... and beyond!
     - name: Python nightly on Linux


### PR DESCRIPTION
In Travis Windows machines, if any unicode is displayed in the console, the program crashes with the following error:
```
Exception UnicodeEncodeError: 'charmap' codec can't encode characters in position 6-69: character maps to <undefined>
```
Tests from PR #824 have verbose definitions for pretty print, which is full of interesting unicode characters. Unfortunately, not even the @skip_win directive can bypass this problem.

This can be reproduced on a local Windows machine by piping the output to a file, like so:
```
poetry run behave > testoutput.txt
```
The solution is to set the PYTHONIOENCODING variable to UTF-8 as documented [here](https://travis-ci.community/t/unicode-on-windows/3109/2).

Now that these tests and all others are (hopefully) working in Windows, this PR also will fail the whole build if Windows tests fail.

### Checklist
- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your core changes, as applicable?
