### PR TITLE
Update github issue templates to use new diagnostic command

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,9 +15,8 @@ Please fill out the points below, as it will make our process much easier.
 
 <!-- Please tell us about your environment -->
 ### Environment
-  - Jrnl version: <!-- Run `jrnl -v` -->
+  - Jrnl `--diagnostic` output: <!-- Run `jrnl --diagnostic` and paste the output -->
   - Install method: <!-- How did you install jrnl? (pipx, brew, etc) -->
-  - OS <!-- What is your operating system? (MacOS, Linux, Windows) -->
 
 ### Current Behavior
 <!--

--- a/.github/ISSUE_TEMPLATE/support_request.md
+++ b/.github/ISSUE_TEMPLATE/support_request.md
@@ -17,9 +17,8 @@ Please fill out the points below, as it will make our process much easier.
 <!--
 Please tell us about your environment
 -->
-  - Jrnl version: <!-- Run `jrnl -v` -->
+  - Jrnl `--diagnostic` output: <!-- Run `jrnl --diagnostic` and paste the output -->
   - Install method: <!-- How did you install jrnl? (pipx, brew, etc) -->
-  - OS <!-- What is your operating system? (MacOS, Linux, Windows) -->
 
 ### What are you trying to do?
 <!--


### PR DESCRIPTION
Closes #727

This is the last step of #727. The command has been released, so this just asks users to run `jrnl --diagnostic` when submitting issues.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [ ] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->