### PR TITLE
Testing hanging Windows tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - poetry run python --version
 
 script:
-  - poetry run behave --no-capture
+  - poetry run behave
 
 aliases:
   test_mac: &test_mac

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - poetry run python --version
 
 script:
-  - poetry run behave
+  - poetry run behave --no-capture
 
 aliases:
   test_mac: &test_mac

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
   - poetry run python --version
 
 script:
-  - poetry run behave
+  - poetry run behave --no-capture-stderr
 
 aliases:
   test_mac: &test_mac

--- a/features/core.feature
+++ b/features/core.feature
@@ -37,7 +37,6 @@ Feature: Basic reading and writing to a journal
         Given we use the config "editor.yaml"
         When we open the editor and enter nothing
         Then we should see the message "[Nothing saved to file]"
-        Then we should see the message "This test was hanging on Travis"
 
     Scenario: Sending an argument with spaces to the editor should work
         Given we use the config "editor-args.yaml"
@@ -47,7 +46,6 @@ Feature: Basic reading and writing to a journal
         And one editor argument should be "-f"
         And one editor argument should be "-c"
         And one editor argument should match "'?setf markdown'?"
-        Then we should see the message "This test was hanging on Travis"
 
     Scenario: Writing an empty entry from the command line
         Given we use the config "basic.yaml"

--- a/features/core.feature
+++ b/features/core.feature
@@ -33,13 +33,12 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl -n 1"
         Then the output should contain "2013-07-23 09:00 A cold and stormy day."
 
-    @skip_win
     Scenario: Writing an empty entry from the editor
         Given we use the config "editor.yaml"
         When we open the editor and enter nothing
         Then we should see the message "[Nothing saved to file]"
+        Then we should see the message "This test was hanging on Travis"
 
-    @skip_win
     Scenario: Sending an argument with spaces to the editor should work
         Given we use the config "editor-args.yaml"
         When we open the editor and enter "lorem ipsum"
@@ -48,6 +47,7 @@ Feature: Basic reading and writing to a journal
         And one editor argument should be "-f"
         And one editor argument should be "-c"
         And one editor argument should match "'?setf markdown'?"
+        Then we should see the message "This test was hanging on Travis"
 
     Scenario: Writing an empty entry from the command line
         Given we use the config "basic.yaml"

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -95,7 +95,7 @@ def open_editor_and_enter(context, text=""):
 
     with patch("subprocess.call", side_effect=_mock_editor_function):
         print("About to run execute_steps", file=sys.stderr)
-        run(context, "jrnl")
+        context.execute_steps('when we run "jrnl"')
 
 
 @then("the editor should have been called with {num} arguments")

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -95,7 +95,7 @@ def open_editor_and_enter(context, text=""):
 
     with patch("subprocess.call", side_effect=_mock_editor_function):
         print("About to run execute_steps", file=sys.stderr)
-        context.execute_steps('when we run "jrnl"')
+        run_with_input(context, "jrnl")
 
 
 @then("the editor should have been called with {num} arguments")

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -94,6 +94,7 @@ def open_editor_and_enter(context, text=""):
         return tmpfile
 
     with patch("subprocess.call", side_effect=_mock_editor_function):
+        print("About to run execute_steps", file=sys.stderr)
         context.execute_steps('when we run "jrnl"')
 
 
@@ -140,6 +141,8 @@ def _mock_input(inputs):
 @when('we run "{command}" and enter nothing')
 @when('we run "{command}" and enter "{inputs}"')
 def run_with_input(context, command, inputs=""):
+    print("run_with_input", file=sys.stderr)
+
     # create an iterator through all inputs. These inputs will be fed one by one
     # to the mocked calls for 'input()', 'util.getpass()' and 'sys.stdin.read()'
     if context.text:
@@ -156,6 +159,7 @@ def run_with_input(context, command, inputs=""):
          patch("sys.stdin.read", side_effect=text) as mock_read:
 
         try:
+            print(f"cli.run {args}", file=sys.stderr)
             cli.run(args or [])
             context.exit_status = 0
         except SystemExit as e:

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -95,7 +95,7 @@ def open_editor_and_enter(context, text=""):
 
     with patch("subprocess.call", side_effect=_mock_editor_function):
         print("About to run execute_steps", file=sys.stderr)
-        run_with_input(context, "jrnl")
+        run(context, "jrnl")
 
 
 @then("the editor should have been called with {num} arguments")

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -401,6 +401,8 @@ def run(manual_args=None):
         else:
             sys.exit()
 
+    print("still going after mode_compose block", file=sys.stderr)
+
     # Import mode
     if mode_import:
         plugins.get_importer(args.import_).import_(journal, args.input)

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -303,6 +303,8 @@ def configure_logger(debug=False):
 
 
 def run(manual_args=None):
+    print("run", file=sys.stderr)
+
     if manual_args is None:
         manual_args = sys.argv[1:]
 
@@ -345,6 +347,9 @@ def run(manual_args=None):
 
     mode_compose, mode_export, mode_import = guess_mode(args, config)
 
+    print(f"mode_compose: {mode_compose}, mode_export: {mode_export}, mode_import: {mode_import}", file=sys.stderr)
+
+
     # How to quit writing?
     if "win32" in sys.platform:
         _exit_multiline_code = "on a blank line, press Ctrl+Z and then Enter"
@@ -357,6 +362,8 @@ def run(manual_args=None):
     except KeyboardInterrupt:
         print("[Interrupted while opening journal]", file=sys.stderr)
         sys.exit(1)
+
+    print("journal is open", file=sys.stderr)
 
     if mode_compose and not args.text:
         if not sys.stdin.isatty():

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -349,7 +349,6 @@ def run(manual_args=None):
 
     print(f"mode_compose: {mode_compose}, mode_export: {mode_export}, mode_import: {mode_import}", file=sys.stderr)
 
-
     # How to quit writing?
     if "win32" in sys.platform:
         _exit_multiline_code = "on a blank line, press Ctrl+Z and then Enter"
@@ -366,13 +365,18 @@ def run(manual_args=None):
     print("journal is open", file=sys.stderr)
 
     if mode_compose and not args.text:
+        print("mode_compose block", file=sys.stderr)
+
         if not sys.stdin.isatty():
             # Piping data into jrnl
+            print("raw = sys.stdin.read()", file=sys.stderr)
             raw = sys.stdin.read()
         elif config["editor"]:
+            print("config[""editor""]", file=sys.stderr)
             template = ""
             if config["template"]:
                 try:
+                    print("open config", file=sys.stderr)
                     template = open(config["template"]).read()
                 except OSError:
                     print(
@@ -380,6 +384,7 @@ def run(manual_args=None):
                         file=sys.stderr,
                     )
                     sys.exit(1)
+            print("about to get_text_from_editor", file=sys.stderr)
             raw = util.get_text_from_editor(config, template)
         else:
             try:

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -164,6 +164,7 @@ def verify_config(config):
 
 
 def get_text_from_editor(config, template=""):
+    print("get_text_from_editor", file=sys.stderr)
     filehandle, tmpfile = tempfile.mkstemp(prefix="jrnl", text=True, suffix=".txt")
     os.close(filehandle)
 
@@ -172,6 +173,8 @@ def get_text_from_editor(config, template=""):
             f.write(template)
 
     try:
+        print("try subprocess.call in get_text_from_editor", file=sys.stderr)
+        print(shlex.split(config["editor"], posix="win32" not in sys.platform) + [tmpfile])
         subprocess.call(
             shlex.split(config["editor"], posix="win32" not in sys.platform) + [tmpfile]
         )


### PR DESCRIPTION
I'm trying to figure out where a couple tests are causing the Travis Windows build to hang, and a PR build is the most convenient way to do that. I'll remove this PR when I find a solution or give up.

Current strategy:
* Remove the two skip_win directives
* Modify the affected tests so that they fail locally
* Add print tracers to see where it hangs in the Travis build log

### Checklist

- [ ] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have tested this code locally.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have you written new tests for these changes, as needed.
- [ ] All tests pass.
