### PR TITLE
Fix Unicode encoding failure in directory export when creating filenames from journal titles with certain characters

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -78,5 +78,5 @@ jobs:
           git config user.name "Jrnl Bot"
           git add "$FILENAME"
           git commit -m "Update changelog"
-          git push origin $BRANCH
+          git push https://${JRNL_BOT_TOKEN}@github.com/jrnl-org/jrnl.git $BRANCH
 

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -82,5 +82,5 @@ jobs:
           git config user.name "Jrnl Bot"
           git add "$FILENAME"
           git commit -m "Update changelog"
-          git push https://${JRNL_BOT_TOKEN}@github.com/jrnl-org/jrnl.git $BRANCH
+          git push origin $BRANCH
 

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -56,6 +56,7 @@ jobs:
           excludeLabels: stale,wontfix
           excludeTagsRegex: '(alpha|beta|rc)'
           sinceTag: ${{ env.gittag }}
+          maxIssues: 150
           releaseUrl: https://pypi.org/project/jrnl/%s/
           verbose: false
 

--- a/features/format.feature
+++ b/features/format.feature
@@ -536,3 +536,21 @@ Feature: Custom formats
             [2013-06-10 15:40] Life is good.
             But I'm better.
             """
+
+    Scenario Outline: Exporting entries with Cyrillic characters to directory should not fail
+        Given we use the config "<config>.yaml"
+        And we use the password "test" if prompted
+        And we create a cache directory
+        When we run "jrnl 2020-11-21: Первая"
+        When we run "jrnl --format md --file {cache_dir} -on 2020-11-21"
+        Then the cache should contain the files
+        """
+        2020-11-21_первая.md
+        """
+
+        Examples: configs
+        | config          |
+        | basic_onefile   |
+        | basic_encrypted |
+        | basic_folder    |
+        | basic_dayone    |

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -37,8 +37,8 @@ class TextExporter:
 
     @classmethod
     def make_filename(cls, entry):
-        return entry.date.strftime(
-            "%Y-%m-%d_{}.{}".format(cls._slugify(str(entry.title)), cls.extension)
+        return entry.date.strftime("%Y-%m-%d") + "_{}.{}".format(
+            cls._slugify(str(entry.title)), cls.extension
         )
 
     @classmethod


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
Fixes #1089.

It turns out that `strftime` doesn't play nicely with all Unicode characters. I think this is a Windows-specific issue, but I'm not sure, and we're testing on all platforms anyway. This PR modifies the directory export's file name builder to use `strftime` to handle only the date part of the filename, then append the rest of the string, which may contain just about any character.

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have written new tests for these changes, as needed.
- [X] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
