### PR TITLE
Change approach for docs workflow to use pa11y-ci

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -9,7 +9,7 @@ on:
     - 'mkdocs.yml'
     - 'readthedocs.yml'
     - '.github/workflows/docs.yaml'
-  pull_request_target:
+  pull_request:
     branches: [ develop ]
     paths:
     - 'docs/**'
@@ -40,64 +40,29 @@ jobs:
         path: .venv
         key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}
 
+    - name: npm cache
+      uses: actions/cache@v2
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-pa11y-v3
+
     - name: Install dependencies
       run: |
         pip install poetry
         poetry config --local virtualenvs.in-project true
         poetry install --no-root --remove-untracked
-        npm install pa11y pa11y-reporter-junit
+        npm install pa11y-ci
+        echo "node_modules/.bin" >> $GITHUB_PATH
 
     - name: Start docs server
       run: poetry run mkdocs serve &
 
-    - name: Accessibility testing (Pa11y)
+    - name: Generate sitemap
       env:
         site_url: http://127.0.0.1:8000
-        exit_code: 0
       run: |
-        set +e
+        select="{urls: [\"${site_url}/\", .urlset.url[].loc]}"
+        curl -s "$site_url/sitemap.xml" | poetry run xq "$select" > list.json
 
-        poetry run mkdocs build
-        mkdir -p "reports"
-
-        printf -- 'scanning: /\n'
-        ./node_modules/.bin/pa11y "$site_url" --reporter junit > "reports/root.xml" || exit_code=2
-
-        for file in $(poetry run xq '.urlset.url[].loc' site/sitemap.xml -r | sed -r 's!https://jrnl.sh/(.*?)/$!\1!'); do
-          printf -- 'scanning: /%s\n' "$file"
-          ./node_modules/.bin/pa11y "$site_url/$file" --reporter junit > "reports/$file.xml" || exit_code=2
-        done
-
-        exit $exit_code
-
-    - name: Upload Unit Test Results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: Unit Test Results (pa11y)
-        path: reports/*.xml
-
-  publish-test-results:
-    if: success() || failure()
-    name: "Publish Unit Tests Results"
-    needs: accessibility
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: artifacts
-
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1.4
-        if: success() || failure()
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          check_name: Unit Test Results
-          hide_comments: all but latest
-          comment_on_pr: true
-          files: '**/*.xml'
-          report_individual_runs: true
-          deduplicate_classes_by_file_name: false
-
+    - name: Accessibility testing (Pa11y)
+      run: pa11y-ci -c list.json


### PR DESCRIPTION
The previous plugin looked nice with the comments and annotations, but apparently doesn't work for PRs. It can only run on the pr target (our branch), which means that the tests are never actually run against the new code.

As you can guess, this is pretty useless for PRs. So, this PR fixes that, and uses the very nice pa11y-ci (instead of the normal pa11y). While it doesn't upload annotations, the output is very readable and seems like the best we're going to get.


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->

Note: The failing tests docs test will be fixed in a separate PR. This is just to get the CI working to where that PR will get real test results.