### PR TITLE
Add PyPI classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,11 @@ license = "GPL-3.0-only"
 readme = "README.md"
 homepage = "https://jrnl.sh"
 repository = "https://github.com/jrnl-org/jrnl"
+classifiers = [
+    "Topic :: Office/Business :: News/Diary",
+    "Environment :: Console",
+    "Operating System :: OS Independent"
+]
 
 [tool.poetry.dependencies]
 python = ">=3.7.0, <3.10.0"


### PR DESCRIPTION
PyPI uses classifiers to help people find projects and perhaps to run stats by category. I think jrnl used to have classifiers in the past, but we lost them during the migration to poetry last year.

poetry already automatically updates the classifiers for the version and license, but this PR applies the following three classifiers that I think are relevant to our project:

 * Topic :: Office/Business :: News/Diary
 * Environment :: Console
 * Operating System :: OS Independent

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
