### PR TITLE
Make changelog auto exclude stale and wontfix issues

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -4,6 +4,7 @@ base=CHANGELOG.md
 issues=true
 issues-wo-labels=false
 include-labels=bug,enhancement,documentation,build,deprecated
+exclude-labels=stale,wontfix
 release-url=https://pypi.org/project/jrnl/%s/
 add-sections={ "build": { "prefix": "**Build:**", "labels": ["build"]}, "docs": { "prefix": "**Updated documentation:**", "labels": ["documentation"]}}
 exclude-tags-regex=(alpha|beta|rc)


### PR DESCRIPTION
Stales out issues were getting included in the changelog. This PR stops that.


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->