### PR TITLE
Allow editing of DayOne entries

### DIFF
--- a/features/data/configs/dayone.yaml
+++ b/features/data/configs/dayone.yaml
@@ -1,10 +1,9 @@
 default_hour: 9
 default_minute: 0
-editor: ''
+editor: noop
 template: false
 encrypt: false
 highlight: true
-editor: noop
 journals:
   default: features/journals/dayone.dayone
 linewrap: 80

--- a/features/data/configs/dayone.yaml
+++ b/features/data/configs/dayone.yaml
@@ -4,6 +4,7 @@ editor: ''
 template: false
 encrypt: false
 highlight: true
+editor: noop
 journals:
   default: features/journals/dayone.dayone
 linewrap: 80

--- a/features/dayone.feature
+++ b/features/dayone.feature
@@ -75,3 +75,9 @@ Feature: Dayone specific implementation details.
         and the json output should contain entries.0.creator.generation_date
         and the json output should contain entries.0.creator.device_agent
         and "entries.0.creator.software_agent" in the json output should contain "jrnl"
+
+    Scenario: Editing Dayone with mock editor
+        Given we use the config "dayone.yaml"
+        When we run "jrnl --edit"
+        Then we should get no error
+

--- a/features/dayone.feature
+++ b/features/dayone.feature
@@ -81,3 +81,15 @@ Feature: Dayone specific implementation details.
         When we run "jrnl --edit"
         Then we should get no error
 
+    Scenario: Editing Dayone entries
+        Given we use the config "dayone.yaml"
+        When we open the editor and append
+            """
+            Here is the first line.
+            Here is the second line.
+            """
+        When we run "jrnl -n 1"
+        Then we should get no error
+        and the output should contain "This entry is starred!"
+        and the output should contain "Here is the first line"
+        and the output should contain "Here is the second line"

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -209,8 +209,13 @@ def run(context, command, cache_dir=None):
 
     args = ushlex(command)
 
+    def _mock_editor(command):
+        context.editor_command = command
+
     try:
-        with patch("sys.argv", args):
+        with patch("sys.argv", args), patch(
+            "subprocess.call", side_effect=_mock_editor
+        ):
             cli.run(args[1:])
             context.exit_status = 0
     except SystemExit as e:

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -222,7 +222,6 @@ class DayOne(Journal.Journal):
 
         # Now, update our current entries if they changed
         for entry in entries:
-            entry._parse_text()
             matched_entries = [
                 e for e in self.entries if e.uuid.lower() == entry.uuid.lower()
             ]

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -13,7 +13,9 @@ class Entry:
         self.journal = journal  # Reference to journal mainly to access its config
         self.date = date or datetime.now()
         self.text = text
-        self._title = self._body = self._tags = None
+        self._title = None
+        self._body = None
+        self._tags = None
         self.starred = starred
         self.modified = False
 
@@ -37,17 +39,29 @@ class Entry:
             self._parse_text()
         return self._title
 
+    @title.setter
+    def title(self, x):
+        self._title = x
+
     @property
     def body(self):
         if self._body is None:
             self._parse_text()
         return self._body
 
+    @body.setter
+    def body(self, x):
+        self._body = x
+
     @property
     def tags(self):
         if self._tags is None:
             self._parse_text()
         return self._tags
+
+    @tags.setter
+    def tags(self, x):
+        self._tags = x
 
     @staticmethod
     def tag_regex(tagsymbols):


### PR DESCRIPTION
Fixes #955


DayOneJournal previously reimplemented Journal._parse inside of DayOneJournal.parse_editable_string, and in doing so caused issues between the two classes (the body was being reparsed for a title, overwriting the title, and essentially dropping the first line of each edited entry). This commit fixes the issue by moving the UUID to be in the body of the entry, rather than above it. Doing this allows us to use Journal._parse like normal (it still finds the correct boundaries between entries), and then DayOneJournal parses the UUID afterward.

Co-authored-by: [MinchinWeb](https://github.com/minchinweb)
Co-authored-by: [Micah Jerome Ellison](https://github.com/micahellison)

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->