### PR TITLE
Fix duplicate text in multiple tag search

### DIFF
--- a/features/tagging.feature
+++ b/features/tagging.feature
@@ -108,3 +108,14 @@ Feature: Tagging
             | As alway's he shared his latest @idea on how to rule the world with me.
             | inst
             """
+
+    Scenario: Searching a journal for multiple tags with -and should display entries with those tags.
+        Given we use the config "tags.yaml"
+        When we run "jrnl -and @idea @journal"
+        Then the output should be
+            """
+            2013-04-09 15:39 I have an @idea:
+            | (1) write a command line @journal software
+            | (2) ???
+            | (3) PROFIT!
+            """

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -224,14 +224,7 @@ def highlight_tags_with_background_color(entry, text, color, is_title=False):
 
     config = entry.journal.config
     if config["highlight"]:  # highlight tags
-        if entry.journal.search_tags:
-            text_fragments = []
-            for tag in entry.journal.search_tags:
-                text_fragments.extend(
-                    re.split(re.compile(f"({re.escape(tag)})", re.IGNORECASE), text)
-                )
-        else:
-            text_fragments = re.split(entry.tag_regex(config["tagsymbols"]), text)
+        text_fragments = re.split(entry.tag_regex(config["tagsymbols"]), text)
 
         # Colorizing tags inside of other blocks of text
         final_text = ""


### PR DESCRIPTION
Fixes #926.

The pretty print feature (#842) highlights all tags by default, but if you search for a particular tag, it only highlights that tag. However, when searching for multiple tags, it would show the entire title and body once for each tag searched for.

This PR removes that selective highlighting (so all tags are highlighted regardless of what you've searched for) and adds a test that catches the duplication bug.

### Checklist

- [X] The code change is tested and works locally.
- [X] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [X] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [X] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [X] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [X] Have you written new tests for your core changes, as applicable?
