### PR TITLE
Add punctuation more commonly used in Asian languages (ellipsis) to sentence parsing

### DIFF
--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -202,7 +202,7 @@ class Entry:
 SENTENCE_SPLITTER = re.compile(
     r"""
 (                       # A sentence ends at one of two sequences:
-    [.!?\u203C\u203D\u2047\u2048\u2049\u3002\uFE52\uFE57\uFF01\uFF0E\uFF1F\uFF61]                # Either, a sequence starting with a sentence terminal,
+    [.!?\u2026\u203C\u203D\u2047\u2048\u2049\u22EF\u3002\uFE52\uFE57\uFF01\uFF0E\uFF1F\uFF61]                # Either, a sequence starting with a sentence terminal,
     [\'\u2019\"\u201D]? # an optional right quote,
     [\]\)]*             # optional closing brackets and
     \s+                 # a sequence of required spaces.


### PR DESCRIPTION
Ellipsis is used to terminate sentences in Chinese and used a lot at end of title.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
