### PR TITLE
Create journal with absolute path when no path is specified

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -113,14 +113,3 @@ Feature: Basic reading and writing to a journal
         2013-06-10 15:40 Life is good.
         """
         And we should get no error
-
-    Scenario: Install with relative path and view from another directory
-        Given there is no config
-        When we run "jrnl hello world" and enter
-        """
-        test.txt
-        n \n
-        """
-        and we move a directory up
-        and we run "jrnl -n 1"
-        Then the output should contain "hello world"

--- a/features/core.feature
+++ b/features/core.feature
@@ -113,3 +113,14 @@ Feature: Basic reading and writing to a journal
         2013-06-10 15:40 Life is good.
         """
         And we should get no error
+
+    Scenario: Installation with relative journal and referencing from another folder
+        Given we use the config "missingconfig"
+        When we run "jrnl hello world" and enter
+        """
+        test.txt
+        n
+        """
+        and we change directory to "features"
+        and we run "jrnl -n 1"
+        Then the output should contain "hello world"

--- a/features/core.feature
+++ b/features/core.feature
@@ -113,3 +113,14 @@ Feature: Basic reading and writing to a journal
         2013-06-10 15:40 Life is good.
         """
         And we should get no error
+
+    Scenario: Install with relative path and view from another directory
+        Given there is no config
+        When we run "jrnl hello world" and enter
+        """
+        test.txt
+        n \n
+        """
+        and we move a directory up
+        and we run "jrnl -n 1"
+        Then the output should contain "hello world"

--- a/features/environment.py
+++ b/features/environment.py
@@ -2,7 +2,7 @@ import os
 import shutil
 import sys
 
-
+CWD = os.getcwd()
 def clean_all_working_dirs():
     for folder in ("configs", "journals", "cache"):
         working_dir = os.path.join("features", folder)
@@ -26,7 +26,7 @@ def before_scenario(context, scenario):
     """Before each scenario, backup all config and journal test data."""
     # Clean up in case something went wrong
     clean_all_working_dirs()
-
+    CWD = os.getcwd()
     for folder in ("configs", "journals"):
         original = os.path.join("features", "data", folder)
         working_dir = os.path.join("features", folder)
@@ -53,3 +53,5 @@ def before_scenario(context, scenario):
 def after_scenario(context, scenario):
     """After each scenario, restore all test data and remove working_dirs."""
     clean_all_working_dirs()
+    if os.getcwd()!=CWD:
+        os.chdir(CWD)

--- a/features/environment.py
+++ b/features/environment.py
@@ -28,7 +28,6 @@ def before_scenario(context, scenario):
     """Before each scenario, backup all config and journal test data."""
     # Clean up in case something went wrong
     clean_all_working_dirs()
-    CWD = os.getcwd()
     for folder in ("configs", "journals"):
         original = os.path.join("features", "data", folder)
         working_dir = os.path.join("features", folder)

--- a/features/environment.py
+++ b/features/environment.py
@@ -52,6 +52,6 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     """After each scenario, restore all test data and remove working_dirs."""
-    clean_all_working_dirs()
     if os.getcwd()!=CWD:
         os.chdir(CWD)
+    clean_all_working_dirs()

--- a/features/environment.py
+++ b/features/environment.py
@@ -3,6 +3,8 @@ import shutil
 import sys
 
 CWD = os.getcwd()
+
+
 def clean_all_working_dirs():
     for folder in ("configs", "journals", "cache"):
         working_dir = os.path.join("features", folder)
@@ -52,6 +54,6 @@ def before_scenario(context, scenario):
 
 def after_scenario(context, scenario):
     """After each scenario, restore all test data and remove working_dirs."""
-    if os.getcwd()!=CWD:
+    if os.getcwd() != CWD:
         os.chdir(CWD)
     clean_all_working_dirs()

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -79,16 +79,6 @@ def set_config(context, config_file):
         with open(install.CONFIG_FILE_PATH, "a") as cf:
             cf.write("version: {}".format(__version__))
 
-@given('there is no config')
-def no_config(context):
-    nonexistentpath = "features/configs/fake_config.yaml"
-    install.CONFIG_FILE_PATH = os.path.abspath(nonexistentpath)
-    install.CONFIG_FILE_PATH_FALLBACK = os.path.abspath(nonexistentpath)
-
-@when('we move a directory up')
-def move_directory_up(context):
-    os.chdir("..")
-
 
 @when('we open the editor and enter "{text}"')
 @when("we open the editor and enter nothing")

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -79,6 +79,16 @@ def set_config(context, config_file):
         with open(install.CONFIG_FILE_PATH, "a") as cf:
             cf.write("version: {}".format(__version__))
 
+@given('there is no config')
+def no_config(context):
+    nonexistentpath = "features/configs/fake_config.yaml"
+    install.CONFIG_FILE_PATH = os.path.abspath(nonexistentpath)
+    install.CONFIG_FILE_PATH_FALLBACK = os.path.abspath(nonexistentpath)
+
+@when('we move a directory up')
+def move_directory_up(context):
+    os.chdir("..")
+
 
 @when('we open the editor and enter "{text}"')
 @when("we open the editor and enter nothing")

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -79,13 +79,6 @@ def set_config(context, config_file):
         with open(install.CONFIG_FILE_PATH, "a") as cf:
             cf.write("version: {}".format(__version__))
 
-
-@given("there is no config")
-def no_config(context):
-    nopath = "features/configs/missingconfig.yaml"
-    install.CONFIG_FILE_PATH = os.path.abspath(nopath)
-
-
 @when('we change directory to "{path}"')
 def move_up_dir(context, path):
     os.chdir(path)

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -84,7 +84,6 @@ def set_config(context, config_file):
 def no_config(context):
     nopath = "features/configs/missingconfig.yaml"
     install.CONFIG_FILE_PATH = os.path.abspath(nopath)
-    # install.CONFIG_FILE_PATH_FALLBACK = os.path.abspath(nopath)
 
 
 @when('we change directory to "{path}"')

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -79,6 +79,15 @@ def set_config(context, config_file):
         with open(install.CONFIG_FILE_PATH, "a") as cf:
             cf.write("version: {}".format(__version__))
 
+@given('there is no config')
+def no_config(context):
+    nopath = "features/configs/missingconfig.yaml"
+    install.CONFIG_FILE_PATH = os.path.abspath(nopath)
+    #install.CONFIG_FILE_PATH_FALLBACK = os.path.abspath(nopath)
+
+@when('we change directory to "{path}"')
+def move_up_dir(context,path):
+    os.chdir(path)
 
 @when('we open the editor and enter "{text}"')
 @when("we open the editor and enter nothing")

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -79,15 +79,18 @@ def set_config(context, config_file):
         with open(install.CONFIG_FILE_PATH, "a") as cf:
             cf.write("version: {}".format(__version__))
 
-@given('there is no config')
+
+@given("there is no config")
 def no_config(context):
     nopath = "features/configs/missingconfig.yaml"
     install.CONFIG_FILE_PATH = os.path.abspath(nopath)
-    #install.CONFIG_FILE_PATH_FALLBACK = os.path.abspath(nopath)
+    # install.CONFIG_FILE_PATH_FALLBACK = os.path.abspath(nopath)
+
 
 @when('we change directory to "{path}"')
-def move_up_dir(context,path):
+def move_up_dir(context, path):
     os.chdir(path)
+
 
 @when('we open the editor and enter "{text}"')
 @when("we open the editor and enter nothing")

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -79,6 +79,7 @@ def set_config(context, config_file):
         with open(install.CONFIG_FILE_PATH, "a") as cf:
             cf.write("version: {}".format(__version__))
 
+
 @when('we change directory to "{path}"')
 def move_up_dir(context, path):
     os.chdir(path)

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -135,7 +135,7 @@ def install():
 
     # Where to create the journal?
     path_query = f"Path to your journal file (leave blank for {JOURNAL_FILE_PATH}): "
-    journal_path = os.path.abspath(input(path_query).strip()) or JOURNAL_FILE_PATH
+    journal_path = os.path.abspath(input(path_query).strip() or JOURNAL_FILE_PATH)
     default_config["journals"][DEFAULT_JOURNAL_KEY] = os.path.expanduser(
         os.path.expandvars(journal_path)
     )

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -135,7 +135,7 @@ def install():
 
     # Where to create the journal?
     path_query = f"Path to your journal file (leave blank for {JOURNAL_FILE_PATH}): "
-    journal_path = input(path_query).strip() or JOURNAL_FILE_PATH
+    journal_path = os.path.abspath(input(path_query).strip()) or JOURNAL_FILE_PATH
     default_config["journals"][DEFAULT_JOURNAL_KEY] = os.path.expanduser(
         os.path.expandvars(journal_path)
     )


### PR DESCRIPTION
Intended to close #860.

During installation, make sure the journal path is added to the config as an absolute path. I think prepending `~/` as @micahellison mentioned is very unexpected. 

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have you written new tests for these changes, as needed.
- [X] All tests pass.
