### PR TITLE
Ensure exported entries end in a newline for Markdown and YAML exporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,8 +49,6 @@ venv*/
 
 # export testing directories
 exp/
-bug768/
-exported_journal/
 
 _extras/
 *.sublime-*

--- a/.gitignore
+++ b/.gitignore
@@ -42,12 +42,15 @@ obj
 # virtaulenv
 env/
 env*/
+venv*/
 
 # PyCharm Project files
 .idea/
 
-# export testing director
+# export testing directories
 exp/
+bug768/
+exported_journal/
 
 _extras/
 *.sublime-*

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -155,7 +155,7 @@ Feature: Zapped bugs should stay dead.
         """
         title: Third entry.
         date: 2019-10-29 11:13
-        stared: False
+        starred: False
         tags:
 
         """

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -122,3 +122,40 @@ Feature: Zapped bugs should stay dead.
         Then the output should contain "This thing happened yesterday"
         Then the output should contain "Adding an entry right now."
         Then the output should not contain "A future entry."
+
+    # See issues #768 and #881
+    # the "deletion" journal is used because it doesn't have a newline at the
+    # end of the last entry
+    Scenario: Add a blank line to Markdown export is there isn't one already
+        Given we use the config "deletion.yaml"
+        When we run "jrnl --export markdown"
+        Then the output should be
+        """
+        # 2019
+
+        ## October
+
+        ### 2019-10-29 11:11 First entry.
+
+
+        ### 2019-10-29 11:11 Second entry.
+
+
+        ### 2019-10-29 11:13 Third entry.
+
+        """
+
+    # See issues #768 and #881
+    Scenario: Add a blank line to YAML export is there isn't one already
+        Given we use the config "deletion.yaml"
+        And we created a directory named "bug768"
+        When we run "jrnl --export yaml -o bug768"
+        Then "bug768" should contain the files ["2019-10-29_first-entry.md", "2019-10-29_second-entry.md", "2019-10-29_third-entry.md"]
+        And the content of exported yaml "bug768/2019-10-29_third-entry.md" should be
+        """
+        title: Third entry.
+        date: 2019-10-29 11:13
+        stared: False
+        tags:
+
+        """

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -96,6 +96,11 @@ def create_directory(context, dir_name):
 def assert_dir_contains_files(context, dir_name, expected_files_json_list):
     actual_files = os.listdir(dir_name)
     expected_files = json.loads(expected_files_json_list)
+
+    # sort to deal with inconsistent default file ordering on different OS's
+    actual_files.sort()
+    expected_files.sort()
+
     assert actual_files == expected_files, [actual_files, expected_files]
 
 

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -54,6 +54,10 @@ class MarkdownExporter(TextExporter):
             previous_line = line
         newbody = newbody + previous_line  # add very last line
 
+        # make sure the export ends with a blank line
+        if previous_line not in ['\r', '\n', '\r\n', '\n\r']:
+            newbody = newbody + os.linesep
+
         if warn_on_heading_level is True:
             print(
                 f"{WARNING_COLOR}WARNING{RESET_COLOR}: "

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -55,7 +55,7 @@ class MarkdownExporter(TextExporter):
         newbody = newbody + previous_line  # add very last line
 
         # make sure the export ends with a blank line
-        if previous_line not in ['\r', '\n', '\r\n', '\n\r']:
+        if previous_line not in ["\r", "\n", "\r\n", "\n\r"]:
             newbody = newbody + os.linesep
 
         if warn_on_heading_level is True:

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -67,7 +67,7 @@ class YAMLExporter(TextExporter):
         newbody = newbody + previous_line  # add very last line
 
         # make sure the export ends with a blank line
-        if previous_line not in ['\r', '\n', '\r\n', '\n\r']:
+        if previous_line not in ["\r", "\n", "\r\n", "\n\r"]:
             newbody = newbody + os.linesep
 
         if warn_on_heading_level is True:

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -66,6 +66,10 @@ class YAMLExporter(TextExporter):
             previous_line = line
         newbody = newbody + previous_line  # add very last line
 
+        # make sure the export ends with a blank line
+        if previous_line not in ['\r', '\n', '\r\n', '\n\r']:
+            newbody = newbody + os.linesep
+
         if warn_on_heading_level is True:
             print(
                 "{}WARNING{}: Headings increased past H6 on export - {} {}".format(


### PR DESCRIPTION
Fixes #768, Fixes #881.

If the exported entry does not have a final empty line, this will add one on export. Some Markdown parsers get picky about not having a empty line above a heading....

The newline added is `os.linesep`, so cross platform issues shouldn't arise.

Also includes tests.

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable? *Yup!*
