### PR TITLE
Fix for hanging Windows tests on Travis

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -45,13 +45,11 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl -n 1"
         Then the output should contain "2013-07-23 09:00 A cold and stormy day."
 
-    @skip_win
     Scenario: Writing an empty entry from the editor
         Given we use the config "editor.yaml"
         When we open the editor and enter nothing
         Then we should see the message "[Nothing saved to file]"
 
-    @skip_win
     Scenario: Sending an argument with spaces to the editor should work
         Given we use the config "editor-args.yaml"
         When we open the editor and enter "lorem ipsum"

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -93,8 +93,14 @@ def open_editor_and_enter(context, text=""):
 
         return tmpfile
 
-    with patch("subprocess.call", side_effect=_mock_editor_function):
+    # fmt: off
+    # see: https://github.com/psf/black/issues/664
+    with \
+        patch("subprocess.call", side_effect=_mock_editor_function), \
+        patch("sys.stdin.isatty", return_value=True) \
+    :
         context.execute_steps('when we run "jrnl"')
+    # fmt: on
 
 
 @then("the editor should have been called with {num} arguments")
@@ -150,11 +156,12 @@ def run_with_input(context, command, inputs=""):
     args = ushlex(command)[1:]
 
     # fmt: off
-    # see: https://github.com/psf/black/issues/557
-    with patch("builtins.input", side_effect=_mock_input(text)) as mock_input, \
-         patch("getpass.getpass", side_effect=_mock_getpass(text)) as mock_getpass, \
-         patch("sys.stdin.read", side_effect=text) as mock_read:
-
+    # see: https://github.com/psf/black/issues/664
+    with \
+        patch("builtins.input", side_effect=_mock_input(text)) as mock_input, \
+        patch("getpass.getpass", side_effect=_mock_getpass(text)) as mock_getpass, \
+        patch("sys.stdin.read", side_effect=text) as mock_read \
+    :
         try:
             cli.run(args or [])
             context.exit_status = 0


### PR DESCRIPTION
This (hopefully) fixes #962 (the hanging tests on Travis).

Co-authored-by: Micah Jerome Ellison <micah.jerome.ellison@gmail.com>

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have you written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->