### PR TITLE
Restore emoji test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ jobs:
   fast_finish: true
   allow_failures:
     - python: nightly
-    - os: windows
 
   include:
     - name: Lint, via Black
@@ -74,6 +73,7 @@ jobs:
       env:
         - JRNL_PYTHON_VERSION=3.6.8
         - PATH=/c/Python36:/c/Python36/Scripts:$PATH
+        - PYTHONIOENCODING=UTF-8
 
     # Python 3.7 Tests
     - name: Python 3.7 on Linux
@@ -89,6 +89,7 @@ jobs:
       env:
         - JRNL_PYTHON_VERSION=3.7.5
         - PATH=/c/Python37:/c/Python37/Scripts:$PATH
+        - PYTHONIOENCODING=UTF-8
 
     # Python 3.8 Tests
     - name: Python 3.8 on Linux
@@ -104,6 +105,7 @@ jobs:
       env:
         - JRNL_PYTHON_VERSION=3.8.0
         - PATH=/c/Python38:/c/Python38/Scripts:$PATH
+        - PYTHONIOENCODING=UTF-8
 
     # ... and beyond!
     - name: Python nightly on Linux

--- a/features/core.feature
+++ b/features/core.feature
@@ -41,6 +41,14 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl -on 'june 6 2013' --short"
         Then the output should be "2013-06-10 15:40 Life is good."
 
+    Scenario: Emoji support
+        Given we use the config "basic.yaml"
+        When we run "jrnl 23 july 2013: 🌞 sunny day. Saw an 🐘"
+        Then we should see the message "Entry added"
+        When we run "jrnl -n 1"
+        Then the output should contain "🌞"
+        and the output should contain "🐘"
+
     Scenario: Writing an entry at the prompt
         Given we use the config "basic.yaml"
         When we run "jrnl" and enter "25 jul 2013: I saw Elvis. He's alive."


### PR DESCRIPTION
This emoji test was removed a while back to allow Travis Windows builds to run. They were crashing before on this test, but eventually I found that it was just a problem with piping unicode and fixed it in PR #836.

# Checklist
- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your core changes, as applicable?
