### PR TITLE
Add lockbot to lock comments on inactive, closed issues and prs

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,38 @@
+# Configuration for Lock Threads - https://github.com/dessant/lock-threads-app
+
+# Number of days of inactivity before a closed issue or pull request is locked
+daysUntilLock: 90
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: false
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Label to add before locking, such as `outdated`. Set to `false` to disable
+lockLabel: ':lock:'
+
+# Comment to post before locking. Set to `false` to disable
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.
+
+# Assign `resolved` as the reason for locking. Set to `false` to disable
+setLockReason: true
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   exemptLabels:
+#     - help-wanted
+#   lockLabel: outdated
+
+# pulls:
+#   daysUntilLock: 30
+
+# Repository to extend settings from
+# _extends: repo


### PR DESCRIPTION
We have a lot of old issues, and sometimes people comment on them. These
comments get lost in the shuffle. We're going to lock old issues, and encourage
people to start new issues (referencing the old issue, if they choose) if they
have any troubles.

### Checklist

- [ ] The code change is tested and works locally.
- [ ] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [ ] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [ ] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [ ] There is no commented out code in this PR.
- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [ ] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [ ] Have you written new tests for your core changes, as applicable?