### PR TITLE
Fix "Edit on GitHub" button on docs site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ extra_css:
 markdown_extensions:
   - admonition
 repo_url: https://github.com/jrnl-org/jrnl/
+edit_uri: edit/develop/docs/
 site_author: Manuel Ebert
 site_description: Collect your thoughts and notes without leaving the command line.
 nav:


### PR DESCRIPTION
"Edit on GitHub" doesn't work on the docs site. This should fix it.

Fixes #1039.
