### PR TITLE
Ensure test data is always checked out with LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.journal text eol=lf
+*.feature text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.journal text eol=lf


### PR DESCRIPTION
Related to discussion in #962, though not a fix to the original problem.

This PR ensures that all clients are checking out test data with LF line endings. This isn't an issue for *nix users, but many Windows git configurations automatically modify line endings to CRLF due to the `core.autocrlf` setting, which breaks a handful of tests.

In the past (#823) we have gotten around this by ensuring that the setting is set to preserve line endings, but that still imposes a significant barrier for Windows developers, especially since the symptom is so confusing (tests failing without any indication why).

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [n/a] I have you written new tests for these changes, as needed.
- [X] All tests pass.
