### PR TITLE
Make behave output more concise when running make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ lint: ## Check style with various tools
 
 test: lint ## Run unit tests and behave tests
 	poetry run pytest
-	poetry run behave
+	poetry run behave --no-skipped --format progress2
 
 build:
 	poetry build


### PR DESCRIPTION
Hides successful tests from the output of the behave command in the makefile. Test output is now a lot easier to read through, and the tests run faster on slow terminals such as cmd.exe.

Co-authored-by: @wren 

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- n/a I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- n/a I have written new tests for these changes, as needed.
- [X] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
