### PR TITLE
Fix editor config when an argument with a space is used

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -33,13 +33,11 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl -n 1"
         Then the output should contain "2013-07-23 09:00 A cold and stormy day."
 
-    @skip_win
     Scenario: Writing an empty entry from the editor
         Given we use the config "editor.yaml"
         When we open the editor and enter nothing
         Then we should see the message "[Nothing saved to file]"
 
-    @skip_win
     Scenario: Sending an argument with spaces to the editor should work
         Given we use the config "editor-args.yaml"
         When we open the editor and enter "lorem ipsum"

--- a/features/core.feature
+++ b/features/core.feature
@@ -39,6 +39,7 @@ Feature: Basic reading and writing to a journal
         When we open the editor and enter nothing
         Then we should see the message "[Nothing saved to file]"
 
+    @skip_win
     Scenario: Sending an argument with spaces to the editor should work
         Given we use the config "editor-args.yaml"
         When we open the editor and enter "lorem ipsum"

--- a/features/core.feature
+++ b/features/core.feature
@@ -33,19 +33,21 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl -n 1"
         Then the output should contain "2013-07-23 09:00 A cold and stormy day."
 
+    @skip_win
     Scenario: Writing an empty entry from the editor
         Given we use the config "editor.yaml"
         When we open the editor and enter nothing
         Then we should see the message "[Nothing saved to file]"
 
+    @skip_win
     Scenario: Sending an argument with spaces to the editor should work
         Given we use the config "editor-args.yaml"
         When we open the editor and enter "lorem ipsum"
         Then the editor should have been called with 5 arguments
-        And the editor arguments should contain "vim"
-        And the editor arguments should contain "-f"
-        And the editor arguments should contain "-c"
-        And the editor arguments should contain "setf markdown"
+        And one editor argument should be "vim"
+        And one editor argument should be "-f"
+        And one editor argument should be "-c"
+        And one editor argument should match "'?setf markdown'?"
 
     Scenario: Writing an empty entry from the command line
         Given we use the config "basic.yaml"

--- a/features/core.feature
+++ b/features/core.feature
@@ -39,6 +39,15 @@ Feature: Basic reading and writing to a journal
         When we open the editor and enter nothing
         Then we should see the message "[Nothing saved to file]"
 
+    Scenario: Sending an argument with spaces to the editor should work
+        Given we use the config "editor-args.yaml"
+        When we open the editor and enter "lorem ipsum"
+        Then the editor should have been called with 5 arguments
+        And the editor arguments should contain "vim"
+        And the editor arguments should contain "-f"
+        And the editor arguments should contain "-c"
+        And the editor arguments should contain "setf markdown"
+
     Scenario: Writing an empty entry from the command line
         Given we use the config "basic.yaml"
         When we run "jrnl" and enter nothing

--- a/features/data/configs/editor-args.yaml
+++ b/features/data/configs/editor-args.yaml
@@ -1,0 +1,12 @@
+default_hour: 9
+default_minute: 0
+editor: vim -f -c 'setf markdown'
+encrypt: false
+highlight: true
+journals:
+  default: features/journals/simple.journal
+linewrap: 80
+tagsymbols: "@"
+template: false
+timeformat: "%Y-%m-%d %H:%M"
+indent_character: "|"

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -166,10 +166,12 @@ def run(context, command, cache_dir=None):
         cache_dir = os.path.join("features", "cache", cache_dir)
         command = command.format(cache_dir=cache_dir)
 
-    args = ushlex(command)[1:]
+    args = ushlex(command)
+
     try:
-        cli.run(args or None)
-        context.exit_status = 0
+        with patch('sys.argv', args):
+            cli.run(args[1:])
+            context.exit_status = 0
     except SystemExit as e:
         context.exit_status = e.code
 

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -85,6 +85,7 @@ def open_editor_and_enter(context, text=""):
     text = text or context.text or ""
 
     def _mock_editor_function(command):
+        context.editor_command = command
         tmpfile = command[-1]
         with open(tmpfile, "w+") as f:
             f.write(text)
@@ -92,7 +93,17 @@ def open_editor_and_enter(context, text=""):
         return tmpfile
 
     with patch("subprocess.call", side_effect=_mock_editor_function):
-        run(context, "jrnl")
+        context.execute_steps('when we run "jrnl"')
+
+
+@then("the editor should have been called with {num} arguments")
+def count_editor_args(context, num):
+    assert len(context.editor_command) == int(num)
+
+
+@then('the editor arguments should contain "{arg}"')
+def contains_editor_arg(context, arg):
+    assert arg in context.editor_command
 
 
 def _mock_getpass(inputs):

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -194,11 +194,14 @@ def parse_args(args=None):
         help="Opens an interactive interface for deleting entries.",
     )
 
+    if not args:
+        args = []
+
     # Handle '-123' as a shortcut for '-n 123'
     num = re.compile(r"^-(\d+)$")
-    if args is None:
-        args = []
-    return parser.parse_args([num.sub(r"-n \1", a) for a in args])
+    args = [num.sub(r"-n \1", arg) for arg in args]
+
+    return parser.parse_args(args)
 
 
 def guess_mode(args, config):
@@ -300,6 +303,9 @@ def configure_logger(debug=False):
 
 
 def run(manual_args=None):
+    if manual_args is None:
+        manual_args = sys.argv[1:]
+
     args = parse_args(manual_args)
 
     configure_logger(args.debug)

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -197,7 +197,7 @@ def parse_args(args=None):
     # Handle '-123' as a shortcut for '-n 123'
     num = re.compile(r"^-(\d+)$")
     if args is None:
-        args = sys.argv[1:]
+        args = []
     return parser.parse_args([num.sub(r"-n \1", a) for a in args])
 
 

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -9,6 +9,7 @@ from string import punctuation, whitespace
 import subprocess
 import sys
 import tempfile
+import textwrap
 from typing import Callable, Optional
 import unicodedata
 
@@ -172,10 +173,17 @@ def get_text_from_editor(config, template=""):
 
     try:
         subprocess.call(
-            shlex.split(config["editor"], posix="win" not in sys.platform) + [tmpfile]
+            shlex.split(config["editor"], posix="win32" not in sys.platform) + [tmpfile]
         )
-    except AttributeError:
-        subprocess.call(config["editor"] + [tmpfile])
+    except Exception as e:
+        error_msg = f"""
+        {ERROR_COLOR}{str(e)}{RESET_COLOR}
+
+        Please check the 'editor' key in your config file for errors:
+            {repr(config['editor'])}
+        """
+        print(textwrap.dedent(error_msg).strip(), file=sys.stderr)
+        exit(1)
 
     with open(tmpfile, "r", encoding="utf-8") as f:
         raw = f.read()


### PR DESCRIPTION
Fixes #581

When the 'editor' key in the config contains an argument with a space, it used
to be parsed incorrectly. The example given in the linked issue is `vim -f -c
'setf markdown'`, which would have `'setf` and `markdown'` parsed as two
separate arguments. There was a partial fix implemented, but it left out mac
users due to a faulty platform check.

This fixes those problems and adds a test to confirm.

<!--
# **TEMPLATE PLEASE EDIT**
*Thank you for wanting to contribute! Please fill out this description as well
as look at the checklist!*

*Short block of text containing:
- Relevant changes in text form
- related issues
- Motivation (if applicable)
- Example of usage (if applicable)
- Example of changes to config files (if applicable)
*
-->

### Checklist

- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [x] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [x] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [x] Have you written new tests for your core changes, as applicable?