### PR TITLE
Speed up jrnl by 10%, improve slow imports

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -242,6 +242,7 @@ def guess_mode(args, config):
 def encrypt(journal, filename=None):
     """ Encrypt into new file. If filename is not set, we encrypt the journal file itself. """
     from .EncryptedJournal import EncryptedJournal
+
     journal.config["encrypt"] = True
 
     new_journal = EncryptedJournal.from_journal(journal)

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -100,7 +100,7 @@ def load_or_install_jrnl():
             from . import upgrade
 
             try:
-                upgrade.upgrade_jrnl_if_necessary(config_path)
+                upgrade.upgrade_jrnl(config_path)
             except upgrade.UpgradeValidationException:
                 print("Aborting upgrade.", file=sys.stderr)
                 print(

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -98,6 +98,7 @@ def load_or_install_jrnl():
 
         if util.is_old_version(config_path):
             from . import upgrade
+
             try:
                 upgrade.upgrade_jrnl_if_necessary(config_path)
             except upgrade.UpgradeValidationException:

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 
 
-
 FAKE_YEAR = 9999
 DEFAULT_FUTURE = datetime(FAKE_YEAR, 12, 31, 23, 59, 59)
 DEFAULT_PAST = datetime(FAKE_YEAR, 1, 1, 0, 0)
+
 
 def __get_pdt_calendar():
     try:

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -34,12 +34,7 @@ def check_exists(path):
     return os.path.exists(path)
 
 
-def upgrade_jrnl_if_necessary(config_path):
-    with open(config_path, "r", encoding="utf-8") as f:
-        config_file = f.read()
-    if not config_file.strip().startswith("{"):
-        return
-
+def upgrade_jrnl(config_path):
     config = util.load_config(config_path)
 
     print(

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -126,7 +126,7 @@ def load_config(config_path):
 def is_config_json(config_path):
     with open(config_path, "r", encoding="utf-8") as f:
         config_file = f.read()
-    return config_file.strip().startswith("{"):
+    return config_file.strip().startswith("{")
 
 
 def is_old_version(config_path):

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -126,10 +126,7 @@ def load_config(config_path):
 def is_config_json(config_path):
     with open(config_path, "r", encoding="utf-8") as f:
         config_file = f.read()
-    if not config_file.strip().startswith("{"):
-        return False
-
-    return True
+    return config_file.strip().startswith("{"):
 
 
 def is_old_version(config_path):


### PR DESCRIPTION
<!--
# **TEMPLATE PLEASE EDIT**
*Thank you for wanting to contribute! Please fill out this description as well
as look at the checklist!*

*Short block of text containing:
- Relevant changes in text form
- related issues
- Motivation (if applicable)
- Example of usage (if applicable)
- Example of changes to config files (if applicable)
*
-->
Hi!

I noticed, that jrnl starts with a slight delay. I researched code and found some slow and rare **global** imports.
I made rare imports local and added an additional function, which checks version of jrnl.

These improvements have boosted speed by 10% and have boosted python imports by 23%. I used 
`perf stat` and `python3 -X importtime` for analyzing.

Perf stat on the develop branch:
```
[user@pc jrnl]$ echo "" > /home/user/.local/share/jrnl/journal.txt
[user@pc jrnl]$ perf stat -r 100 -d ./run test

 Performance counter stats for './run test' (100 runs):

            254,69 msec task-clock:u              #    0,993 CPUs utilized            ( +-  0,67% )
                 0      context-switches:u        #    0,000 K/sec                  
                 0      cpu-migrations:u          #    0,000 K/sec                  
             3 363      page-faults:u             #    0,013 M/sec                    ( +-  0,05% )
       377 839 305      cycles:u                  #    1,484 GHz                      ( +-  0,34% )  (60,78%)
       485 808 775      instructions:u            #    1,29  insn per cycle           ( +-  0,20% )  (74,92%)
       101 730 359      branches:u                #  399,435 M/sec                    ( +-  0,13% )  (75,89%)
         3 194 572      branch-misses:u           #    3,14% of all branches          ( +-  0,20% )  (76,18%)
       136 039 720      L1-dcache-loads:u         #  534,148 M/sec                    ( +-  0,29% )  (76,24%)
         7 853 820      L1-dcache-load-misses:u   #    5,77% of all L1-dcache hits    ( +-  0,40% )  (76,28%)
         2 254 441      LLC-loads:u               #    8,852 M/sec                    ( +-  0,62% )  (47,87%)
           399 044      LLC-load-misses:u         #   17,70% of all LL-cache hits     ( +-  2,48% )  (47,54%)

           0,25655 +- 0,00190 seconds time elapsed  ( +-  0,74% )
``` 
Perf stat with my improvements:
```
[user@pc jrnl]$ echo "" > /home/user/.local/share/jrnl/journal.txt
[user@pc jrnl]$ perf stat -r 100 -d ./run test

 Performance counter stats for './run test' (100 runs):

            228,56 msec task-clock:u              #    0,993 CPUs utilized            ( +-  0,83% )
                 0      context-switches:u        #    0,000 K/sec                  
                 0      cpu-migrations:u          #    0,000 K/sec                  
             2 981      page-faults:u             #    0,013 M/sec                    ( +-  0,11% )
       337 848 080      cycles:u                  #    1,478 GHz                      ( +-  0,40% )  (60,34%)
       438 910 527      instructions:u            #    1,30  insn per cycle           ( +-  0,22% )  (73,59%)
        90 813 645      branches:u                #  397,327 M/sec                    ( +-  0,18% )  (73,62%)
         2 918 506      branch-misses:u           #    3,21% of all branches          ( +-  0,18% )  (73,74%)
       133 304 455      L1-dcache-loads:u         #  583,232 M/sec                    ( +-  0,37% )  (74,73%)
         6 939 200      L1-dcache-load-misses:u   #    5,21% of all L1-dcache hits    ( +-  0,34% )  (77,41%)
         2 235 461      LLC-loads:u               #    9,781 M/sec                    ( +-  0,36% )  (51,65%)
           510 868      LLC-load-misses:u         #   22,85% of all LL-cache hits     ( +-  0,91% )  (48,84%)

           0,23022 +- 0,00195 seconds time elapsed  ( +-  0,85% )
```

And some screenshots for importtime measures
Develop: https://imgur.com/lk4AslE
My improvements: https://imgur.com/0snmcEo



### Checklist

- [x] The code change is tested and works locally.
- [x] Tests pass. Your PR cannot be merged unless tests pass. --
  `poetry run behave`
- [x] The code passes linting via
  [black](https://black.readthedocs.io/en/stable/) (consistent code styling). --
  `poetry run black --check . --verbose --diff`
- [x] The code passes linting via [pyflakes](https://launchpad.net/pyflakes)
  (logically errors and unused imports). -- `poetry run pyflakes jrnl features`
- [x] There is no commented out code in this PR.
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open
  [Pull Requests](../pulls) for the same update/change?
- [x] Have you added an explanation of what your changes do and why you'd like
  us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
