### PR TITLE
Rename master branch to release

### DIFF
--- a/.build/generate_changelog.sh
+++ b/.build/generate_changelog.sh
@@ -2,7 +2,7 @@
 
 BRANCH=$TRAVIS_BRANCH
 if [[ $TRAVIS_BRANCH == $TRAVIS_TAG ]]; then
-  BRANCH='master'
+  BRANCH='release'
 fi
 
 # Check if branch has been updated since this build started
@@ -39,7 +39,7 @@ elif [[ ! -z $TRAVIS_TAG ]]; then
   echo "beta elease"
   gittag=${release_latest}
 else
-  echo "merge into master or develop"
+  echo "merge into release or develop"
   gittag=${release_latest}
 fi
 echo "gittag: ${gittag}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ You will need to install [poetry](https://poetry.eustace.io/) to develop jrnl. I
 jrnl uses two primary branches:
 
  * `develop` - for ongoing development
- * `master` - for releases
+ * `release` - for releases
 
 In general, pull requests should be made on the `develop` branch.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-jrnl [![Build Status](https://travis-ci.com/jrnl-org/jrnl.svg?branch=master)](https://travis-ci.com/jrnl-org/jrnl) [![Downloads](https://pepy.tech/badge/jrnl)](https://pepy.tech/project/jrnl) [![Version](http://img.shields.io/pypi/v/jrnl.svg?style=flat)](https://pypi.python.org/pypi/jrnl/)
+jrnl [![Build Status](https://travis-ci.com/jrnl-org/jrnl.svg?branch=release)](https://travis-ci.com/jrnl-org/jrnl) [![Downloads](https://pepy.tech/badge/jrnl)](https://pepy.tech/project/jrnl) [![Version](http://img.shields.io/pypi/v/jrnl.svg?style=flat)](https://pypi.python.org/pypi/jrnl/)
 ====
 
 _To get help, [submit an issue](https://github.com/jrnl-org/jrnl/issues/new) on


### PR DESCRIPTION
Fixes #983

There's an industry-wide trend to move away from terms that invoke master/slave
relationships to be slightly more welcoming to members of marginalized populations.
Also, it's already not our main branch anyway, and "release" makes it more clear what
it's for.

I know this doesn't do much to help in the grand scheme of things, but it's a tiny
effortless change, so why not?

That being said, if anyone reading this has any ideas how this project can help make
people from these populations more comfortable, or help in anyway, please let us know.
Feel free to [file a public issue](https://github.com/jrnl-org/jrnl/issues/new/choose), or privately [email the maintainers](mailto:jrnl-sh@googlegroups.com).


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [n/a] I have written new tests for these changes, as needed.
- [n/a] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->