### PR TITLE
Change jrnl.sh GitHub new issue link to issue template chooser

### DIFF
--- a/docs/theme/index.html
+++ b/docs/theme/index.html
@@ -95,7 +95,7 @@
         </div>
     </main>
     <footer>
-        jrnl is made with love by <a href="https://github.com/jrnl-org/jrnl/graphs/contributors" title="Contributors">many fabulous people</a>. If you need help, <a href="https://github.com/jrnl-org/jrnl/issues/new" title="Open a new issue on Github">submit an issue</a> on Github.
+        jrnl is made with love by <a href="https://github.com/jrnl-org/jrnl/graphs/contributors" title="Contributors">many fabulous people</a>. If you need help, <a href="https://github.com/jrnl-org/jrnl/issues/new/choose" title="Open a new issue on Github">submit an issue</a> on Github.
     </footer>
     <script src="//cdnjs.cloudflare.com/ajax/libs/typed.js/2.0.10/typed.min.js"></script>
     <script>


### PR DESCRIPTION
I noticed that the support link at the bottom of jrnl.sh points to an empty form for a new GitHub issue. This fix points it to the new issue templates, which should increase the quality of support requests and bug reports.

### Checklist

- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [X] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [X] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [n/a] Have you written new tests for your core changes, as applicable?
