### PR TITLE
Add ability to put --edit partly through a cli entry to move it to the editor

### DIFF
--- a/features/write.feature
+++ b/features/write.feature
@@ -43,6 +43,26 @@ Feature: Writing new entries.
         | dayone       |
         | encrypted    |
 
+    Scenario Outline: Writing a partial entry from command line with edit flag should go to the editor
+        Given we use the config "<config_file>.yaml"
+        And we use the password "test" if prompted
+        When we run "jrnl this is a partial --edit"
+        Then we should see the message "Entry added"
+        Then the editor should have been called
+        And the editor file content should be
+        """
+        this is a partial
+        """
+        When we run "jrnl -n 1"
+        Then the output should contain "this is a partial"
+
+        Examples: configs
+        | config_file     |
+        | basic_onefile   |
+        | basic_encrypted |
+        | basic_dayone    |
+        | basic_folder    |
+
     Scenario Outline: Writing an empty entry from the editor should yield "Nothing saved to file" message
         Given we use the config "<config_file>.yaml"
         And we use the password "test" if prompted

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -83,6 +83,10 @@ def _is_write_mode(args, config, **kwargs):
         )
     )
 
+    # Might be writing and want to move to editor part of the way through
+    if args.edit and args.text:
+        write_mode = True
+
     # If the text is entirely tags, then we are also searching (not writing)
     if (
         write_mode
@@ -108,6 +112,8 @@ def write_mode(args, config, journal, **kwargs):
     if args.text:
         logging.debug("Write mode: cli text detected: %s", args.text)
         raw = " ".join(args.text).strip()
+        if args.edit:
+            raw = _write_in_editor(config, raw)
 
     elif not sys.stdin.isatty():
         logging.debug("Write mode: receiving piped text")
@@ -157,10 +163,11 @@ def search_mode(args, journal, **kwargs):
         _display_search_results(**kwargs)
 
 
-def _write_in_editor(config):
+def _write_in_editor(config, template=None):
     if config["editor"]:
         logging.debug("Write mode: opening editor")
-        template = _get_editor_template(config)
+        if not template:
+            template = _get_editor_template(config)
         raw = get_text_from_editor(config, template)
 
     else:


### PR DESCRIPTION
Fixes #906

Also add some functionality to test suite to see what the editor file contents were and make assertions about it.


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->