### PR TITLE
Update lockbot comment to encourage linking to issue

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -8,7 +8,7 @@ daysUntilLock: 90
 skipCreatedBefore: false
 
 # Issues and pull requests with these labels will be ignored. Set to `[]` to disable
-exemptLabels: []
+exemptLabels: [':pushpin:']
 
 # Label to add before locking, such as `outdated`. Set to `false` to disable
 lockLabel: ':lock:'
@@ -17,7 +17,8 @@ lockLabel: ':lock:'
 lockComment: >
   This thread has been automatically locked since there has not been
   any recent activity after it was closed. Please open a new issue for
-  related bugs.
+  related bugs. You can link back here from your new issue to continue
+  the conversation.
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -8,7 +8,7 @@ daysUntilLock: 90
 skipCreatedBefore: false
 
 # Issues and pull requests with these labels will be ignored. Set to `[]` to disable
-exemptLabels: [':pushpin:']
+exemptLabels: []
 
 # Label to add before locking, such as `outdated`. Set to `false` to disable
 lockLabel: ':lock:'


### PR DESCRIPTION
Further to #938.

Should starred/[pushpinned issues](https://github.com/jrnl-org/jrnl/issues?q=is%3Aopen+is%3Aissue+label%3A%3Apushpin%3A) be immune to being closed? I think that was the purpose of that label.

Also, I think the closing text should encourage people to link back to "this" issue, so the conversation can be followed.

### Checklist

- [ n/a ] The code change is tested and works locally.
- [ n/a ] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [ n/a ] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [ n/a ] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [ n/a ] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [ n/a ] Have you written new tests for your core changes, as applicable?
