### PR TITLE
Add --diagnostic argument

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -130,3 +130,8 @@ Feature: Basic reading and writing to a journal
         and we change directory to "features"
         and we run "jrnl -n 1"
         Then the output should contain "hello world"
+
+    Scenario: --diagnostic runs without exceptions
+        When we run "jrnl --diagnostic"
+        Then the output should contain "jrnl"
+        And the output should contain "Python"

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -21,6 +21,7 @@
 
 import argparse
 import logging
+import platform
 import re
 import sys
 
@@ -43,6 +44,14 @@ def parse_args(args=None):
         action="store_true",
         help="prints version information and exits",
     )
+
+    parser.add_argument(
+        "--diagnostic",
+        dest="diagnostic",
+        action="store_true",
+        help="outputs diagnostic information and exits",
+    )
+
     parser.add_argument(
         "-ls", dest="ls", action="store_true", help="displays accessible journals"
     )
@@ -313,6 +322,14 @@ def run(manual_args=None):
     if args.version:
         version_str = f"{jrnl.__title__} version {jrnl.__version__}"
         print(version_str)
+        sys.exit(0)
+
+    if args.diagnostic:
+        print(
+            f"jrnl: {jrnl.__version__}\n"
+            f"Python: {sys.version}\n"
+            f"OS: {platform.system()} {platform.release()}"
+        )
         sys.exit(0)
 
     try:


### PR DESCRIPTION
Adds a `--diagnostic` argument that outputs the jrnl version, Python version, and OS version.

After this is released, there should be a follow-up PR to change the bug issue template to mention this argument.

Fixes #727.

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have written new tests for these changes, as needed.
- [X] All tests pass.
