### PR TITLE
Add support for Python 3.9 build testing

### DIFF
--- a/.build/allow_all_python_version.py
+++ b/.build/allow_all_python_version.py
@@ -1,0 +1,8 @@
+import toml
+
+pyproject = toml.load("pyproject.toml")
+
+pyproject['tool']['poetry']['dependencies']['python'] = "*"
+
+with open("pyproject.toml", "w") as toml_file:
+	toml.dump(pyproject, toml_file)

--- a/.build/allow_all_python_version.py
+++ b/.build/allow_all_python_version.py
@@ -2,7 +2,7 @@ import toml
 
 pyproject = toml.load("pyproject.toml")
 
-pyproject['tool']['poetry']['dependencies']['python'] = "*"
+pyproject["tool"]["poetry"]["dependencies"]["python"] = "*"
 
 with open("pyproject.toml", "w") as toml_file:
-	toml.dump(pyproject, toml_file)
+    toml.dump(pyproject, toml_file)

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,12 +44,13 @@ aliases:
     os: windows
     language: shell
     env: &env_windows
-      PATH: /c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:$PATH
+      PATH: /c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:/c/Python39:/c/Python39/Scripts:$PATH
       PYTHONIOENCODING: UTF-8
     cache:
       directories:
         - /c/Python37
         - /c/Python38
+        - /c/Python39
         - /c/ProgramData/chocolatey/lib
         - /c/ProgramData/chocolatey/bin
         - /c/Users/travis/AppData/Local/pypoetry/Cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,10 +131,11 @@ jobs:
       name: Python 3.9 on Windows
       before_install:
         - choco install python --pre
-        - C:\ProgramData\chocolatey\bin\python3 -m pip install --upgrade pip
+        - ls C:/ProgramData/chocolatey/bin/
+        - C:/ProgramData/chocolatey/bin/python -m pip install --upgrade pip
         - pip --version
         - pip install toml
-        - C:\ProgramData\chocolatey\bin\python3 .build/allow_all_python_version.py
+        - C:/ProgramData/chocolatey/bin/python3 .build/allow_all_python_version.py
       env:
         <<: *env_windows
         JRNL_PYTHON_VERSION: 3.9.0b5

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,20 +110,26 @@ jobs:
 
     # Python 3.9 Dev Tests
     - name: Python 3.9 on Linux
-      before_install:
+      script:
         - python .build/allow_all_python_version.py
+        - poetry run pytest
+        - poetry run behave
       python: 3.9-dev
     - <<: *test_mac
       name: Python 3.9 on MacOS
-      before_install:
+      script:
         - python .build/allow_all_python_version.py
+        - poetry run pytest
+        - poetry run behave
       python: 3.9-dev
       env:
         JRNL_PYTHON_VERSION: 3.9.0b5
     - <<: *test_windows
       name: Python 3.9 on Windows
-      before_install:
+      script:
         - python .build/allow_all_python_version.py
+        - poetry run pytest
+        - poetry run behave
       python: 3.9-dev
       env:
         <<: *env_windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,14 +108,20 @@ jobs:
 
     # Python 3.9 Dev Tests
     - name: Python 3.9 on Linux
+      before_install:
+        - sed -i 's/^python = ">=3\.7\.0.*"$/python = "*"/' pyproject.toml
       python: 3.9-dev
     - <<: *test_mac
       name: Python 3.9 on MacOS
+      before_install:
+        - sed -i 's/^python = ">=3\.7\.0.*"$/python = "*"/' pyproject.toml
       python: 3.9-dev
       env:
         JRNL_PYTHON_VERSION: 3.9.0b5
     - <<: *test_windows
       name: Python 3.9 on Windows
+      before_install:
+        - powershell -Command "(gc pyproject.toml) -replace 'python = "">=3.7.0, <3.9.0""', 'python = "">=3.7.0, <3.10.0""' | Out-File -encoding UTF8 pyproject.toml"
       python: 3.9-dev
       env:
         <<: *env_windows
@@ -124,7 +130,7 @@ jobs:
     # ... and beyond!
     - name: Python nightly on Linux
       before_install:
-        - sed -i 's/^python = ">=3\.6\.0.*"$/python = "*"/' pyproject.toml
+        - sed -i 's/^python = ">=3\.7\.0.*"$/python = "*"/' pyproject.toml
       python: nightly
 
     # Specialty tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,26 +110,23 @@ jobs:
 
     # Python 3.9 Dev Tests
     - name: Python 3.9 on Linux
-      script:
+      before_install:
+        - pip install toml
         - python .build/allow_all_python_version.py
-        - poetry run pytest
-        - poetry run behave
       python: 3.9-dev
     - <<: *test_mac
       name: Python 3.9 on MacOS
-      script:
+      before_install:
+        - pip install toml
         - python .build/allow_all_python_version.py
-        - poetry run pytest
-        - poetry run behave
       python: 3.9-dev
       env:
         JRNL_PYTHON_VERSION: 3.9.0b5
     - <<: *test_windows
       name: Python 3.9 on Windows
-      script:
+      before_install:
+        - pip install toml
         - python .build/allow_all_python_version.py
-        - poetry run pytest
-        - poetry run behave
       python: 3.9-dev
       env:
         <<: *env_windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,17 +117,23 @@ jobs:
     - <<: *test_mac
       name: Python 3.9 on MacOS
       before_install:
+        - eval "$(pyenv init -)"
+        - pyenv install -s $JRNL_PYTHON_VERSION
+        - pyenv global $JRNL_PYTHON_VERSION
+        - pip install --upgrade pip
+        - pip --version
         - pip install toml
         - python .build/allow_all_python_version.py
-      python: 3.9-dev
       env:
         JRNL_PYTHON_VERSION: 3.9.0b5
     - <<: *test_windows
       name: Python 3.9 on Windows
       before_install:
+        - choco install python --pre
+        - python -m pip install --upgrade pip
+        - pip --version
         - pip install toml
         - python .build/allow_all_python_version.py
-      python: 3.9-dev
       env:
         <<: *env_windows
         JRNL_PYTHON_VERSION: 3.9.0b5

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,11 +131,13 @@ jobs:
       name: Python 3.9 on Windows
       before_install:
         - choco install python --pre
-        - ls C:/ProgramData/chocolatey/bin/
-        - C:/ProgramData/chocolatey/bin/python -m pip install --upgrade pip
+        - C:/ProgramData/chocolatey/bin/python --version
+        - curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py
+        - C:/ProgramData/chocolatey/bin/python get-pip.py
+        - rm get-pip.py
         - pip --version
         - pip install toml
-        - C:/ProgramData/chocolatey/bin/python3 .build/allow_all_python_version.py
+        - C:/ProgramData/chocolatey/bin/python .build/allow_all_python_version.py
       env:
         <<: *env_windows
         JRNL_PYTHON_VERSION: 3.9.0b5

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,9 @@ aliases:
 jobs:
   fast_finish: true
   allow_failures:
-    - python: 3.9-dev
+    - name: Python 3.9 on Windows
+    - name: Python 3.9 on Linux
+    - name: Python 3.9 on MacOS
     - python: nightly
 
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ aliases:
 jobs:
   fast_finish: true
   allow_failures:
-    - python: 3.9
+    - python: 3.9-dev
     - python: nightly
 
   include:
@@ -121,7 +121,7 @@ jobs:
     - <<: *test_windows
       name: Python 3.9 on Windows
       before_install:
-        - powershell -Command "(gc pyproject.toml) -replace 'python = "">=3.7.0, <3.9.0""', 'python = "">=3.7.0, <3.10.0""' | Out-File -encoding UTF8 pyproject.toml"
+        - powershell -Command "(gc pyproject.toml) -replace 'python = "">=3.7.0, <3.9.0""', 'python = "">=3.7.0, <3.10.0""' -join \"`n\" | Out-File -encoding UTF8 pyproject.toml"
       python: 3.9-dev
       env:
         <<: *env_windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,6 +132,7 @@ jobs:
       before_install:
         - choco install python --pre
         - python --version
+        - pip install --upgrade pip
         - pip --version
         - pip install toml
         - python .build/allow_all_python_version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,12 +131,7 @@ jobs:
       name: Python 3.9 on Windows
       before_install:
         - choco install python --pre
-        - ls /c/
-        #- C:/ProgramData/chocolatey/bin/python --version # this doesn't work - it's Python 2.7
         - python --version
-        - curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py
-        - python get-pip.py
-        - rm get-pip.py
         - pip --version
         - pip install toml
         - python .build/allow_all_python_version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ aliases:
 jobs:
   fast_finish: true
   allow_failures:
+    - python: 3.9
     - python: nightly
 
   include:
@@ -104,6 +105,21 @@ jobs:
       env:
         <<: *env_windows
         JRNL_PYTHON_VERSION: 3.8.2
+
+    # Python 3.9 Dev Tests
+    - name: Python 3.9 on Linux
+      python: 3.9-dev
+    - <<: *test_mac
+      name: Python 3.9 on MacOS
+      python: 3.9-dev
+      env:
+        JRNL_PYTHON_VERSION: 3.9.0b5
+    - <<: *test_windows
+      name: Python 3.9 on Windows
+      python: 3.9-dev
+      env:
+        <<: *env_windows
+        JRNL_PYTHON_VERSION: 3.9.0b5
 
     # ... and beyond!
     - name: Python nightly on Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,7 @@ jobs:
     # ... and beyond!
     - name: Python nightly on Linux
       before_install:
-        - sed -i 's/^python = ">=3\.7\.0.*"$/python = "*"/' pyproject.toml
+        - python .build/allow_all_python_version.py
       python: nightly
 
     # Specialty tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,6 +130,7 @@ jobs:
       name: Python 3.9 on Windows
       before_install:
         - choco install python --pre
+        - refreshenv
         - python -m pip install --upgrade pip
         - pip --version
         - pip install toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,6 +117,7 @@ jobs:
     - <<: *test_mac
       name: Python 3.9 on MacOS
       before_install:
+        - brew upgrade pyenv
         - eval "$(pyenv init -)"
         - pyenv install -s $JRNL_PYTHON_VERSION
         - pyenv global $JRNL_PYTHON_VERSION
@@ -130,11 +131,10 @@ jobs:
       name: Python 3.9 on Windows
       before_install:
         - choco install python --pre
-        - refreshenv
-        - python -m pip install --upgrade pip
+        - C:\ProgramData\chocolatey\bin\python3 -m pip install --upgrade pip
         - pip --version
         - pip install toml
-        - python .build/allow_all_python_version.py
+        - C:\ProgramData\chocolatey\bin\python3 .build/allow_all_python_version.py
       env:
         <<: *env_windows
         JRNL_PYTHON_VERSION: 3.9.0b5

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,19 +111,19 @@ jobs:
     # Python 3.9 Dev Tests
     - name: Python 3.9 on Linux
       before_install:
-        - sed -i 's/^python = ">=3\.7\.0.*"$/python = "*"/' pyproject.toml
+        - python .build/allow_all_python_version.py
       python: 3.9-dev
     - <<: *test_mac
       name: Python 3.9 on MacOS
       before_install:
-        - sed -i 's/^python = ">=3\.7\.0.*"$/python = "*"/' pyproject.toml
+        - python .build/allow_all_python_version.py
       python: 3.9-dev
       env:
         JRNL_PYTHON_VERSION: 3.9.0b5
     - <<: *test_windows
       name: Python 3.9 on Windows
       before_install:
-        - powershell -Command "(gc pyproject.toml) -replace 'python = "">=3.7.0, <3.9.0""', 'python = "">=3.7.0, <3.10.0""' -join \"`n\" | Out-File -encoding UTF8 pyproject.toml"
+        - python .build/allow_all_python_version.py
       python: 3.9-dev
       env:
         <<: *env_windows

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,10 @@ aliases:
     os: windows
     language: shell
     env: &env_windows
-      PATH: /c/Python36:/c/Python36/Scripts:/c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:$PATH
+      PATH: /c/Python37:/c/Python37/Scripts:/c/Python38:/c/Python38/Scripts:$PATH
       PYTHONIOENCODING: UTF-8
     cache:
       directories:
-        - /c/Python36
         - /c/Python37
         - /c/Python38
         - /c/ProgramData/chocolatey/lib
@@ -131,7 +130,8 @@ jobs:
       name: Python 3.9 on Windows
       before_install:
         - choco install python --pre
-        #- C:/ProgramData/chocolatey/bin/python --version # this doesn't work - 2.7
+        - ls /c/
+        #- C:/ProgramData/chocolatey/bin/python --version # this doesn't work - it's Python 2.7
         - python --version
         - curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py
         - python get-pip.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,13 +131,14 @@ jobs:
       name: Python 3.9 on Windows
       before_install:
         - choco install python --pre
-        - C:/ProgramData/chocolatey/bin/python --version
+        #- C:/ProgramData/chocolatey/bin/python --version # this doesn't work - 2.7
+        - python --version
         - curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py
-        - C:/ProgramData/chocolatey/bin/python get-pip.py
+        - python get-pip.py
         - rm get-pip.py
         - pip --version
         - pip install toml
-        - C:/ProgramData/chocolatey/bin/python .build/allow_all_python_version.py
+        - python .build/allow_all_python_version.py
       env:
         <<: *env_windows
         JRNL_PYTHON_VERSION: 3.9.0b5

--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ jobs:
       before_install:
         - choco install python --pre
         - python --version
-        - pip install --upgrade pip
+        - python -m pip install --upgrade pip
         - pip --version
         - pip install toml
         - python .build/allow_all_python_version.py


### PR DESCRIPTION
First step of #1017 - add build steps for Python 3.9 in Travis. Allowing failures for now, until 3.9 is stable.

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [n/a] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [n/a] I have written new tests for these changes, as needed.
- [n/a] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
