### PR TITLE
Update Poetry requirements for testing latest Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,6 +115,8 @@ jobs:
 
     # ... and beyond!
     - name: Python nightly on Linux
+      before_install:
+        - sed -i 's/^python = ">=3\.6\.0.*"$/python = "*"/' pyproject.toml
       python: nightly
 
     # Specialty tests


### PR DESCRIPTION
Fixes #870

Poetry errors out if we try to run a different version of Python that
what is specified in the config file. We want to run tests against the
latest Python version so we can see problems before they happen. This
fix updates the config file so Poetry will allow us to test. Nothing is
committed after the update.

### Checklist
- [ ] The code change is tested and works locally.
- [ ] Tests pass. Your PR cannot be merged unless tests pass
- [ ] There is no commented out code in this PR.
- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?