### PR TITLE
Create directory if it doesn't exist

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -103,3 +103,9 @@ Feature: Basic reading and writing to a journal
         2013-06-10 15:40 Life is good.
         """
         And we should get no error
+
+    Scenario: Journal directory does not exist
+        Given we use the config "missing_directory.yaml"
+        When we run "jrnl Life is good"
+        and we run "jrnl -n 1"
+        Then the output should contain "Life is good"

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -44,7 +44,7 @@ class EncryptedJournal(Journal):
         if not os.path.exists(filename):
             if not os.path.isdir(dirname):
                 os.makedirs(dirname)
-                print(f"[Directory {dirname} created]",file=sys.stderr)
+                print(f"[Directory {dirname} created]", file=sys.stderr)
             self.create_file(filename)
             self.password = util.create_password(self.name)
             print(

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -43,8 +43,8 @@ class EncryptedJournal(Journal):
         dirname = os.path.dirname(filename)
         if not os.path.exists(filename):
             if not os.path.isdir(dirname):
-                os.mkdir(dirname)
-                print(f"[Directory {dirname} created]")
+                os.makedirs(dirname)
+                print(f"[Directory {dirname} created]",file=sys.stderr)
             self.create_file(filename)
             self.password = util.create_password(self.name)
             print(

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -40,8 +40,11 @@ class EncryptedJournal(Journal):
         """Opens the journal file defined in the config and parses it into a list of Entries.
         Entries have the form (date, title, body)."""
         filename = filename or self.config["journal"]
-
+        dirname = os.path.dirname(filename)
         if not os.path.exists(filename):
+            if not os.path.isdir(dirname):
+                print(f"[Directory {dirname} created]")
+                os.mkdir(dirname)
             self.create_file(filename)
             self.password = util.create_password(self.name)
             print(

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -43,8 +43,8 @@ class EncryptedJournal(Journal):
         dirname = os.path.dirname(filename)
         if not os.path.exists(filename):
             if not os.path.isdir(dirname):
-                print(f"[Directory {dirname} created]")
                 os.mkdir(dirname)
+                print(f"[Directory {dirname} created]")
             self.create_file(filename)
             self.password = util.create_password(self.name)
             print(

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -77,8 +77,8 @@ class Journal:
         dirname = os.path.dirname(filename)
         if not os.path.exists(filename):
             if not os.path.isdir(dirname):
-                os.mkdir(dirname)
-                print(f"[Directory {dirname} created]")
+                os.makedirs(dirname)
+                print(f"[Directory {dirname} created]",file=sys.stderr)
             self.create_file(filename)
             print(f"[Journal '{self.name}' created at {filename}]", file=sys.stderr)
 

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -74,8 +74,11 @@ class Journal:
         """Opens the journal file defined in the config and parses it into a list of Entries.
         Entries have the form (date, title, body)."""
         filename = filename or self.config["journal"]
-
+        dirname = os.path.dirname(filename)
         if not os.path.exists(filename):
+            if not os.path.isdir(dirname):
+                print(f"[Directory {dirname} created]")
+                os.mkdir(dirname)
             self.create_file(filename)
             print(f"[Journal '{self.name}' created at {filename}]", file=sys.stderr)
 

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -77,8 +77,8 @@ class Journal:
         dirname = os.path.dirname(filename)
         if not os.path.exists(filename):
             if not os.path.isdir(dirname):
-                print(f"[Directory {dirname} created]")
                 os.mkdir(dirname)
+                print(f"[Directory {dirname} created]")
             self.create_file(filename)
             print(f"[Journal '{self.name}' created at {filename}]", file=sys.stderr)
 

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -78,7 +78,7 @@ class Journal:
         if not os.path.exists(filename):
             if not os.path.isdir(dirname):
                 os.makedirs(dirname)
-                print(f"[Directory {dirname} created]",file=sys.stderr)
+                print(f"[Directory {dirname} created]", file=sys.stderr)
             self.create_file(filename)
             print(f"[Journal '{self.name}' created at {filename}]", file=sys.stderr)
 


### PR DESCRIPTION
This is intended to close #893.
It creates the directory if it does not exist. 

If the directory doesn't exist it now prints:
```
[Directory <directory> created]
[Journal <journal>  created at <filename>]
[Entry added to <journal> journal]
```
The same thing happens right before asking for a password for EncryptedJournals.

### Checklist
- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have you written new tests for these changes, as needed.
- [X] All tests pass.

I can't really make tests for this because it requires a directory that does not exist, and creates one if it doesn't; so the test would fail once and then pass every time after that, which obviously isn't very good. 

