### PR TITLE
Change styling of terminal on docs site, small copy changes

### DIFF
--- a/docs/theme/index.css
+++ b/docs/theme/index.css
@@ -65,18 +65,18 @@ header {
     border: 0px solid transparent;
     display: relative;
     padding-top: 150px;
-    overflow: hidden;
+    overflow: visible;
 }
 
 #terminal {
     background: #1B1C2E;
     max-width: 520px;
     box-shadow: 0 -2px 16px 0 rgba(0,0,0,0.35);
-    border-radius: 6px 6px 0 0;
-    min-height: 100px;
+    border-radius: 6px;
+    min-height: 120px;
     margin: 0px auto;
     position: relative;
-    /*transform: translateY(40px);*/
+    transform: translateY(75px);
     color: #f7f8f9;
     font-family: "Monaco", "Courier New";
     font-size: 12pt;
@@ -146,7 +146,7 @@ header {
 
 #prompt {
     max-width: 700px;
-    margin: 100px auto 0px auto;
+    margin: 25px auto 100px auto;
     padding: 0px 20px;
 }
 

--- a/docs/theme/index.html
+++ b/docs/theme/index.html
@@ -75,12 +75,12 @@
             <section>
                 <i class="icon secure"></i>
                 <h3>Secure.</h3>
-                <p>Encrypt your journals with the industry-strength AES encryption. The NSA won't be able to read your dirty secrets.</p>
+                <p>Encrypt your journals with industry-strength AES encryption. The NSA won't be able to read your dirty secrets.</p>
             </section>
             <section>
                 <i class="icon sync"></i>
                 <h3>Accessible anywhere.</h3>
-                <p>Sync your journals with Dropbox and capture your thoughts where ever you are</p>
+                <p>Sync your journals with Dropbox and capture your thoughts where ever you are.</p>
             </section>
             <section>
                 <i class="icon github"></i>
@@ -106,8 +106,8 @@
             "jrnl <b>-from</b> 2009 <b>-until</b> may<br /><i>`(Displays all entries from January 2009 to last may)`</i>",
             "jrnl A day on the beach with @beth and @frank. Taggidy-tag-tag.",
             "jrnl <b>--tags</b><br /><i>`@idea    7<br />@beth    5</i>`",
-            "jrnl <b>--export</b> json<br /><i>`(Exports your entire journal to json)</i>`",
-            "jrnl <b>--encrypt</b><br /><i>`(256 bit AES encryption. Crack this, NSA)</i>`"
+            "jrnl <b>--format</b> json<br /><i>`(Outputs your entire journal as json)</i>`",
+            "jrnl <b>--encrypt</b><br /><i>`(AES encryption. Crack this, NSA)</i>`"
         ],
         typeSpeed: 35,
         backSpeed: 15,


### PR DESCRIPTION
The terminal now overlaps the header (the purple area at the top of the page) and the main area (the white area underneath). This draws more focus to it, and quite literally puts the terminal front and center.

This also fixes a few typos, and updates the commands in the terminal to match jrnl v2.5 updates.

There's no issue for this, because writing up an issue for it would have taken longer than just doing it. You can see the styling changes on readthedocs below. Let me know if you think this is not a good styling change!


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->