### PR TITLE
Add new documentation issue type to github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,31 @@
+---
+name: Documentation Change
+about: Request or report any updates to our documentation (https://jrnl.sh)
+title: ''
+labels: ":new:, Documentation"
+assignees: ''
+
+---
+
+## Documentation Change
+<!--
+Hello, and thank you for reporting an issue!
+Please fill out the points below, as it will make our process much easier.
+-->
+
+### Affected Page(s)
+<!--
+Please tell us which page, or pages, from the documentation site (https://jrnl.sh) are
+affected in this issue
+-->
+  - <!-- example: https://jrnl.sh/overview -->
+
+### What's wrong?
+<!--
+Please write a short description of what is happening.
+-->
+
+### Other Information
+<!--
+Is there anything else we should know that might be helpful?
+-->


### PR DESCRIPTION
We've gotten a few issues lately where people point out problems with the documentation.
This is good! We like to hear about these issues. Our current issue types don't really
have a good place to enter documentation issues, though, so this adds a new type to
better encourage more people to file these types of issues.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->