### PR TITLE
Add circle ci config file for linux tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,102 @@
+version: 2.1
+
+executors:
+  python37:
+    docker:
+      - image: circleci/python:3.7.9
+    resource_class: small
+  python38:
+    docker:
+      - image: circleci/python:3.8.6
+    resource_class: small
+  python39:
+    docker:
+      - image: circleci/python:3.9.0
+    resource_class: small
+
+aliases:
+  linux_test: &linux_test
+    steps:
+      - checkout
+      - run:
+          name: Checking Python version
+          command: python --version > /tmp/pythonversion
+      - restore_cache:
+          key: 'deps-00-{{ checksum "poetry.lock" }}-{{ checksum "/tmp/pythonversion" }}'
+      - run:
+          name: Installing dependencies
+          command: |
+            poetry config --local virtualenvs.in-project true
+            poetry install --no-root --remove-untracked
+      - save_cache:
+          key: 'deps-00-{{ checksum "poetry.lock" }}-{{ checksum "/tmp/pythonversion" }}'
+          paths:
+            - ~/project/.venv
+      - run: poetry install
+      - run:
+          name: Tests - Pytest
+          when: always
+          command: >
+            poetry run pytest
+            --junitxml=reports/pytest/results.xml
+      - run:
+          name: Tests - Behave
+          when: always
+          command: >
+            poetry run behave
+            --no-skipped
+            --format progress2
+            --junit
+            --junit-directory reports/behave
+      - store_test_results:
+          path: reports
+
+jobs:
+  linux_test_37:
+    executor: python37
+    <<: *linux_test
+
+  linux_test_38:
+    executor: python38
+    <<: *linux_test
+
+  linux_test_39:
+    executor: python39
+    <<: *linux_test
+
+  lint:
+    executor: python39
+    steps:
+      - checkout
+      - run: python --version > /tmp/pythonversion
+      - restore_cache:
+          key: 'deps-00-{{ checksum "poetry.lock" }}-{{ checksum "/tmp/pythonversion" }}'
+      - run: poetry config --local virtualenvs.in-project true
+      - run: poetry install --no-root --remove-untracked
+      - save_cache:
+          key: 'deps-00-{{ checksum "poetry.lock" }}-{{ checksum "/tmp/pythonversion" }}'
+          paths:
+            - ~/project/.venv
+      - run:
+          name: Poetry Check
+          command: |
+            poetry --version
+            poetry check
+      - run:
+          name: Black Code Formatter
+          command: |
+            poetry run black --version
+            poetry run black --check --diff .
+      - run:
+          name: PyFlakes
+          command: |
+            poetry run pyflakes --version
+            poetry run pyflakes jrnl features tests
+
+workflows:
+  main:
+    jobs:
+      - lint
+      - linux_test_37
+      - linux_test_38
+      - linux_test_39

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ commands:
     steps:
       - run:
           name: Tests - Pytest
+          when: always
           command: >
             poetry run pytest
             --junitxml=reports/pytest/results.xml
@@ -46,6 +47,7 @@ commands:
     steps:
       - run:
           name: Tests - Behave
+          when: always
           command: >
             poetry run behave
             --no-skipped
@@ -57,16 +59,19 @@ commands:
     steps:
       - run:
           name: Poetry Check
+          when: always
           command: |
             poetry --version
             poetry check
       - run:
           name: Black Code Formatter
+          when: always
           command: |
             poetry run black --version
             poetry run black --check --diff .
       - run:
           name: PyFlakes
+          when: always
           command: |
             poetry run pyflakes --version
             poetry run pyflakes jrnl features tests
@@ -77,10 +82,8 @@ aliases:
       - checkout
       - get_poetry_deps
       - run: poetry install
-      - pytest:
-          when: always
-      - behave:
-          when: always
+      - pytest
+      - behave
       - store_test_results:
           path: reports
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,20 @@ executors:
     docker:
       - image: circleci/python:3.7.9
     resource_class: small
+
   python38:
     docker:
       - image: circleci/python:3.8.6
     resource_class: small
+
   python39:
     docker:
       - image: circleci/python:3.9.0
     resource_class: small
 
-aliases:
-  linux_test: &linux_test
+commands:
+  get_poetry_deps:
     steps:
-      - checkout
       - run:
           name: Checking Python version
           command: python --version > /tmp/pythonversion
@@ -32,51 +33,28 @@ aliases:
           key: 'deps-00-{{ checksum "poetry.lock" }}-{{ checksum "/tmp/pythonversion" }}'
           paths:
             - ~/project/.venv
-      - run: poetry install
+
+  pytest:
+    steps:
       - run:
           name: Tests - Pytest
-          when: always
           command: >
             poetry run pytest
             --junitxml=reports/pytest/results.xml
+
+  behave:
+    steps:
       - run:
           name: Tests - Behave
-          when: always
           command: >
             poetry run behave
             --no-skipped
             --format progress2
             --junit
             --junit-directory reports/behave
-      - store_test_results:
-          path: reports
-
-jobs:
-  linux_test_37:
-    executor: python37
-    <<: *linux_test
-
-  linux_test_38:
-    executor: python38
-    <<: *linux_test
-
-  linux_test_39:
-    executor: python39
-    <<: *linux_test
 
   lint:
-    executor: python39
     steps:
-      - checkout
-      - run: python --version > /tmp/pythonversion
-      - restore_cache:
-          key: 'deps-00-{{ checksum "poetry.lock" }}-{{ checksum "/tmp/pythonversion" }}'
-      - run: poetry config --local virtualenvs.in-project true
-      - run: poetry install --no-root --remove-untracked
-      - save_cache:
-          key: 'deps-00-{{ checksum "poetry.lock" }}-{{ checksum "/tmp/pythonversion" }}'
-          paths:
-            - ~/project/.venv
       - run:
           name: Poetry Check
           command: |
@@ -93,10 +71,48 @@ jobs:
             poetry run pyflakes --version
             poetry run pyflakes jrnl features tests
 
+aliases:
+  linux_test: &linux_test
+    steps:
+      - checkout
+      - get_poetry_deps
+      - run: poetry install
+      - pytest:
+          when: always
+      - behave:
+          when: always
+      - store_test_results:
+          path: reports
+
+jobs:
+  test_37_linux:
+    executor: python37
+    <<: *linux_test
+
+  test_38_linux:
+    executor: python38
+    <<: *linux_test
+
+  test_39_linux:
+    executor: python39
+    <<: *linux_test
+
+  linting:
+    executor: python39
+    steps:
+      - checkout
+      - get_poetry_deps
+      - lint
+
 workflows:
+  version: 2
   main:
     jobs:
-      - lint
-      - linux_test_37
-      - linux_test_38
-      - linux_test_39
+      - linting:
+          name: Linting and Formatting
+      - test_37_linux:
+          name: Python 3.7 - Linux
+      - test_38_linux:
+          name: Python 3.8 - Linux
+      - test_39_linux:
+          name: Python 3.9 - Linux


### PR DESCRIPTION
Starting work on #1060

This adds the circle ci config file, and runs linux tests, and linting (no mac or windows, yet).

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->