### PR TITLE
[Travis] update Windows Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+version: ~> 1.0
 dist: xenial   # required for Python >= 3.7
 os: linux
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-version: ~> 1.0
 dist: xenial   # required for Python >= 3.7
 os: linux
 language: python
@@ -49,12 +48,11 @@ aliases:
         - /c/Python36
         - /c/Python37
         - /c/Python38
-        - /c/Python39
         - /c/ProgramData/chocolatey/lib
         - /c/ProgramData/chocolatey/bin
         - /c/Users/travis/AppData/Local/pypoetry/Cache
     before_install:
-      - choco install python --version $JRNL_PYTHON_VERSION --pre
+      - choco install python --version $JRNL_PYTHON_VERSION
       - python -m pip install --upgrade pip
       - pip --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,14 @@ aliases:
     os: windows
     language: shell
     env: &env_windows
-      PATH: /c/Python36:/c/Python36/Scripts:/c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:$PATH
+      PATH: /c/Python36:/c/Python36/Scripts:/c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:/c/Python39:/c/Python39/Scripts:$PATH
       PYTHONIOENCODING: UTF-8
     cache:
       directories:
         - /c/Python36
         - /c/Python37
         - /c/Python38
+        - /c/Python39
         - /c/ProgramData/chocolatey/lib
         - /c/ProgramData/chocolatey/bin
         - /c/Users/travis/AppData/Local/pypoetry/Cache
@@ -60,6 +61,8 @@ jobs:
   fast_finish: true
   allow_failures:
     - python: nightly
+    - os: windows
+      env: JRNL_PYTHON_VERSION=3.9.0-a5
 
   include:
     - name: Lint, via Black
@@ -96,7 +99,7 @@ jobs:
       python: 3.7
       env:
         <<: *env_windows
-        JRNL_PYTHON_VERSION: 3.7.5
+        JRNL_PYTHON_VERSION: 3.7.7
 
     # Python 3.8 Tests
     - name: Python 3.8 on Linux
@@ -111,13 +114,19 @@ jobs:
       python: 3.8
       env:
         <<: *env_windows
-        JRNL_PYTHON_VERSION: 3.8.0
+        JRNL_PYTHON_VERSION: 3.8.2
 
     # ... and beyond!
     - name: Python nightly on Linux
       before_install:
         - sed -i 's/^python = ">=3\.6\.0.*"$/python = "*"/' pyproject.toml
       python: nightly
+    - <<: *test_windows
+      name: Python 3.9-alpha on Windows
+      python: 3.9
+      env:
+        <<: *env_windows
+        JRNL_PYTHON_VERSION: 3.9.0-a5
 
     # Specialty tests
     - name: Python 3.7 on Linux, not UTC

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ aliases:
     os: windows
     language: shell
     env: &env_windows
-      PATH: /c/Python36:/c/Python36/Scripts:/c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:/c/Python39:/c/Python39/Scripts:$PATH
+      PATH: /c/Python36:/c/Python36/Scripts:/c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:$PATH
       PYTHONIOENCODING: UTF-8
     cache:
       directories:
@@ -62,8 +62,6 @@ jobs:
   fast_finish: true
   allow_failures:
     - python: nightly
-    - os: windows
-      env: JRNL_PYTHON_VERSION=3.9.0-a5
 
   include:
     - name: Lint, via Black
@@ -122,12 +120,6 @@ jobs:
       before_install:
         - sed -i 's/^python = ">=3\.6\.0.*"$/python = "*"/' pyproject.toml
       python: nightly
-    - <<: *test_windows
-      name: Python 3.9-alpha on Windows
-      python: nightly
-      env:
-        <<: *env_windows
-        JRNL_PYTHON_VERSION: 3.9.0-a5
 
     # Specialty tests
     - name: Python 3.7 on Linux, not UTC

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ aliases:
         - /c/ProgramData/chocolatey/bin
         - /c/Users/travis/AppData/Local/pypoetry/Cache
     before_install:
-      - choco install python --version $JRNL_PYTHON_VERSION
+      - choco install python --version $JRNL_PYTHON_VERSION --pre
       - python -m pip install --upgrade pip
       - pip --version
 
@@ -62,6 +62,7 @@ jobs:
   fast_finish: true
   allow_failures:
     - python: nightly
+    - python: 3.9
     - os: windows
       env: JRNL_PYTHON_VERSION=3.9.0-a5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ jobs:
   fast_finish: true
   allow_failures:
     - python: nightly
-    - python: 3.9
     - os: windows
       env: JRNL_PYTHON_VERSION=3.9.0-a5
 
@@ -125,7 +124,7 @@ jobs:
       python: nightly
     - <<: *test_windows
       name: Python 3.9-alpha on Windows
-      python: 3.9
+      python: nightly
       env:
         <<: *env_windows
         JRNL_PYTHON_VERSION: 3.9.0-a5

--- a/.travis.yml
+++ b/.travis.yml
@@ -90,7 +90,7 @@ jobs:
       name: Python 3.7 on MacOS
       python: 3.7
       env:
-        JRNL_PYTHON_VERSION: 3.7.5
+        JRNL_PYTHON_VERSION: 3.7.7
     - <<: *test_windows
       name: Python 3.7 on Windows
       python: 3.7
@@ -105,7 +105,7 @@ jobs:
       name: Python 3.8 on MacOS
       python: 3.8
       env:
-        JRNL_PYTHON_VERSION: 3.8.0
+        JRNL_PYTHON_VERSION: 3.8.2
     - <<: *test_windows
       name: Python 3.8 on Windows
       python: 3.8


### PR DESCRIPTION
Updates Python 3.7.5 to 3.7.7 and 3.8.0 to 3.8.2.
~Also add the alpha 5 build of Python 3.9 as an allowable failure.~ Poetry doesn't support Python 3.9 yet. See https://github.com/python-poetry/poetry/issues/2154

### Checklist
- [ n/a ] The code change is tested and works locally.
- [ ? ] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
