### PR TITLE
Add tags to json and xml exporters

### DIFF
--- a/features/exporting.feature
+++ b/features/exporting.feature
@@ -9,6 +9,8 @@ Feature: Exporting a Journal
         And "tags" in the json output should contain "@idea"
         And "tags" in the json output should contain "@journal"
         And "tags" in the json output should contain "@dan"
+        And entry 1 should have an array called "tags" with 2 elements
+        And entry 2 should have an array called "tags" with 2 elements
 
     Scenario: Exporting using filters should only export parts of the journal
         Given we use the config "tags.yaml"

--- a/features/exporting.feature
+++ b/features/exporting.feature
@@ -9,8 +9,8 @@ Feature: Exporting a Journal
         And "tags" in the json output should contain "@idea"
         And "tags" in the json output should contain "@journal"
         And "tags" in the json output should contain "@dan"
-        And entry 1 should have an array called "tags" with 2 elements
-        And entry 2 should have an array called "tags" with 2 elements
+        And entry 1 should have an array "tags" with 2 elements
+        And entry 2 should have an array "tags" with 2 elements
 
     Scenario: Exporting using filters should only export parts of the journal
         Given we use the config "tags.yaml"

--- a/features/exporting.feature
+++ b/features/exporting.feature
@@ -89,6 +89,7 @@ Feature: Exporting a Journal
         Then the output should be a valid XML string
         And "entries" node in the xml output should have 2 elements
         And "tags" in the xml output should contain ["@idea", "@journal", "@dan"]
+        And there should be 7 "tag" elements
 
     Scenario: Exporting tags
         Given we use the config "tags.yaml"

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -52,12 +52,16 @@ def check_json_output_path(context, path, value):
             struct = struct[node]
     assert struct == value, struct
 
-@then('entry {entry_number:d} should have an array called "{name}" with {items_number:d} elements')
-def entry_array_count(context,entry_number,name,items_number):
-    #note that entry_number is 1-indexed.
+
+@then(
+    'entry {entry_number:d} should have an array called "{name}" with {items_number:d} elements'
+)
+def entry_array_count(context, entry_number, name, items_number):
+    # note that entry_number is 1-indexed.
     out = context.stdout_capture.getvalue()
     out_json = json.loads(out)
-    assert len(out_json["entries"][entry_number-1][name])==items_number
+    assert len(out_json["entries"][entry_number - 1][name]) == items_number
+
 
 @then("the output should be a valid XML string")
 def assert_valid_xml_string(context):
@@ -77,11 +81,12 @@ def assert_xml_output_entries_count(context, item, number):
     actual_entry_count = len(xml_tree.find(item))
     assert actual_entry_count == number, actual_entry_count
 
+
 @then('there should be {number:d} "{item}" elements')
-def count_elements(context,number,item):
+def count_elements(context, number, item):
     output = context.stdout_capture.getvalue()
     xml_tree = ElementTree.fromstring(output)
-    assert len(xml_tree.findall(".//"+item))==number
+    assert len(xml_tree.findall(".//" + item)) == number
 
 
 @then('"tags" in the xml output should contain {expected_tags_json_list}')

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -60,16 +60,22 @@ def assert_valid_xml_string(context):
     assert xml_tree, output
 
 
-@then('"entries" node in the xml output should have {number:d} elements')
-def assert_xml_output_entries_count(context, number):
+@then('"{item}" node in the xml output should have {number:d} elements')
+def assert_xml_output_entries_count(context, item, number):
     output = context.stdout_capture.getvalue()
     xml_tree = ElementTree.fromstring(output)
 
     xml_tags = (node.tag for node in xml_tree)
-    assert "entries" in xml_tags, str(list(xml_tags))
+    assert item in xml_tags, str(list(xml_tags))
 
-    actual_entry_count = len(xml_tree.find("entries"))
+    actual_entry_count = len(xml_tree.find(item))
     assert actual_entry_count == number, actual_entry_count
+
+@then('there should be {number:d} "{item}" elements')
+def count_elements(context,number,item):
+    output = context.stdout_capture.getvalue()
+    xml_tree = ElementTree.fromstring(output)
+    assert len(xml_tree.findall(".//"+item))==number
 
 
 @then('"tags" in the xml output should contain {expected_tags_json_list}')

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -52,6 +52,12 @@ def check_json_output_path(context, path, value):
             struct = struct[node]
     assert struct == value, struct
 
+@then('entry {entry_number:d} should have an array called "{name}" with {items_number:d} elements')
+def entry_array_count(context,entry_number,name,items_number):
+    #note that entry_number is 1-indexed.
+    out = context.stdout_capture.getvalue()
+    out_json = json.loads(out)
+    assert len(out_json["entries"][entry_number-1][name])==items_number
 
 @then("the output should be a valid XML string")
 def assert_valid_xml_string(context):

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -54,7 +54,7 @@ def check_json_output_path(context, path, value):
 
 
 @then(
-    'entry {entry_number:d} should have an array called "{name}" with {items_number:d} elements'
+    'entry {entry_number:d} should have an array "{name}" with {items_number:d} elements'
 )
 def entry_array_count(context, entry_number, name, items_number):
     # note that entry_number is 1-indexed.

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -20,6 +20,7 @@ class JSONExporter(TextExporter):
             "body": entry.body,
             "date": entry.date.strftime("%Y-%m-%d"),
             "time": entry.date.strftime("%H:%M"),
+            "tags": entry.tags,
             "starred": entry.starred,
         }
         if hasattr(entry, "uuid"):

--- a/jrnl/plugins/xml_exporter.py
+++ b/jrnl/plugins/xml_exporter.py
@@ -35,6 +35,11 @@ class XMLExporter(JSONExporter):
         if hasattr(entry, "uuid"):
             entry_el.setAttribute("uuid", entry.uuid)
         entry_el.setAttribute("starred", entry.starred)
+        tags = entry.tags
+        for tag in tags:
+            tag_el = doc.createElement("tag")
+            tag_el.setAttribute("name", tag)
+            entry_el.appendChild(tag_el)
         entry_el.appendChild(doc.createTextNode(entry.fulltext))
         return entry_el
 


### PR DESCRIPTION
This is intended to close #974.

It is nice to have the tags separately by entry rather than just a frequency chart which is somewhat useless except for perhaps interesting statistics.
The only exporters that support this kind of structure is JSON, XML, and YAML. YAML already has this feature.
This PR adds individually tagged entries for both xml and json. 

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have you written new tests for these changes, as needed.
- [X] All tests pass.