### PR TITLE
Use strict date matching, if using the default time format

### DIFF
--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -31,6 +31,7 @@ class Journal:
             "default_hour": 9,
             "default_minute": 0,
             "timeformat": "%Y-%m-%d %H:%M",
+            "timeformat_strict": False,
             "tagsymbols": "@",
             "highlight": True,
             "linewrap": 80,
@@ -129,9 +130,12 @@ class Journal:
 
         date_blob_re = re.compile("(?:^|\n)\\[([^\\]]+)\\] ")
 
-        # Use strict date matching, if using the default time format
+        # Use strict date matching
+        # (1) if using the default time format, and
+        # (2) if timeformat_strict is set to true.
         if self.config["timeformat"] == "%Y-%m-%d %H:%M":
-            date_blob_re = re.compile("(?:^|\n)\\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\\] ")
+            if self.config["timeformat_strict"]:
+                date_blob_re = re.compile("(?:^|\n)\\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\\] ")
 
         last_entry_pos = 0
         for match in date_blob_re.finditer(journal_txt):

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -128,6 +128,11 @@ class Journal:
         entries = []
 
         date_blob_re = re.compile("(?:^|\n)\\[([^\\]]+)\\] ")
+
+        # Use strict date matching, if using the default time format
+        if self.config["timeformat"] == '%Y-%m-%d %H:%M':
+            date_blob_re = re.compile("(?:^|\n)\\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\\] ")
+
         last_entry_pos = 0
         for match in date_blob_re.finditer(journal_txt):
             date_blob = match.groups()[0]

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -130,7 +130,7 @@ class Journal:
         date_blob_re = re.compile("(?:^|\n)\\[([^\\]]+)\\] ")
 
         # Use strict date matching, if using the default time format
-        if self.config["timeformat"] == '%Y-%m-%d %H:%M':
+        if self.config["timeformat"] == "%Y-%m-%d %H:%M":
             date_blob_re = re.compile("(?:^|\n)\\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\\] ")
 
         last_entry_pos = 0

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -135,7 +135,9 @@ class Journal:
         # (2) if timeformat_strict is set to true.
         if self.config["timeformat"] == "%Y-%m-%d %H:%M":
             if self.config["timeformat_strict"]:
-                date_blob_re = re.compile("(?:^|\n)\\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\\] ")
+                date_blob_re = re.compile(
+                    "(?:^|\n)\\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2})\\] "
+                )
 
         last_entry_pos = 0
         for match in date_blob_re.finditer(journal_txt):


### PR DESCRIPTION
### Description

- What is this new code intended to do?

After updating to v2, I noticed the bug described here: https://github.com/jrnl-org/jrnl/issues/625

jrnl version v2.4.5

Using this configuration:
```
(jrnl-hIZQiBQS-py3.8) ➜  jrnl git:(develop) cat ~/.config/jrnl/jrnl.yaml
colors:
  body: none
  date: none
  tags: none
  title: none
default_hour: 9
default_minute: 0
editor: 'atom'
encrypt: false
highlight: true
indent_character: '|'
journals:
  default: ~/notes/journal.txt
  home: ~/notes/home.txt
  test: ~/notes/test.txt
linewrap: 79
tagsymbols: '@'
template: false
timeformat: '%Y-%m-%d %H:%M'
version: v2.4.5
```

I'm doing my test on the "test" journal, which starts out like this:
```
[2020-09-10 19:47] Here is a chat log
[26/11, 23:32] Someone: chat line.
```

Before the patch: the second line is incorrectly parsed as a new entry.
```
(jrnl-hIZQiBQS-py3.8) ➜  jrnl git:(develop) ✗ jrnl test --short
2020-09-10 19:47 Here is a chat log
2020-09-10 23:32 Someone: chat line.
```

After the patch: as long as the default time format is unchanged, the second line is correctly interpreted as part of the first entry.
```
(jrnl-hIZQiBQS-py3.8) ➜  jrnl git:(develop) jrnl test --short
2020-09-10 19:47 Here is a chat log
```

- Are there any related issues?

https://github.com/jrnl-org/jrnl/issues/630
https://github.com/jrnl-org/jrnl/issues/625

- What is the motivation for this change?

I love to use jrnl as a notepad for when I am dealing with server downtime.
When I'm doing that, I often edit my jrnl directly and paste large amounts of server logs there.
Those log entries all start with an opening square bracket and usually have some sort of date.

My motivation:
I accept this is not a full solution to the problem, and it will only help those who do not change the default time format.
For people who do stick to the default, I think jrnl should try its best to parse the date string at the beginning of an entry strictly.
That "fixes the bug" for the majority of users, and solves my problem.
Of course, if my log file entries have the same time format as jrnl, then jrnl will parse those log file entries as new jrnl entries.
That's fine, because the default jrnl time format is '%Y-%m-%d %H:%M' and most log entries are accurate to the second or millisecond.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
(I'm a new contributor, I'm not sure how to test, so I will submit the PR and see what happens)
