### PR TITLE
Make sure testing cleans up after itself

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -2,11 +2,13 @@ import shutil
 import os
 import sys
 
+
 def clean_all_working_dirs():
     for folder in ("configs", "journals", "cache"):
         working_dir = os.path.join("features", folder)
         if os.path.exists(working_dir):
             shutil.rmtree(working_dir)
+
 
 def before_feature(context, feature):
     # add "skip" tag
@@ -51,4 +53,3 @@ def before_scenario(context, scenario):
 def after_scenario(context, scenario):
     """After each scenario, restore all test data and remove working_dirs."""
     clean_all_working_dirs()
-

--- a/features/environment.py
+++ b/features/environment.py
@@ -2,6 +2,11 @@ import shutil
 import os
 import sys
 
+def clean_all_working_dirs():
+    for folder in ("configs", "journals", "cache"):
+        working_dir = os.path.join("features", folder)
+        if os.path.exists(working_dir):
+            shutil.rmtree(working_dir)
 
 def before_feature(context, feature):
     # add "skip" tag
@@ -18,10 +23,7 @@ def before_feature(context, feature):
 def before_scenario(context, scenario):
     """Before each scenario, backup all config and journal test data."""
     # Clean up in case something went wrong
-    for folder in ("configs", "journals", "cache"):
-        working_dir = os.path.join("features", folder)
-        if os.path.exists(working_dir):
-            shutil.rmtree(working_dir)
+    clean_all_working_dirs()
 
     for folder in ("configs", "journals"):
         original = os.path.join("features", "data", folder)
@@ -48,7 +50,5 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     """After each scenario, restore all test data and remove working_dirs."""
-    for folder in ("configs", "journals", "cache"):
-        working_dir = os.path.join("features", folder)
-        if os.path.exists(working_dir):
-            shutil.rmtree(working_dir)
+    clean_all_working_dirs()
+

--- a/features/environment.py
+++ b/features/environment.py
@@ -18,7 +18,7 @@ def before_feature(context, feature):
 def before_scenario(context, scenario):
     """Before each scenario, backup all config and journal test data."""
     # Clean up in case something went wrong
-    for folder in ("configs", "journals"):
+    for folder in ("configs", "journals", "cache"):
         working_dir = os.path.join("features", folder)
         if os.path.exists(working_dir):
             shutil.rmtree(working_dir)
@@ -48,7 +48,7 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     """After each scenario, restore all test data and remove working_dirs."""
-    for folder in ("configs", "journals"):
+    for folder in ("configs", "journals", "cache"):
         working_dir = os.path.join("features", folder)
         if os.path.exists(working_dir):
             shutil.rmtree(working_dir)

--- a/features/exporting.feature
+++ b/features/exporting.feature
@@ -123,7 +123,7 @@ Feature: Exporting a Journal
     Scenario: Export to yaml
         Given we use the config "tags.yaml"
         And we created a directory named "exported_journal"
-        When we run "jrnl --export yaml -o exported_journal"
+        When we run "jrnl --export yaml -o features/cache/exported_journal"
         Then "exported_journal" should contain the files ["2013-04-09_i-have-an-idea.md", "2013-06-10_i-met-with-dan.md"]
         And the content of exported yaml "exported_journal/2013-04-09_i-have-an-idea.md" should be
         """

--- a/features/exporting.feature
+++ b/features/exporting.feature
@@ -122,10 +122,16 @@ Feature: Exporting a Journal
 
     Scenario: Export to yaml
         Given we use the config "tags.yaml"
-        And we created a directory named "exported_journal"
-        When we run "jrnl --export yaml -o features/cache/exported_journal"
-        Then "exported_journal" should contain the files ["2013-04-09_i-have-an-idea.md", "2013-06-10_i-met-with-dan.md"]
-        And the content of exported yaml "exported_journal/2013-04-09_i-have-an-idea.md" should be
+        And we create cache directory "exported_journal"
+        When we run "jrnl --export yaml -o {cache_dir}" with cache directory "exported_journal"
+        Then cache directory "exported_journal" should contain the files
+        """
+        [
+        "2013-04-09_i-have-an-idea.md",
+        "2013-06-10_i-met-with-dan.md"
+        ]
+        """
+        And the content of file "2013-04-09_i-have-an-idea.md" in cache directory "exported_journal" should be
         """
         title: I have an @idea:
         date: 2013-04-09 15:39

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -148,10 +148,17 @@ Feature: Zapped bugs should stay dead.
     # See issues #768 and #881
     Scenario: Add a blank line to YAML export is there isn't one already
         Given we use the config "deletion.yaml"
-        And we created a directory named "bug768"
-        When we run "jrnl --export yaml -o features/cache/bug768"
-        Then "bug768" should contain the files ["2019-10-29_first-entry.md", "2019-10-29_second-entry.md", "2019-10-29_third-entry.md"]
-        And the content of exported yaml "bug768/2019-10-29_third-entry.md" should be
+        And we create cache directory "bug768"
+        When we run "jrnl --export yaml -o {cache_dir}" with cache directory "bug768"
+        Then cache directory "bug768" should contain the files
+        """
+        [
+        "2019-10-29_first-entry.md",
+        "2019-10-29_second-entry.md",
+        "2019-10-29_third-entry.md"
+        ]
+        """
+        And the content of file "2019-10-29_third-entry.md" in cache directory "bug768" should be
         """
         title: Third entry.
         date: 2019-10-29 11:13

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -76,30 +76,30 @@ Feature: Zapped bugs should stay dead.
         Then the output should not contain "But I'm better."
 
     Scenario: Create entry using day of the week as entry date.
-    	Given we use the config "basic.yaml"
-    	When we run "jrnl monday: This is an entry on a Monday."
-    	Then we should see the message "Entry added"
-    	When we run "jrnl -1"
+        Given we use the config "basic.yaml"
+        When we run "jrnl monday: This is an entry on a Monday."
+        Then we should see the message "Entry added"
+        When we run "jrnl -1"
         Then the output should contain "monday at 9am" in the local time
         Then the output should contain "This is an entry on a Monday."
 
     Scenario: Create entry using day of the week abbreviations as entry date.
-    	Given we use the config "basic.yaml"
-    	When we run "jrnl fri: This is an entry on a Friday."
-    	Then we should see the message "Entry added"
-    	When we run "jrnl -1"
-        Then the output should contain "friday at 9am" in the local time 
+        Given we use the config "basic.yaml"
+        When we run "jrnl fri: This is an entry on a Friday."
+        Then we should see the message "Entry added"
+        When we run "jrnl -1"
+        Then the output should contain "friday at 9am" in the local time
 
     Scenario: Displaying entries using -on today should display entries created today.
         Given we use the config "basic.yaml"
-        When we run "jrnl today: Adding an entry right now." 
+        When we run "jrnl today: Adding an entry right now."
         Then we should see the message "Entry added"
         When we run "jrnl -on today"
         Then the output should contain "Adding an entry right now."
 
     Scenario: Displaying entries using -from day should display correct entries
         Given we use the config "basic.yaml"
-        When we run "jrnl yesterday: This thing happened yesterday" 
+        When we run "jrnl yesterday: This thing happened yesterday"
         Then we should see the message "Entry added"
         When we run "jrnl today at 11:59pm: Adding an entry right now."
         Then we should see the message "Entry added"
@@ -112,7 +112,7 @@ Feature: Zapped bugs should stay dead.
 
     Scenario: Displaying entries using -from and -to day should display correct entries
         Given we use the config "basic.yaml"
-        When we run "jrnl yesterday: This thing happened yesterday" 
+        When we run "jrnl yesterday: This thing happened yesterday"
         Then we should see the message "Entry added"
         When we run "jrnl today at 11:59pm: Adding an entry right now."
         Then we should see the message "Entry added"

--- a/features/regression.feature
+++ b/features/regression.feature
@@ -149,7 +149,7 @@ Feature: Zapped bugs should stay dead.
     Scenario: Add a blank line to YAML export is there isn't one already
         Given we use the config "deletion.yaml"
         And we created a directory named "bug768"
-        When we run "jrnl --export yaml -o bug768"
+        When we run "jrnl --export yaml -o features/cache/bug768"
         Then "bug768" should contain the files ["2019-10-29_first-entry.md", "2019-10-29_second-entry.md", "2019-10-29_third-entry.md"]
         And the content of exported yaml "bug768/2019-10-29_third-entry.md" should be
         """

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -151,7 +151,12 @@ def run_with_input(context, command, inputs=""):
 
 
 @when('we run "{command}"')
-def run(context, command):
+@when('we run "{command}" with cache directory "{cache_dir}"')
+def run(context, command, cache_dir=None):
+    if cache_dir is not None:
+        cache_dir = os.path.join("features", "cache", cache_dir)
+        command = command.format(cache_dir=cache_dir)
+
     args = ushlex(command)[1:]
     try:
         cli.run(args or None)

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -45,9 +45,7 @@ keyring.set_keyring(TestKeyring())
 
 
 def ushlex(command):
-    if sys.version_info[0] == 3:
-        return shlex.split(command)
-    return map(lambda s: s.decode("UTF8"), shlex.split(command.encode("utf8")))
+    return shlex.split(command, posix="win32" not in sys.platform)
 
 
 def read_journal(journal_name="default"):

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -87,14 +87,16 @@ def assert_xml_output_tags(context, expected_tags_json_list):
 
 @given('we created a directory named "{dir_name}"')
 def create_directory(context, dir_name):
-    if os.path.exists(dir_name):
-        shutil.rmtree(dir_name)
-    os.mkdir(dir_name)
+    working_dir = os.path.join("features", "cache", dir_name)
+    if os.path.exists(working_dir):
+        shutil.rmtree(working_dir)
+    os.makedirs(working_dir)
 
 
 @then('"{dir_name}" should contain the files {expected_files_json_list}')
 def assert_dir_contains_files(context, dir_name, expected_files_json_list):
-    actual_files = os.listdir(dir_name)
+    working_dir = os.path.join("features", "cache", dir_name)
+    actual_files = os.listdir(working_dir)
     expected_files = json.loads(expected_files_json_list)
 
     # sort to deal with inconsistent default file ordering on different OS's
@@ -107,8 +109,9 @@ def assert_dir_contains_files(context, dir_name, expected_files_json_list):
 @then('the content of exported yaml "{file_path}" should be')
 def assert_exported_yaml_file_content(context, file_path):
     expected_content = context.text.strip().splitlines()
+    full_file_path = os.path.join("features", "cache", file_path)
 
-    with open(file_path, "r") as f:
+    with open(full_file_path, "r") as f:
         actual_content = f.read().strip().splitlines()
 
     for actual_line, expected_line in zip(actual_content, expected_content):

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -85,7 +85,7 @@ def assert_xml_output_tags(context, expected_tags_json_list):
     assert actual_tags == set(expected_tags), [actual_tags, set(expected_tags)]
 
 
-@given('we created a directory named "{dir_name}"')
+@given('we create cache directory "{dir_name}"')
 def create_directory(context, dir_name):
     working_dir = os.path.join("features", "cache", dir_name)
     if os.path.exists(working_dir):
@@ -93,11 +93,16 @@ def create_directory(context, dir_name):
     os.makedirs(working_dir)
 
 
-@then('"{dir_name}" should contain the files {expected_files_json_list}')
-def assert_dir_contains_files(context, dir_name, expected_files_json_list):
+@then('cache directory "{dir_name}" should contain the files')
+@then(
+    'cache directory "{dir_name}" should contain the files {expected_files_json_list}'
+)
+def assert_dir_contains_files(context, dir_name, expected_files_json_list="[]"):
     working_dir = os.path.join("features", "cache", dir_name)
     actual_files = os.listdir(working_dir)
-    expected_files = json.loads(expected_files_json_list)
+
+    expected_files = context.text or expected_files_json_list
+    expected_files = json.loads(expected_files)
 
     # sort to deal with inconsistent default file ordering on different OS's
     actual_files.sort()
@@ -106,10 +111,10 @@ def assert_dir_contains_files(context, dir_name, expected_files_json_list):
     assert actual_files == expected_files, [actual_files, expected_files]
 
 
-@then('the content of exported yaml "{file_path}" should be')
-def assert_exported_yaml_file_content(context, file_path):
+@then('the content of file "{file_path}" in cache directory "{cache_dir}" should be')
+def assert_exported_yaml_file_content(context, file_path, cache_dir):
     expected_content = context.text.strip().splitlines()
-    full_file_path = os.path.join("features", "cache", file_path)
+    full_file_path = os.path.join("features", "cache", cache_dir, file_path)
 
     with open(full_file_path, "r") as f:
         actual_content = f.read().strip().splitlines()


### PR DESCRIPTION
Fixes #939

This centralizes where we store all of our testing temporary files (in
`features` for now, but can easily be moved later), and cleans that central
location properly. This should result in a clean working directory after
running the testing suite.

### Checklist

- [x] The code change is tested and works locally.
- [ ] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [x] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [x] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [x] Have you written new tests for your core changes, as applicable?