### PR TITLE
Display warning if Python version is less than 3.7

### DIFF
--- a/features/core.feature
+++ b/features/core.feature
@@ -138,4 +138,4 @@ Feature: Basic reading and writing to a journal
 
     Scenario: Version warning appears for versions below 3.7
         When we run "jrnl --diagnostic"
-        Then the Python version warning should appear if our version is below "3.7"
+        Then the Python version warning should appear if our version is below 3.7

--- a/features/core.feature
+++ b/features/core.feature
@@ -135,3 +135,7 @@ Feature: Basic reading and writing to a journal
         When we run "jrnl --diagnostic"
         Then the output should contain "jrnl"
         And the output should contain "Python"
+
+    Scenario: Version warning appears for versions below 3.7
+        When we run "jrnl --diagnostic"
+        Then the Python version warning should appear if our version is below "3.7"

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -381,10 +381,7 @@ def check_python_warning_if_version_low_enough(context, version):
         version
     ):
         out = context.stderr_capture.getvalue()
-        assert (
-            "THIS SHOULD FAIL ON 3.6 REMOVE WHEN CONFIRMING - WARNING: Python versions"
-            in out
-        )
+        assert "WARNING: Python versions" in out
     else:
         assert True
 

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -371,6 +371,17 @@ def list_journal_directory(context, journal="default"):
         for file in f:
             print(os.path.join(root, file))
 
+@then("the Python version warning should appear if our version is below {version}")
+def check_python_warning_if_version_low_enough(context, version):
+    import packaging.version
+    import platform
+
+    if packaging.version.parse(platform.python_version()) < packaging.version.parse(version):
+        out = context.stderr_capture.getvalue()
+        assert "THIS SHOULD FAIL ON 3.6 REMOVE WHEN CONFIRMING - WARNING: Python versions" in out
+    else:
+        assert True
+
 
 @then("fail")
 def debug_fail(context):

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -371,14 +371,20 @@ def list_journal_directory(context, journal="default"):
         for file in f:
             print(os.path.join(root, file))
 
+
 @then("the Python version warning should appear if our version is below {version}")
 def check_python_warning_if_version_low_enough(context, version):
     import packaging.version
     import platform
 
-    if packaging.version.parse(platform.python_version()) < packaging.version.parse(version):
+    if packaging.version.parse(platform.python_version()) < packaging.version.parse(
+        version
+    ):
         out = context.stderr_capture.getvalue()
-        assert "THIS SHOULD FAIL ON 3.6 REMOVE WHEN CONFIRMING - WARNING: Python versions" in out
+        assert (
+            "THIS SHOULD FAIL ON 3.6 REMOVE WHEN CONFIRMING - WARNING: Python versions"
+            in out
+        )
     else:
         assert True
 

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -314,8 +314,13 @@ def configure_logger(debug=False):
 
 
 def run(manual_args=None):
-    if packaging.version.parse(platform.python_version()) < packaging.version.parse('3.7'):
-        print("WARNING: Python versions below 3.7 are not supported by jrnl\n", file=sys.stderr)
+    if packaging.version.parse(platform.python_version()) < packaging.version.parse(
+        "3.7"
+    ):
+        print(
+            "WARNING: Python versions below 3.7 are not supported by jrnl\n",
+            file=sys.stderr,
+        )
 
     if manual_args is None:
         manual_args = sys.argv[1:]

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -21,6 +21,7 @@
 
 import argparse
 import logging
+import packaging.version
 import platform
 import re
 import sys
@@ -313,6 +314,9 @@ def configure_logger(debug=False):
 
 
 def run(manual_args=None):
+    if packaging.version.parse(platform.python_version()) < packaging.version.parse('3.7'):
+        print("WARNING: Python versions below 3.7 are not supported by jrnl\n", file=sys.stderr)
+
     if manual_args is None:
         manual_args = sys.argv[1:]
 

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -30,7 +30,7 @@ import jrnl
 
 from . import install, plugins, util
 from .Journal import PlainJournal, open_journal
-from .util import ERROR_COLOR, RESET_COLOR, UserAbort
+from .util import WARNING_COLOR, ERROR_COLOR, RESET_COLOR, UserAbort
 
 log = logging.getLogger(__name__)
 logging.getLogger("keyring.backend").setLevel(logging.ERROR)
@@ -318,7 +318,11 @@ def run(manual_args=None):
         "3.7"
     ):
         print(
-            "WARNING: Python versions below 3.7 are not supported by jrnl\n",
+            f"""{WARNING_COLOR}
+WARNING: Python versions below 3.7 will no longer be supported as of jrnl v2.5
+(the next release). You are currently on Python {platform.python_version()}. Please update to
+Python 3.7 (or higher) soon.
+{RESET_COLOR}""",
             file=sys.stderr,
         )
 


### PR DESCRIPTION
Fixes #992. Shows a warning in STDERR if the user's Python version is less than 3.7:
```
WARNING: Python versions below 3.7 are not supported by jrnl
```

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
