### PR TITLE
Add automatic deployment for homebrew releases (and prereleases)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,7 @@ jobs:
     - name: Validate version
       run: |
         JRNL_VERSION="${{ github.event.inputs.version }}"
+        echo "::debug::version: $JRNL_VERSION"
         if [[ ! $JRNL_VERSION =~ ^v[0-9]+(\.[0-9]+){1,2}(-(alpha|beta)(\.[0-9]+)?)?$ ]]; then
           echo
           echo "::error::Bad version"
@@ -29,13 +30,15 @@ jobs:
           echo "  v2.5.1-beta"
           exit 1
         fi
-        echo "::debug::version: $JRNL_VERSION"
-        echo "JRNL_VERSION=$JRNL_VERSION" >> $GITHUB_ENV
 
   release_pypi:
     needs: validate
     name: "Release to PyPI"
     runs-on: ubuntu-latest
+    outputs:
+      pypi_version: ${{ steps.pypi-version-getter.outputs.pypi_version }}
+    env:
+      HOME_REPO: ${{ secrets.HOME_REPO }}
     steps:
     - name: Get version
       run: |
@@ -48,9 +51,15 @@ jobs:
       with:
         python-version: 3.9
 
-    - uses: actions/checkout@v2
+    - name: Checkout repo
+      uses: actions/checkout@v2
       with:
         token: ${{ secrets.JRNL_BOT_TOKEN }}
+
+    - name: Config git user
+      run: |
+        git config --global user.name "${{ secrets.JRNL_BOT_NAME }}"
+        git config --global user.email "${{ secrets.JRNL_BOT_EMAIL }}"
 
     - name: Install dependencies
       run: pip install poetry
@@ -61,17 +70,127 @@ jobs:
         echo __version__ = \"$JRNL_VERSION\" > jrnl/__version__.py
 
     - name: Commit updated files
+      if: ${{ github.repository == env.HOME_REPO }}
       run: |
-        git config user.email "jrnl.bot@gmail.com"
-        git config user.name "Jrnl Bot"
         git add pyproject.toml jrnl/__version__.py
         git commit -m "Increment version to ${JRNL_VERSION}"
         git tag -a -m "$JRNL_VERSION" "$JRNL_VERSION"
-        git push origin develop --tags
+        git push --tags
+
+    - name: Build
+      run: poetry build
 
     - name: Deploy to PyPI
+      if: ${{ github.repository == env.HOME_REPO }}
       env:
         POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        poetry publish --build
+      run: poetry publish
 
+    - name: Get PyPI version
+      id: pypi-version-getter
+      run: |
+        pypi_version="$(ls dist/jrnl-*.tar.gz | sed -r 's!dist/jrnl-(.*)\.tar\.gz!\1!')"
+        echo "::set-output name=pypi_version::$pypi_version"
+
+  release_homebrew:
+    needs: release_pypi
+    name: "Release to Homebrew"
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOME_REPO: ${{ secrets.HOME_REPO }}
+    steps:
+
+    - name: Get version
+      run: |
+        JRNL_VERSION="${{ github.event.inputs.version }}"
+        PYPI_VERSION="${{ needs.release_pypi.outputs.pypi_version }}"
+
+        echo "::debug::jrnl version: $JRNL_VERSION"
+        echo "::debug::pypi version: $PYPI_VERSION"
+
+        echo "JRNL_VERSION=$JRNL_VERSION" >> $GITHUB_ENV
+        echo "PYPI_VERSION=$PYPI_VERSION" >> $GITHUB_ENV
+
+    - name: Determine type of release
+      env:
+        REPO_OWNER: ${{ github.repository_owner }}
+      run: |
+        if [[ $JRNL_VERSION =~ (alpha|beta) ]]; then
+          echo '::debug::Prerelease (not a full release)'
+          {
+            echo "RELEASE_TYPE=pre"
+            echo "FORMULA_REPO=${REPO_OWNER}/homebrew-prerelease"
+            echo "BOT_REPO=jrnl-bot/homebrew-prerelease"
+            echo "FORMULA_NAME=jrnl-beta"
+          } >> $GITHUB_ENV
+        else
+          echo '::debug::Full release (not a prerelease)'
+          if [[ "${{ github.repository }}" == "${HOME_REPO}" ]]; then
+            REPO_OWNER="homebrew"
+          fi
+          {
+            echo "RELEASE_TYPE=full"
+            echo "FORMULA_REPO=${REPO_OWNER}/homebrew-core"
+            echo "BOT_REPO=jrnl-bot/homebrew-core"
+            echo "FORMULA_NAME=jrnl"
+          } >> $GITHUB_ENV
+        fi
+
+    - name: Checkout homebrew repo
+      uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.JRNL_BOT_TOKEN }}
+        repository: ${{ env.FORMULA_REPO }}
+
+    - name: Config git user
+      run: |
+        git config --global user.name "${{ secrets.JRNL_BOT_NAME }}"
+        git config --global user.email "${{ secrets.JRNL_BOT_EMAIL }}"
+
+    - name: Create branch
+      run: |
+        BRANCH_NAME="jrnl-${JRNL_VERSION}--${RANDOM}"
+        git remote rename origin upstream
+        git remote add origin "https://github.com/${BOT_REPO}.git"
+        git fetch origin
+        git checkout -b $BRANCH_NAME
+        git push -u origin $BRANCH_NAME
+
+    - name: Install dependencies
+      run: brew install pipgrip
+
+    - name: Query PyPI API
+      run: curl -Ls https://pypi.org/pypi/jrnl/json > api_response.json
+
+    - name: Update Homebrew Formula
+      run: >
+        brew bump-formula-pr "Formula/${FORMULA_NAME}.rb"
+        --url $(jq ".releases[\"${PYPI_VERSION}\"][1].url" -r api_response.json)
+        --sha256 $(jq ".releases[\"${PYPI_VERSION}\"][1].digests.sha256" -r api_response.json)
+        --version=$PYPI_VERSION
+        --no-audit
+        --write
+        --commit
+        --force
+
+    - name: Update commit message
+      run: |
+        git commit --amend \
+        -m "jrnl ${JRNL_VERSION}" \
+        -m "Update jrnl to ${JRNL_VERSION}" \
+        -m '${{ secrets.RELEASE_COAUTHORS }}'
+
+    - name: Push commit
+      run: |
+        git show head
+        git push
+
+    - name: Open pull request
+      env:
+        GH_TOKEN: ${{ secrets.JRNL_BOT_TOKEN }}
+      run: >
+        gh pr create
+        --title "jrnl ${JRNL_VERSION}"
+        --body 'Created with `brew bump-formula-pr`.'


### PR DESCRIPTION
Fixes #686

This new job will submit a PR to the relevant upstream repo as part of
the release workflow.

If we decide to later, we can make it directly commit to our prerelease repo instead of submitting a PR.

Here's an example of a build where this ran successfully:
- https://github.com/wren/jrnl/actions/runs/419539722

And here's an example PR that the bot opened:
- https://github.com/wren/homebrew-prerelease/pull/9

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->