### PR TITLE
Use gitlab to trigger releases in pipeline

### DIFF
--- a/.build/generate_changelog.sh
+++ b/.build/generate_changelog.sh
@@ -59,6 +59,6 @@ git config --global user.email "jrnl.bot@gmail.com"
 git config --global user.name "Jrnl Bot"
 git checkout $BRANCH
 git add "$FILENAME"
-git commit -m "Updating changelog [ci skip]"
+git commit -m "Update changelog [ci skip]"
 git push https://${GITHUB_TOKEN}@github.com/jrnl-org/jrnl.git $BRANCH
 

--- a/.build/gitlab-ci.yml
+++ b/.build/gitlab-ci.yml
@@ -1,0 +1,36 @@
+# This file is a template, and might need editing before it works on your project.
+# Official language image. Look for the different tagged releases at:
+# https://hub.docker.com/r/library/python/tags/
+image: python:latest
+
+# Change pip's cache directory to be inside the project directory since we can
+# only cache local items.
+variables:
+  PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+
+# Pip's cache doesn't store the python packages
+# https://pip.pypa.io/en/stable/reference/pip_install/#caching
+#
+# If you want to also cache the installed packages, you have to install
+# them in a virtualenv and cache it as well.
+cache:
+  paths:
+    - .cache/pip
+
+before_script:
+  - python -V  # Print out python version for debugging
+  - pip install poetry
+
+release:
+  rules:
+    - if: $RELEASE != null
+  script:
+    - git config --global user.email "jrnl.bot@gmail.com"
+    - git config --global user.name "Jrnl Bot"
+    - git checkout "$CI_COMMIT_BRANCH"
+    - poetry version "$RELEASE"
+    - echo __version__ = \"$RELEASE\" > jrnl/__version__.py
+    - git add pyproject.toml jrnl/__version__.py
+    - git commit -m "Increment version to ${RELEASE}"
+    - git tag -a -m "$RELEASE" "$RELEASE"
+    - git push --follow-tags "https://${GITHUB_TOKEN}@github.com/jrnl-org/jrnl.git" "$CI_COMMIT_BRANCH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -129,19 +129,9 @@ jobs:
       env:
         TZ: America/Edmonton
 
-    # Changelog for Unreleased changes
-    - stage: Update Changelog
-      if: (tag IS present) OR (branch = develop AND type NOT IN (pull_request))
-      install:
-        - echo 'Skipping install'
-      script:
-        - ./.build/generate_changelog.sh
-
     - stage: Deploy
       if: tag IS present
       before_deploy:
-        - poetry version "$TRAVIS_TAG"
-        - echo __version__ = \"$TRAVIS_TAG\" > jrnl/__version__.py
         - poetry build
       script:
         - echo "Deployment starting..."
@@ -149,13 +139,12 @@ jobs:
         - provider: script
           script: poetry publish
           skip_cleanup: true
-          on:
-            branch: master
-            tags: true
-      after_deploy:
-        - git config --global user.email "jrnl.bot@gmail.com"
-        - git config --global user.name "Jrnl Bot"
-        - git checkout master
-        - git add pyproject.toml jrnl/__version__.py
-        - git commit -m "Incrementing version to ${TRAVIS_TAG} [ci skip]"
-        - git push https://${GITHUB_TOKEN}@github.com/jrnl-org/jrnl.git master
+
+    # Changelog for Unreleased changes
+    - stage: Update Changelog
+      if: (tag IS present) OR (branch = develop AND type NOT IN (pull_request))
+      install:
+        - echo 'Skipping installation step'
+      script:
+        - ./.build/generate_changelog.sh
+


### PR DESCRIPTION
Neither Travis Github Actions support manually triggering a pipeline step, so
this PR adds that step to Gitlab. It just increments the version, commits and
tags the release. Our regular Travis release process will take over after the
tag is pushed.

### Checklist

- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [x] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [x] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [x] Have you written new tests for your core changes, as applicable?