### PR TITLE
Disable --delete due to critical bug

### DIFF
--- a/features/delete.feature
+++ b/features/delete.feature
@@ -1,5 +1,5 @@
 Feature: Delete entries from journal
-
+    @skip
     Scenario: --delete flag allows deletion of single entry
         Given we use the config "deletion.yaml"
         When we run "jrnl -n 1"

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -187,12 +187,14 @@ def parse_args(args=None):
         action="store_true",
     )
 
-    exporting.add_argument(
-        "--delete",
-        dest="delete",
-        action="store_true",
-        help="Opens an interactive interface for deleting entries.",
-    )
+    # Disabling this momentarily due to critical bug
+    # @see https://github.com/jrnl-org/jrnl/issues/932
+    # exporting.add_argument(
+    #     "--delete",
+    #     dest="delete",
+    #     action="store_true",
+    #     help="Opens an interactive interface for deleting entries.",
+    # )
 
     # Handle '-123' as a shortcut for '-n 123'
     num = re.compile(r"^-(\d+)$")
@@ -301,6 +303,10 @@ def configure_logger(debug=False):
 
 def run(manual_args=None):
     args = parse_args(manual_args)
+
+    # temporary until bring back --delete
+    args.delete = False  # TODO: remove me
+
     configure_logger(args.debug)
     if args.version:
         version_str = f"{jrnl.__title__} version {jrnl.__version__}"


### PR DESCRIPTION
The new `--delete` flag has a critical bug (#932). I'm disabling it for now to prevent new users from getting it. We'll follow this with another patch soon to bring back the flag once it's fixed.

### Checklist
- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass
- [ ] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your core changes, as applicable?