### PR TITLE
Add missing dependency (packaging)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -314,7 +314,7 @@ tgrep = ["pyparsing"]
 twitter = ["twython"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
@@ -420,7 +420,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.2.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python parsing module"
 name = "pyparsing"
 optional = false
@@ -602,7 +602,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "72b606d9ecfdfe78e24c580ac0a4fd9e78823fdd63be714da316cbb55fc7f037"
+content-hash = "7501ac8306b65f63e3e470a35e25dd9d3d8c911c21b3a9d61a267e3945f4c1e5"
 python-versions = ">=3.6.0, <3.9.0"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ colorama = "^0.4.1"
 python-dateutil = "^2.8"
 pyyaml = "^5.1"
 ansiwrap = "^0.8.4"
+packaging = "^20.4"
 
 [tool.poetry.dev-dependencies]
 behave = "^1.2"


### PR DESCRIPTION
Fixes #1010

`packaging` was missing from our latest release (only included in our dev dependencies). Our tests missed it because they all have dev deps installed. This PR adds the missing dep, and we'll deal with the test suite separately.


### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->