### PR TITLE
Put back build lines in Poetry config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,7 @@ black = {version = "^19.10b0",allow-prereleases = true}
 [tool.poetry.scripts]
 jrnl = 'jrnl.cli:run'
 
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"
+


### PR DESCRIPTION
Taking out these lines earlier fixed the homebrew release, but broke
other things. So, I'm putting them back for now until we can find a
better solution.