### PR TITLE
Update travis caching to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ os: linux
 language: python
 
 cache:
-  - pip
+  pip: true
+  directories:
+    - $HOME/virtualenv
 
 git:
   depth: false
@@ -28,6 +30,7 @@ aliases:
     cache:
       directories:
         - $HOME/.pyenv/versions
+        - $HOME/Library/Caches/pypoetry
     before_install:
       - eval "$(pyenv init -)"
       - pyenv install -s $JRNL_PYTHON_VERSION
@@ -37,11 +40,17 @@ aliases:
   test_windows: &test_windows
     os: windows
     language: shell
+    env: &env_windows
+      PATH: /c/Python36:/c/Python36/Scripts:/c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:$PATH
+      PYTHONIOENCODING: UTF-8
     cache:
       directories:
         - /c/Python36
         - /c/Python37
         - /c/Python38
+        - /c/ProgramData/chocolatey/lib
+        - /c/ProgramData/chocolatey/bin
+        - /c/Users/travis/AppData/Local/pypoetry/Cache
     before_install:
       - choco install python --version $JRNL_PYTHON_VERSION
       - python -m pip install --upgrade pip
@@ -66,14 +75,13 @@ jobs:
       name: Python 3.6 on MacOS
       python: 3.6
       env:
-        - JRNL_PYTHON_VERSION=3.6.8
+        JRNL_PYTHON_VERSION: 3.6.8
     - <<: *test_windows
       name: Python 3.6 on Windows
       python: 3.6
       env:
-        - JRNL_PYTHON_VERSION=3.6.8
-        - PATH=/c/Python36:/c/Python36/Scripts:$PATH
-        - PYTHONIOENCODING=UTF-8
+        <<: *env_windows
+        JRNL_PYTHON_VERSION: 3.6.8
 
     # Python 3.7 Tests
     - name: Python 3.7 on Linux
@@ -82,14 +90,13 @@ jobs:
       name: Python 3.7 on MacOS
       python: 3.7
       env:
-        - JRNL_PYTHON_VERSION=3.7.5
+        JRNL_PYTHON_VERSION: 3.7.5
     - <<: *test_windows
       name: Python 3.7 on Windows
       python: 3.7
       env:
-        - JRNL_PYTHON_VERSION=3.7.5
-        - PATH=/c/Python37:/c/Python37/Scripts:$PATH
-        - PYTHONIOENCODING=UTF-8
+        <<: *env_windows
+        JRNL_PYTHON_VERSION: 3.7.5
 
     # Python 3.8 Tests
     - name: Python 3.8 on Linux
@@ -98,14 +105,13 @@ jobs:
       name: Python 3.8 on MacOS
       python: 3.8
       env:
-        - JRNL_PYTHON_VERSION=3.8.0
+        JRNL_PYTHON_VERSION: 3.8.0
     - <<: *test_windows
       name: Python 3.8 on Windows
       python: 3.8
       env:
-        - JRNL_PYTHON_VERSION=3.8.0
-        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
-        - PYTHONIOENCODING=UTF-8
+        <<: *env_windows
+        JRNL_PYTHON_VERSION: 3.8.0
 
     # ... and beyond!
     - name: Python nightly on Linux
@@ -115,7 +121,7 @@ jobs:
     - name: Python 3.7 on Linux, not UTC
       python: 3.7
       env:
-        - TZ=America/Edmonton
+        TZ: America/Edmonton
 
     # Changelog for Unreleased changes
     - stage: Update Changelog


### PR DESCRIPTION
Linux and Mac are both under 60s each, and Windows is under 1m 30s