### PR TITLE
Typo fix in output.py: "us" -> "use"

### DIFF
--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -10,7 +10,7 @@ def deprecated_cmd(old_cmd, new_cmd, callback=None, **kwargs):
 
     warning_msg = f"""
     The command {old_cmd} is deprecated and will be removed from jrnl soon.
-    Please us {new_cmd} instead.
+    Please use {new_cmd} instead.
     """
     warning_msg = textwrap.dedent(warning_msg)
     logging.warning(warning_msg)


### PR DESCRIPTION
Small typo, 'us' should be 'use'

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [ *] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have tested this code locally.
- [ *] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
