### PR TITLE
Fix regression for displaying entries during a tag search

### DIFF
--- a/features/tagging.feature
+++ b/features/tagging.feature
@@ -98,3 +98,13 @@ Feature: Tagging
             | @hi. Hello
             | hi Hello
             """
+
+    Scenario: Searching a journal for tags should display entries with that tag.
+        Given we use the config "tags.yaml"
+        When we run "jrnl @dan"
+        Then the output should be
+            """
+            2013-06-10 15:40 I met with @dan.
+            | As alway's he shared his latest @idea on how to rule the world with me.
+            | inst
+            """

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -228,7 +228,7 @@ def highlight_tags_with_background_color(entry, text, color, is_title=False):
             text_fragments = []
             for tag in entry.journal.search_tags:
                 text_fragments.extend(
-                    re.split(re.compile(re.escape(tag), re.IGNORECASE), text)
+                    re.split(re.compile(f"({re.escape(tag)})", re.IGNORECASE), text)
                 )
         else:
             text_fragments = re.split(entry.tag_regex(config["tagsymbols"]), text)


### PR DESCRIPTION
Fixes #901 where if you do a tag search, jrnl doesn't include the tag itself in the search results. Added a test to catch this issue.

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
