### PR TITLE
Don't re-run tests on deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,8 @@ jobs:
         - poetry version "$TRAVIS_TAG"
         - echo __version__ = \"$TRAVIS_TAG\" > jrnl/__version__.py
         - poetry build
+      script:
+        - echo "Deployment starting..."
       deploy:
         - provider: script
           script: poetry publish


### PR DESCRIPTION
By the time we get to the deployment step, we've already run these tests
dozens of times. We don't need to run them yet again at deploy time.