### PR TITLE
Apply isort Mk II

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -1,5 +1,5 @@
-import shutil
 import os
+import shutil
 import sys
 
 

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -1,23 +1,24 @@
+import ast
+from codecs import decode, encode
+from collections import defaultdict
+import json
+import os
+import shlex
+import sys
+import time
 from unittest.mock import patch
 
-from behave import given, when, then
-from jrnl import cli, install, Journal, util, plugins
-from jrnl import __version__
-from collections import defaultdict
+import keyring
+import tzlocal
+import yaml
+
+from behave import given, then, when
+from jrnl import Journal, __version__, cli, install, plugins, util
 
 try:
     import parsedatetime.parsedatetime_consts as pdt
 except ImportError:
     import parsedatetime as pdt
-import time
-import os
-import ast
-import yaml
-import keyring
-import shlex
-import sys
-from pathlib import Path
-import toml
 
 consts = pdt.Constants(usePyICU=False)
 consts.DOWParseStyle = -1  # Prefers past weekdays

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -1,15 +1,14 @@
 import ast
-from codecs import decode, encode
 from collections import defaultdict
-import json
 import os
+from pathlib import Path
 import shlex
 import sys
 import time
 from unittest.mock import patch
 
 import keyring
-import tzlocal
+import toml
 import yaml
 
 from behave import given, then, when

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -3,7 +3,7 @@ import os
 import shutil
 from xml.etree import ElementTree
 
-from behave import then, given
+from behave import given, then
 
 
 @then("the output should be parsable as json")

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -1,19 +1,20 @@
 #!/usr/bin/env python
 
-from . import Entry
-from . import Journal
-from . import time as jrnl_time
-import os
-import re
 from datetime import datetime
-import time
 import fnmatch
 from pathlib import Path
+import os
 import plistlib
-import pytz
+import re
+import time
 import uuid
-import tzlocal
 from xml.parsers.expat import ExpatError
+
+import pytz
+import tzlocal
+
+from . import Entry, Journal
+from . import time as jrnl_time
 
 
 class DayOne(Journal.Journal):

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -2,8 +2,8 @@
 
 from datetime import datetime
 import fnmatch
-from pathlib import Path
 import os
+from pathlib import Path
 import plistlib
 import re
 import time

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -3,7 +3,6 @@ import hashlib
 import logging
 import os
 import sys
-from typing import Optional
 
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.backends import default_backend

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -1,16 +1,18 @@
-from . import util
-from .Journal import Journal, LegacyJournal
+import base64
+import hashlib
+import logging
+import os
+import sys
+from typing import Optional
+
 from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes, padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-import hashlib
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from cryptography.hazmat.backends import default_backend
-import sys
-import os
-import base64
-import logging
 
+from . import util
+from .Journal import Journal, LegacyJournal
 
 log = logging.getLogger()
 

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
-import re
-import ansiwrap
 from datetime import datetime
-from .util import split_title, colorize, highlight_tags_with_background_color
+import re
+
+import ansiwrap
+
+from .util import colorize, highlight_tags_with_background_color, split_title
 
 
 class Entry:

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals
 from . import Journal
 import codecs
 import os

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from . import Journal
 import codecs
-import os
 import fnmatch
+import os
+
+from . import Journal
 
 
 def get_files(journal_config):

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
+from datetime import datetime
 import logging
 import os
-import sys
 import re
+import sys
 
-from datetime import datetime
-from jrnl import Entry, util, time
+from jrnl import Entry, time, util
 
 log = logging.getLogger(__name__)
 

--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from . import cli
 
-
 if __name__ == "__main__":
     cli.run()

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -19,17 +19,17 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-from .Journal import PlainJournal, open_journal
-from .EncryptedJournal import EncryptedJournal
-from . import util
-from . import install
-from . import plugins
-from .util import ERROR_COLOR, RESET_COLOR, UserAbort
-import jrnl
 import argparse
-import sys
-import re
 import logging
+import re
+import sys
+
+import jrnl
+
+from . import install, plugins, util
+from .EncryptedJournal import EncryptedJournal
+from .Journal import PlainJournal, open_journal
+from .util import ERROR_COLOR, RESET_COLOR, UserAbort
 
 log = logging.getLogger(__name__)
 logging.getLogger("keyring.backend").setLevel(logging.ERROR)

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import getpass
 import glob
 import logging
 import os
@@ -10,8 +9,6 @@ import xdg.BaseDirectory
 import yaml
 
 from . import __version__, upgrade, util
-from .EncryptedJournal import EncryptedJournal
-from .Journal import PlainJournal
 from .util import UserAbort, verify_config
 
 if "win32" not in sys.platform:

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -1,15 +1,18 @@
 #!/usr/bin/env python
 
+import getpass
 import glob
-import os
-import xdg.BaseDirectory
-from . import util
-from . import upgrade
-from . import __version__
-from .util import UserAbort, verify_config
-import yaml
 import logging
+import os
 import sys
+
+import xdg.BaseDirectory
+import yaml
+
+from . import __version__, upgrade, util
+from .EncryptedJournal import EncryptedJournal
+from .Journal import PlainJournal
+from .util import UserAbort, verify_config
 
 if "win32" not in sys.platform:
     # readline is not included in Windows Active Python

--- a/jrnl/plugins/__init__.py
+++ b/jrnl/plugins/__init__.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
+from .fancy_exporter import FancyExporter
 from .jrnl_importer import JRNLImporter
 from .json_exporter import JSONExporter
 from .markdown_exporter import MarkdownExporter
 from .tag_exporter import TagExporter
+from .template_exporter import __all__ as template_exporters
+from .text_exporter import TextExporter
 from .xml_exporter import XMLExporter
 from .yaml_exporter import YAMLExporter
-from .template_exporter import __all__ as template_exporters
-from .fancy_exporter import FancyExporter
 
 __exporters = [
     JSONExporter,

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from __future__ import absolute_import, unicode_literals, print_function
 from .text_exporter import TextExporter
 from textwrap import TextWrapper
 

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
 from textwrap import TextWrapper
+
+from .text_exporter import TextExporter
 
 
 class FancyExporter(TextExporter):

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -3,6 +3,8 @@
 
 import sys
 
+from .. import util
+
 
 class JRNLImporter:
     """This plugin imports entries from other jrnl files."""
@@ -14,6 +16,7 @@ class JRNLImporter:
         """Imports from an existing file if input is specified, and
         standard input otherwise."""
         old_cnt = len(journal.entries)
+        old_entries = journal.entries
         if input:
             with open(input, "r", encoding="utf-8") as f:
                 other_journal_txt = f.read()

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -3,8 +3,6 @@
 
 import sys
 
-from .. import util
-
 
 class JRNLImporter:
     """This plugin imports entries from other jrnl files."""
@@ -16,7 +14,6 @@ class JRNLImporter:
         """Imports from an existing file if input is specified, and
         standard input otherwise."""
         old_cnt = len(journal.entries)
-        old_entries = journal.entries
         if input:
             with open(input, "r", encoding="utf-8") as f:
                 other_journal_txt = f.read()

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
 import json
+
+from .text_exporter import TextExporter
 from .util import get_tags_count
 
 

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
-import re
 import os
+import re
 import sys
-from ..util import WARNING_COLOR, RESET_COLOR
+
+from ..util import RESET_COLOR, WARNING_COLOR
+from .text_exporter import TextExporter
 
 
 class MarkdownExporter(TextExporter):
@@ -53,10 +54,6 @@ class MarkdownExporter(TextExporter):
                 newbody = newbody + previous_line
             previous_line = line
         newbody = newbody + previous_line  # add very last line
-
-        # make sure the export ends with a blank line
-        if previous_line not in ["\r", "\n", "\r\n", "\n\r"]:
-            newbody = newbody + os.linesep
 
         if warn_on_heading_level is True:
             print(

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -55,6 +55,10 @@ class MarkdownExporter(TextExporter):
             previous_line = line
         newbody = newbody + previous_line  # add very last line
 
+        # make sure the export ends with a blank line
+        if previous_line not in ["\r", "\n", "\r\n", "\n\r"]:
+            newbody = newbody + os.linesep
+
         if warn_on_heading_level is True:
             print(
                 f"{WARNING_COLOR}WARNING{RESET_COLOR}: "

--- a/jrnl/plugins/template.py
+++ b/jrnl/plugins/template.py
@@ -1,4 +1,5 @@
 import re
+
 import yaml
 
 VAR_RE = r"[_a-zA-Z][a-zA-Z0-9_]*"

--- a/jrnl/plugins/template_exporter.py
+++ b/jrnl/plugins/template_exporter.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
-from .template import Template
-import os
 from glob import glob
+import os
+
+from .template import Template
+from .text_exporter import TextExporter
 
 
 class GenericTemplateExporter(TextExporter):

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from ..util import slugify
 import os
-from ..util import ERROR_COLOR, RESET_COLOR
+
+from ..util import ERROR_COLOR, RESET_COLOR, slugify
 
 
 class TextExporter:

--- a/jrnl/plugins/xml_exporter.py
+++ b/jrnl/plugins/xml_exporter.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+from xml.dom import minidom
+
 from .json_exporter import JSONExporter
 from .util import get_tags_count
-from xml.dom import minidom
 
 
 class XMLExporter(JSONExporter):

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-from .text_exporter import TextExporter
 import os
 import re
 import sys
-from ..util import WARNING_COLOR, ERROR_COLOR, RESET_COLOR
+
+from ..util import ERROR_COLOR, RESET_COLOR, WARNING_COLOR
+from .text_exporter import TextExporter
 
 
 class YAMLExporter(TextExporter):

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from dateutil.parser import parse as dateparse
 
 try:

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -1,11 +1,9 @@
+import os
 import sys
 
-from . import __version__
-from . import Journal
-from . import util
+from . import Journal, __version__, util
 from .EncryptedJournal import EncryptedJournal
 from .util import UserAbort
-import os
 
 
 def backup(filename, binary=False):

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 
-import sys
-import os
 import getpass as gp
-import yaml
+import logging
+import os
+import re
+import shlex
+from string import punctuation, whitespace
+import subprocess
+import sys
+import tempfile
+from typing import Callable, Optional
+import unicodedata
+
 import colorama
+import yaml
 
 if "win32" in sys.platform:
     colorama.init()
-import re
-import tempfile
-import subprocess
-import unicodedata
-import shlex
-from string import punctuation, whitespace
-import logging
-from typing import Optional, Callable
 
 log = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,15 @@ pyflakes = "^2.2.0"
 [tool.poetry.scripts]
 jrnl = 'jrnl.cli:run'
 
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88
+known_first_party = "jrnl"
+force_sort_within_sections = true
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 88
-known_first_party = "jrnl"
+known_first_party = ["jrnl", "behave"]
 force_sort_within_sections = true
 
 [build-system]


### PR DESCRIPTION
Recreates #917 

Applies `isort` to the codebase to organize imports. Includes the configuration used here in the project's `pyproject.toml` file so this can be reproduced, but does not add any forced linting.

### Checklist

- [ x ] The code change is tested and works locally.
- [ ? ] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [x] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [x] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [x] Have you written new tests for your core changes, as applicable?
