### PR TITLE
Fix set_keychain errors

### DIFF
--- a/features/encryption.feature
+++ b/features/encryption.feature
@@ -55,3 +55,27 @@
             Then the config for journal "simple" should have "encrypt" set to "bool:True"
             When we run "jrnl simple -n 1"
             Then the output should contain "2013-06-10 15:40 Life is good"
+
+        Scenario: Encrypt journal with no keyring backend and do not store in keyring
+            Given we use the config "basic.yaml"
+            When we disable the keychain
+            and we run "jrnl test entry"
+            and we run "jrnl --encrypt" and enter
+            """
+            password
+            password
+            n
+            """
+            Then we should get no error
+
+        Scenario: Encrypt journal with no keyring backend and do store in keyring
+            Given we use the config "basic.yaml"
+            When we disable the keychain
+            and we run "jrnl test entry"
+            and we run "jrnl --encrypt" and enter
+            """
+            password
+            password
+            y
+            """
+            Then we should get no error

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -42,7 +42,7 @@ class TestKeyring(keyring.backend.KeyringBackend):
 
 
 class NoKeyring(keyring.backend.KeyringBackend):
-    """A test keyring that just stores its values in a hash"""
+    """A keyring that simulated an environment with no keyring backend."
 
     priority = 2
     keys = defaultdict(dict)

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -42,7 +42,7 @@ class TestKeyring(keyring.backend.KeyringBackend):
 
 
 class NoKeyring(keyring.backend.KeyringBackend):
-    """A keyring that simulated an environment with no keyring backend."
+    """A keyring that simulated an environment with no keyring backend."""
 
     priority = 2
     keys = defaultdict(dict)

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -40,6 +40,21 @@ class TestKeyring(keyring.backend.KeyringBackend):
     def delete_password(self, servicename, username):
         self.keys[servicename][username] = None
 
+class NoKeyring(keyring.backend.KeyringBackend):
+    """A test keyring that just stores its values in a hash"""
+
+    priority = 2
+    keys = defaultdict(dict)
+
+    def set_password(self, servicename, username, password):
+        raise keyring.errors.NoKeyringError
+
+    def get_password(self, servicename, username):
+        raise keyring.errors.NoKeyringError
+
+    def delete_password(self, servicename, username):
+        raise keyring.errors.NoKeyringError
+
 
 # set the keyring for keyring lib
 keyring.set_keyring(TestKeyring())
@@ -200,6 +215,10 @@ def load_template(context, filename):
 def set_keychain(context, journal, password):
     keyring.set_password("jrnl", journal, password)
 
+
+@when('we disable the keychain')
+def disable_keychain(context):
+    keyring.core.set_keyring(NoKeyring())
 
 @then("we should get an error")
 def has_error(context):

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -40,6 +40,7 @@ class TestKeyring(keyring.backend.KeyringBackend):
     def delete_password(self, servicename, username):
         self.keys[servicename][username] = None
 
+
 class NoKeyring(keyring.backend.KeyringBackend):
     """A test keyring that just stores its values in a hash"""
 
@@ -216,9 +217,10 @@ def set_keychain(context, journal, password):
     keyring.set_password("jrnl", journal, password)
 
 
-@when('we disable the keychain')
+@when("we disable the keychain")
 def disable_keychain(context):
     keyring.core.set_keyring(NoKeyring())
+
 
 @then("we should get an error")
 def has_error(context):

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -60,8 +60,6 @@ def create_password(
 
     if yesno("Do you want to store the password in your keychain?", default=True):
         set_keychain(journal_name, pw)
-    else:
-        pass
     return pw
 
 
@@ -111,7 +109,7 @@ def set_keychain(journal_name, password):
             keyring.set_password("jrnl", journal_name, password)
         except keyring.errors.NoKeyringError:
             print(
-                "Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/"
+                "Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/",file=sys.stderr
             )
 
 

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -110,7 +110,9 @@ def set_keychain(journal_name, password):
         try:
             keyring.set_password("jrnl", journal_name, password)
         except keyring.errors.NoKeyringError:
-            print("Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/")
+            print(
+                "Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/"
+            )
 
 
 def yesno(prompt, default=True):

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -109,7 +109,8 @@ def set_keychain(journal_name, password):
             keyring.set_password("jrnl", journal_name, password)
         except keyring.errors.NoKeyringError:
             print(
-                "Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/",file=sys.stderr
+                "Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/",
+                file=sys.stderr,
             )
 
 

--- a/jrnl/util.py
+++ b/jrnl/util.py
@@ -61,8 +61,7 @@ def create_password(
     if yesno("Do you want to store the password in your keychain?", default=True):
         set_keychain(journal_name, pw)
     else:
-        set_keychain(journal_name, None)
-
+        pass
     return pw
 
 
@@ -108,7 +107,10 @@ def set_keychain(journal_name, password):
         except keyring.errors.PasswordDeleteError:
             pass
     else:
-        keyring.set_password("jrnl", journal_name, password)
+        try:
+            keyring.set_password("jrnl", journal_name, password)
+        except keyring.errors.NoKeyringError:
+            print("Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/")
 
 
 def yesno(prompt, default=True):


### PR DESCRIPTION
This is intended to close #851.

There are two problems with the current keyring system:
1. The program tries to delete a password even if a password hasn't been set yet
2. Disgracefully crashes when there's no keyring backend.

This pull request solves both of those problems. 
Do note that that the new mechanism **does not** exit if a keyring backend is not found. This is because for whatever reason, the password seems to get corrupted/missing after the program crashes due to `keyring.errors.KeyringError`. 

The problem with not exiting is that if the editor is queued to pop up, the user never had an opportunity to see that their password didn't get saved. I would have just asked the user whether they wanted to continue or not, but this leads to the problem of what happens if they Ctrl-C out of that prompt. It also leads to some probably nasty scenario where you'd have to set a flag that we need to quit if the user chooses no, and then somehow finish the program without adding any text. I thought this was far too messy to be worth it.

This is very easy to test for me. The default poetry shell does not have a keyring. Perhaps we should include the `keyrings.cryptfile` package as a dev dependency?
### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have written new tests for these changes, as needed.
- [X] All tests pass.
