### PR TITLE
Ask for password before adding entry instead of after

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -345,7 +345,7 @@ def run(manual_args=None):
     else:
         _exit_multiline_code = "press Ctrl+D"
 
-    # This is where we fi±nally open the journal!
+    # This is where we finally open the journal!
     try:
         journal = open_journal(journal_name, config)
     except KeyboardInterrupt:

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -345,6 +345,13 @@ def run(manual_args=None):
     else:
         _exit_multiline_code = "press Ctrl+D"
 
+    # This is where we fi±nally open the journal!
+    try:
+        journal = open_journal(journal_name, config)
+    except KeyboardInterrupt:
+        print("[Interrupted while opening journal]", file=sys.stderr)
+        sys.exit(1)
+
     if mode_compose and not args.text:
         if not sys.stdin.isatty():
             # Piping data into jrnl
@@ -375,13 +382,6 @@ def run(manual_args=None):
             args.text = [raw]
         else:
             sys.exit()
-
-    # This is where we finally open the journal!
-    try:
-        journal = open_journal(journal_name, config)
-    except KeyboardInterrupt:
-        print("[Interrupted while opening journal]", file=sys.stderr)
-        sys.exit(1)
 
     # Import mode
     if mode_import:


### PR DESCRIPTION
<!--
# **TEMPLATE PLEASE EDIT**
*Thank you for wanting to contribute! Please fill out this description as well
as look at the checklist!*

*Short block of text containing:
- Relevant changes in text form
- related issues
- Motivation (if applicable)
- Example of usage (if applicable)
- Example of changes to config files (if applicable)
*
-->

This hopefully fixes #799 because prviously it would allow you to create an entry using your editor and then attempt to open the journal. This behaviour is fine for unecrypted journals but with encrypted journals it means that if you get the password wrong three times then the entry you wrote is lost.

Swapping the code around so that it attempts to open the journal before it opens an editor means that this can't happen. This should solve #270, #256 and #284 too.

It appears that this was the [behaviour in earlier versions of `jrnl`](https://github.com/jrnl-org/jrnl/blob/9618b74f8db84e7847bf15fa46838f100663db0a/jrnl/cli.py#L162) but I'm assuming that this got lost after a rewrite.

This is my first time contributing to open source so I apologise if I've formatted anything wrong or made a big mistake but I'm not really sure what the process is yet and would be happy to fix anything that I did incorrectly.

### Checklist

- [X] The code change is tested and works locally.
- [X]  Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [X] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [X] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [X] There is no commented out code in this PR.
- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
