### PR TITLE
Fix typo in recipes.md

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -73,7 +73,7 @@ jrnlimport () {
 !!! note
     Templates require an [external editor](./advanced.md) be configured. 
 
-A template is a code snippet that makes it easier to enter use repeated text 
+A template is a code snippet that makes it easier to use repeated text 
 each time a new journal entry is started. There are two ways you can utilize
 templates in your entries.  
 


### PR DESCRIPTION
typo in recipes.md. two verbs in a row. only one is needed :)
cheers
mja


<!--
# **TEMPLATE PLEASE EDIT**
*Thank you for wanting to contribute! Please fill out this description as well
as look at the checklist!*

*Short block of text containing:
- Relevant changes in text form
- related issues
- Motivation (if applicable)
- Example of usage (if applicable)
- Example of changes to config files (if applicable)
*
-->

### Checklist

- [ ] The code change is tested and works locally.
- [ ] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [ ] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [ ] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [ ] There is no commented out code in this PR.
- [ ] Have you followed the guidelines in our Contributing document?
- [ ] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [ ] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
