### PR TITLE
[Travis] Lint via `isort`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,8 @@
 ### Checklist
 - [ ] The code change is tested and works locally.
 - [ ] Tests pass. Your PR cannot be merged unless tests pass
+- [ ] The code passes linting via
+  [isort](https://github.com/timothycrosley/isort) (import sorting) -- `isort`
 - [ ] There is no commented out code in this PR.
 - [ ] Have you followed the guidelines in our Contributing document?
 - [ ] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,11 @@ jobs:
       script:
         - black --version
         - black --check . --verbose --diff
+    - name: Lint, via Isort
+      python: 3.8
+      script:
+        - isort --version
+        - isort --check-only --diff
 
     # Python 3.6 Tests
     - name: Python 3.6 on Linux

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,5 +1,5 @@
-import shutil
 import os
+import shutil
 import sys
 
 

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -1,24 +1,24 @@
+import ast
+from codecs import decode, encode
+from collections import defaultdict
+import json
+import os
+import shlex
+import sys
+import time
 from unittest.mock import patch
 
-from behave import given, when, then
-from jrnl import cli, install, Journal, util, plugins
-from jrnl import __version__
-from collections import defaultdict
+from behave import given, then, when
+import keyring
+import tzlocal
+import yaml
+
+from jrnl import Journal, __version__, cli, install, plugins, util
 
 try:
     import parsedatetime.parsedatetime_consts as pdt
 except ImportError:
     import parsedatetime as pdt
-import time
-from codecs import encode, decode
-import os
-import ast
-import json
-import yaml
-import keyring
-import tzlocal
-import shlex
-import sys
 
 consts = pdt.Constants(usePyICU=False)
 consts.DOWParseStyle = -1  # Prefers past weekdays

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -3,7 +3,7 @@ import os
 import shutil
 from xml.etree import ElementTree
 
-from behave import then, given
+from behave import given, then
 
 
 @then("the output should be parsable as json")

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python
 
-from . import Entry
-from . import Journal
-from . import time as jrnl_time
-import os
-import re
 from datetime import datetime
-import time
 import fnmatch
+import os
 import plistlib
-import pytz
+import re
+import time
 import uuid
-import tzlocal
 from xml.parsers.expat import ExpatError
+
+import pytz
+import tzlocal
+
+from . import Entry, Journal
+from . import time as jrnl_time
 
 
 class DayOne(Journal.Journal):

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -1,17 +1,18 @@
-from . import util
-from .Journal import Journal, LegacyJournal
-from cryptography.fernet import Fernet, InvalidToken
-from cryptography.hazmat.primitives import hashes, padding
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-import hashlib
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from cryptography.hazmat.backends import default_backend
-import sys
-import os
 import base64
+import hashlib
 import logging
+import os
+import sys
 from typing import Optional
 
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+from . import util
+from .Journal import Journal, LegacyJournal
 
 log = logging.getLogger()
 

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
-import re
-import ansiwrap
 from datetime import datetime
-from .util import split_title, colorize, highlight_tags_with_background_color
+import re
+
+import ansiwrap
+
+from .util import colorize, highlight_tags_with_background_color, split_title
 
 
 class Entry:

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 from . import Entry
 from . import Journal
 import codecs

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from . import Entry
-from . import Journal
 import codecs
-import os
 import fnmatch
+import os
+
+from . import Entry, Journal
 
 
 def get_files(journal_config):

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
+from datetime import datetime
 import logging
 import os
-import sys
 import re
+import sys
 
-from datetime import datetime
-from jrnl import Entry, util, time
+from jrnl import Entry, time, util
 
 log = logging.getLogger(__name__)
 

--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from . import cli
 
-
 if __name__ == "__main__":
     cli.run()

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -6,17 +6,17 @@
     license: MIT, see LICENSE for more details.
 """
 
-from .Journal import PlainJournal, open_journal
-from .EncryptedJournal import EncryptedJournal
-from . import util
-from . import install
-from . import plugins
-from .util import ERROR_COLOR, RESET_COLOR, UserAbort
-import jrnl
 import argparse
-import sys
-import re
 import logging
+import re
+import sys
+
+import jrnl
+
+from . import install, plugins, util
+from .EncryptedJournal import EncryptedJournal
+from .Journal import PlainJournal, open_journal
+from .util import ERROR_COLOR, RESET_COLOR, UserAbort
 
 log = logging.getLogger(__name__)
 logging.getLogger("keyring.backend").setLevel(logging.ERROR)

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
 
-import glob
 import getpass
-import os
-import xdg.BaseDirectory
-from . import util
-from . import upgrade
-from . import __version__
-from .Journal import PlainJournal
-from .EncryptedJournal import EncryptedJournal
-from .util import UserAbort, verify_config
-import yaml
+import glob
 import logging
+import os
 import sys
+
+import xdg.BaseDirectory
+import yaml
+
+from . import __version__, upgrade, util
+from .EncryptedJournal import EncryptedJournal
+from .Journal import PlainJournal
+from .util import UserAbort, verify_config
 
 if "win32" not in sys.platform:
     # readline is not included in Windows Active Python

--- a/jrnl/plugins/__init__.py
+++ b/jrnl/plugins/__init__.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
+from .fancy_exporter import FancyExporter
 from .jrnl_importer import JRNLImporter
 from .json_exporter import JSONExporter
 from .markdown_exporter import MarkdownExporter
 from .tag_exporter import TagExporter
+from .template_exporter import __all__ as template_exporters
+from .text_exporter import TextExporter
 from .xml_exporter import XMLExporter
 from .yaml_exporter import YAMLExporter
-from .template_exporter import __all__ as template_exporters
-from .fancy_exporter import FancyExporter
 
 __exporters = [
     JSONExporter,

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals, print_function
 from .text_exporter import TextExporter
 from textwrap import TextWrapper
 

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
 from textwrap import TextWrapper
+
+from .text_exporter import TextExporter
 
 
 class FancyExporter(TextExporter):

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 import sys
+
 from .. import util
 
 

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
 import json
+
+from .text_exporter import TextExporter
 from .util import get_tags_count
 
 

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
 import os
 import re
 import sys
-from ..util import WARNING_COLOR, RESET_COLOR
+
+from ..util import RESET_COLOR, WARNING_COLOR
+from .text_exporter import TextExporter
 
 
 class MarkdownExporter(TextExporter):

--- a/jrnl/plugins/template.py
+++ b/jrnl/plugins/template.py
@@ -1,4 +1,5 @@
 import re
+
 import yaml
 
 VAR_RE = r"[_a-zA-Z][a-zA-Z0-9_]*"

--- a/jrnl/plugins/template_exporter.py
+++ b/jrnl/plugins/template_exporter.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
-from .template import Template
-import os
 from glob import glob
+import os
+
+from .template import Template
+from .text_exporter import TextExporter
 
 
 class GenericTemplateExporter(TextExporter):

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from ..util import slugify
 import os
-from ..util import ERROR_COLOR, RESET_COLOR
+
+from ..util import ERROR_COLOR, RESET_COLOR, slugify
 
 
 class TextExporter:

--- a/jrnl/plugins/xml_exporter.py
+++ b/jrnl/plugins/xml_exporter.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+from xml.dom import minidom
+
 from .json_exporter import JSONExporter
 from .util import get_tags_count
-from xml.dom import minidom
 
 
 class XMLExporter(JSONExporter):

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
 import os
 import re
 import sys
-from ..util import WARNING_COLOR, ERROR_COLOR, RESET_COLOR
+
+from ..util import ERROR_COLOR, RESET_COLOR, WARNING_COLOR
+from .text_exporter import TextExporter
 
 
 class YAMLExporter(TextExporter):

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from dateutil.parser import parse as dateparse
 
 try:

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -1,11 +1,9 @@
+import os
 import sys
 
-from . import __version__
-from . import Journal
-from . import util
+from . import Journal, __version__, util
 from .EncryptedJournal import EncryptedJournal
 from .util import UserAbort
-import os
 
 
 def backup(filename, binary=False):

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 
-import sys
-import os
 import getpass as gp
-import yaml
+import logging
+import os
+import re
+import shlex
+from string import punctuation, whitespace
+import subprocess
+import sys
+import tempfile
+from typing import Callable, Optional
+import unicodedata
+
 import colorama
+import yaml
 
 if "win32" in sys.platform:
     colorama.init()
-import re
-import tempfile
-import subprocess
-import unicodedata
-import shlex
-from string import punctuation, whitespace
-import logging
-from typing import Optional, Callable
 
 log = logging.getLogger(__name__)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -169,6 +169,25 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "importlib-resources"]
 
 [[package]]
+category = "dev"
+description = "A Python utility / library to sort Python imports."
+name = "isort"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "4.3.21"
+
+[package.dependencies]
+[package.dependencies.toml]
+optional = true
+version = "*"
+
+[package.extras]
+pipfile = ["pipreqs", "requirementslib"]
+pyproject = ["toml"]
+requirements = ["pipreqs", "pip-api"]
+xdg_home = ["appdirs (>=1.4.0)"]
+
+[[package]]
 category = "main"
 description = "Low-level, pure Python DBus protocol wrapper."
 marker = "sys_platform == \"linux\""
@@ -522,7 +541,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "17cf8d4cf5a772217160daf312f590901dea4a3f5545d003035f3fb713a70f07"
+content-hash = "02dfef7e538fa800bc9cc255eaa776ebe275afb0edb48b404458bf65b152a690"
 python-versions = ">=3.6.0, <3.9.0"
 
 [metadata.files]
@@ -622,6 +641,10 @@ future = [
 importlib-metadata = [
     {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
     {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+]
+isort = [
+    {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
+    {file = "isort-4.3.21.tar.gz", hash = "sha256:54da7e92468955c4fceacd0c86bd0ec997b0e1ee80d97f67c35a78b719dccab1"},
 ]
 jeepney = [
     {file = "jeepney-0.4.3-py3-none-any.whl", hash = "sha256:d6c6b49683446d2407d2fe3acb7a368a77ff063f9182fe427da15d622adc24cf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,18 @@ behave = "^1.2"
 mkdocs = "^1.0"
 flake8 = "^3.7"
 black = {version = "^19.10b0",allow-prereleases = true}
+isort = {version = "^4.3.21", extras = ["pyproject"]}
 
 [tool.poetry.scripts]
 jrnl = 'jrnl.cli:run'
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88
+known_first_party = "jrnl"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
Further to #770, this adds linting via `isort` to Travis-CI. It also updates the GitHub PR template to mention this.

Also, the code is updated to remove any `__future__` imports (a relic from when we supported both Python 2 and 3), and then applies any other changes needed by isort.

isort is configured using the `pyproject.toml` file, and the configuration included should be compatible with balck.

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?
