### PR TITLE
Disable logging by default

### DIFF
--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -24,8 +24,12 @@ from .args import parse_args
 
 
 def configure_logger(debug=False):
+    if not debug:
+        logging.disable()
+        return
+
     logging.basicConfig(
-        level=logging.DEBUG if debug else logging.ERROR,
+        level=logging.DEBUG,
         format="%(levelname)-8s %(name)-12s %(message)s",
     )
     logging.getLogger("parsedatetime").setLevel(logging.INFO)

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -29,8 +29,7 @@ def configure_logger(debug=False):
         return
 
     logging.basicConfig(
-        level=logging.DEBUG,
-        format="%(levelname)-8s %(name)-12s %(message)s",
+        level=logging.DEBUG, format="%(levelname)-8s %(name)-12s %(message)s",
     )
     logging.getLogger("parsedatetime").setLevel(logging.INFO)
     logging.getLogger("keyring.backend").setLevel(logging.ERROR)


### PR DESCRIPTION
Fixes #1048.

This disables all logging unless the `--debug` flag is given



<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [n/a] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->