### PR TITLE
Change install doc guideline from pip to pipx

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,16 +3,16 @@
 ## Installation
 
 On OS X, the easiest way to install *jrnl* is using
-[Homebrew](http://brew.sh/)
+[Homebrew](http://brew.sh/):
 
 ``` sh
 brew install jrnl
 ```
 
-On other platforms, install *jrnl* using pip
+On other platforms, install *jrnl* using [Python](https://www.python.org/) 3.6+ and [pipx](https://pipxproject.github.io/pipx/):
 
 ``` sh
-pip install jrnl
+pipx install jrnl
 ```
 
 The first time you run `jrnl` you will be asked where your journal file


### PR DESCRIPTION
Fixes #903.

As I was working on this, I also realized it doesn't even mention that Python is required to run jrnl. I added that in as well, along with the minimum version number. 

### Checklist
- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [n/a] Have you written new tests for your core changes, as applicable?
