### PR TITLE
Fix configuration slashes and indentation in advanced usage documentation

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -63,8 +63,8 @@ for example:
 
 ``` yaml
 journals:
-  default: ~\journal.txt
-  work: ~\work.txt
+  default: ~/journal.txt
+  work: ~/work.txt
 ```
 
 The `default` journal gets created the first time you start `jrnl`
@@ -85,11 +85,11 @@ If your `jrnl.yaml` looks like this:
 ``` yaml
 encrypt: false
 journals:
-default: ~/journal.txt
-work:
-  journal: ~/work.txt
-  encrypt: true
-food: ~/my_recipes.txt
+  default: ~/journal.txt
+  work:
+    journal: ~/work.txt
+    encrypt: true
+  food: ~/my_recipes.txt
 ```
 
 Your `default` and your `food` journals won't be encrypted, however your


### PR DESCRIPTION
# **Update Advanced Usage documentation**
**Changes**
1. Update `\` to `/` from the first code snippet from _Multiple journal files_ section.

    I had copy and pasted this into my `~/.config/jrnl/jrnl.yaml` and found that journal files were created in my current working directory as `~\work.txt` and `~\journal.txt`.

    <img width="559" alt="Screenshot 2020-02-16 10 41 37" src="https://user-images.githubusercontent.com/3106250/74607709-f1391800-50a8-11ea-9ec2-2a00bbdb90d5.png">

    Manual test
    ``` bash
    # Confirm the issue from current version of docs
    cd /tmp
    cat << HERE > ~/.config/jrnl/jrnl.yaml
    journals:
      default: ~\test-journal.txt
      work: ~\test-work.txt
    HERE
    ls *.txt

    jrnl at 3:30pm: Test default journal
    jrnl work at 4:30pm: Test work journal
    ls *.txt
    echo '*.txt files should exist in your current directory (which confirms the issue!)'
    rm -f *.txt

    # Confirm the doc changes work as intended
    rm -f ~/test-journal.txt ~/test-work.txt

    cat << HERE > ~/.config/jrnl/jrnl.yaml
    journals:
      default: ~/test-journal.txt
      work: ~/test-work.txt
    HERE

    jrnl at 3:30pm: Test default journal
    jrnl work at 4:30pm: Test work journal

    ls *.txt
    echo 'No *.txt should exist in your current directory'
    ```

2. Indent code snippet from _override defaults per journal_ example from _Multiple journal files_ section.

    Taking the snippet as-is, I got `TypeError: argument of type 'NoneType' is not iterable` errors. However; updating the YAML to have an indents resolved the issue.

    <img width="802" alt="Screenshot 2020-02-16 10 44 24" src="https://user-images.githubusercontent.com/3106250/74607778-a9ff5700-50a9-11ea-8527-262281b13c8e.png">

    Manual test
    ``` bash
    # Confirm the issue from current version of docs
    cd /tmp
    cat << HERE > ~/.config/jrnl/jrnl.yaml
    journals:
    default: ~/test-journal.txt
    work:
      journal: ~/test-work.txt
      encrypt: true
    food: ~/test-food.txt
    HERE

    # Errors will to occur when trying to write journal entries
    jrnl at 3:30pm: Test default journal
    jrnl work at 4:30pm: Test work journal
    jrnl food at 5:30pm: Test food journal

    jrnl -n 1
    jrnl work -n 1
    jrnl food -n 1


    # Confirm the doc changes work as intended
    cat << HERE > ~/.config/jrnl/jrnl.yaml
    journals:
      default: ~/test-journal.txt
      work:
        journal: ~/test-work.txt
        encrypt: true
      food: ~/test-food.txt
    HERE

    jrnl at 3:30pm: Test default journal
    jrnl work at 4:30pm: Test work journal
    jrnl food at 5:30pm: Test food journal

    jrnl -n 1
    jrnl work -n 1
    jrnl food -n 1
    ```

### Documentation Before Changes
<img width="640" alt="Screenshot 2020-02-16 10 32 12" src="https://user-images.githubusercontent.com/3106250/74608158-d5d00c00-50ac-11ea-9c9a-b0c6ff359662.png">

### Documentation After Changes
<img width="574" alt="Screenshot 2020-02-16 10 33 14" src="https://user-images.githubusercontent.com/3106250/74608163-e3859180-50ac-11ea-92f1-d6d08ecaaf9e.png">

My **motivation** for these changes are to improve the advanced usage documentation.

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
