### PR TITLE
Add fix for changelog conditional always returning false

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -127,6 +127,8 @@ jobs:
           fi
           SOMETHING_CHANGED=false
           git diff --exit-code || SOMETHING_CHANGED=true
+          echo "::debug::SOMETHING_CHANGED: $SOMETHING_CHANGED"
+          echo "SOMETHING_CHANGED=$SOMETHING_CHANGED" >> $GITHUB_ENV
 
       - name: Commit
         if: env.SOMETHING_CHANGED


### PR DESCRIPTION
The changelog generator check to see if anything changed from `git diff` was always returning false. This was because the env var was being set, but not exported to the github file that subsequent steps need to see the correct value. This fixes that, and the changelog generator should run again.

Example of the workflow running successfully:
https://github.com/wren/jrnl/runs/1468224087?check_suite_focus=true

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [n/a] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->