### PR TITLE
Update old links

### DIFF
--- a/docs/theme/index.html
+++ b/docs/theme/index.html
@@ -34,7 +34,7 @@
         "operatingSystem": ["macOS", "Windows", "Linux"],
         "thumbnailUrl": "https://jrnl.sh/img/banner_og.png",
         "installUrl": "https://jrnl.sh/installation",
-        "softwareVersion": "2.0.0rc2"
+        "softwareVersion": "2.2"
     }
     </script>
 </head>
@@ -42,7 +42,7 @@
 <body>
     <header>
         <aside>
-            <a id="twitter" href="https://twitter.com/intent/tweet?text=Write+your+memoirs+on+the+command+line.+Like+a+boss.+%23jrnl&url=http%3A%2F%2Fjrnl.sh&via=maebert"><i class="icon twitter"></i>Tell your friends</a>
+            <a id="twitter" href="https://twitter.com/intent/tweet?text=Write+your+memoirs+on+the+command+line.+Like+a+boss.+%23jrnl&url=http%3A%2F%2Fjrnl.sh"><i class="icon twitter"></i>Tell your friends</a>
         </aside>
         <div id="title">
             <img id="logo" src="img/jrnl_white.svg" width="90px" height="98px" title="jrnl" />
@@ -58,7 +58,7 @@
         <nav>
             <a href="overview">Documentation</a>
             <a href="http://github.com/jrnl-org/jrnl" title="View on Github">Fork me on GitHub</a>
-            <a id="twitter-nav" href="https://twitter.com/intent/tweet?text=Write+your+memoirs+on+the+command+line.+Like+a+boss.+%23jrnl&url=http%3A%2F%2Fjrnl.sh&via=maebert">Tell your friends on twitter</a>
+            <a id="twitter-nav" href="https://twitter.com/intent/tweet?text=Write+your+memoirs+on+the+command+line.+Like+a+boss.+%23jrnl&url=http%3A%2F%2Fjrnl.sh">Tell your friends on twitter</a>
             <a href="installation" class="cta">Download</a>
         </nav>
         <div class="flex">

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -1,7 +1,7 @@
 Feature: Zapped bugs should stay dead.
 
     Scenario: Writing an entry does not print the entire journal
-        # https://github.com/maebert/jrnl/issues/87
+        # https://github.com/jrnl-org/jrnl/issues/87
         Given we use the config "basic.yaml"
         When we run "jrnl 23 july 2013: A cold and stormy day. I ate crisps on the sofa."
         Then we should see the message "Entry added"
@@ -9,14 +9,14 @@ Feature: Zapped bugs should stay dead.
         Then the output should not contain "Life is good"
 
     Scenario: Date with time should be parsed correctly
-        # https://github.com/maebert/jrnl/issues/117
+        # https://github.com/jrnl-org/jrnl/issues/117
         Given we use the config "basic.yaml"
         When we run "jrnl 2013-11-30 15:42: Project Started."
         Then we should see the message "Entry added"
         and the journal should contain "[2013-11-30 15:42] Project Started."
 
     Scenario: Loading entry with ambiguous time stamp
-        #https://github.com/maebert/jrnl/issues/153
+        #https://github.com/jrnl-org/jrnl/issues/153
         Given we use the config "bug153.yaml"
         When we run "jrnl -1"
         Then we should get no error
@@ -26,7 +26,7 @@ Feature: Zapped bugs should stay dead.
             """
 
     Scenario: Date in the future should be parsed correctly
-        # https://github.com/maebert/jrnl/issues/185
+        # https://github.com/jrnl-org/jrnl/issues/185
         Given we use the config "basic.yaml"
         When we run "jrnl 26/06/2019: Planet? Earth. Year? 2019."
         Then we should see the message "Entry added"


### PR DESCRIPTION
Since we moved the core repo to jrnl-org, the old links no longer work.