### PR TITLE
Check for readline module instead of Windows when initializing autocomplete in install

### DIFF
--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -12,13 +12,8 @@ from . import __version__
 from .config import load_config
 from .config import verify_config_colors
 from .exception import UserAbort
-from .os_compat import on_windows
 from .prompt import yesno
 from .upgrade import is_old_version
-
-if not on_windows:
-    # readline is not included in Windows Active Python
-    import readline
 
 DEFAULT_CONFIG_NAME = "jrnl.yaml"
 DEFAULT_JOURNAL_NAME = "journal.txt"
@@ -127,10 +122,7 @@ def load_or_install_jrnl():
 
 
 def install():
-    if not on_windows:
-        readline.set_completer_delims(" \t\n;")
-        readline.parse_and_bind("tab: complete")
-        readline.set_completer(_autocomplete_path)
+    _initialize_autocomplete()
 
     # Where to create the journal?
     path_query = f"Path to your journal file (leave blank for {JOURNAL_FILE_PATH}): "
@@ -157,6 +149,16 @@ def install():
 
     save_config(default_config)
     return default_config
+
+
+def _initialize_autocomplete():
+    # readline is not included in Windows Active Python and perhaps some other distributions
+    if sys.modules.get("readline"):
+        import readline
+
+        readline.set_completer_delims(" \t\n;")
+        readline.parse_and_bind("tab: complete")
+        readline.set_completer(_autocomplete_path)
 
 
 def _autocomplete_path(text, state):

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,13 @@
+from unittest import mock
+import pytest
+import sys
+
+
+@pytest.mark.filterwarnings(
+    "ignore:.*imp module is deprecated.*"
+)  # ansiwrap spits out an unrelated warning
+def test_initialize_autocomplete_runs_without_readline():
+    from jrnl import install
+
+    with mock.patch.dict(sys.modules, {"readline": None}):
+        install._initialize_autocomplete()  # should not throw exception


### PR DESCRIPTION
Fixes #1015 and should now prevent crashes on install for ActivePython users that aren't on Windows. We haven't seen this `readline` issue as much lately, and unfortunately I can't reproduce every environment in which it happens, but this should hopefully mitigate the problem further, and the unit test offers some peace of mind.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
