### PR TITLE
Update release workflow to wait for pypi metadata

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,7 +162,15 @@ jobs:
       run: brew install pipgrip
 
     - name: Query PyPI API
-      run: curl -Ls https://pypi.org/pypi/jrnl/json > api_response.json
+      uses: nick-invision/retry@v2
+      with:
+        timeout_seconds: 10
+        max_attempts: 30
+        retry_wait_seconds: 10
+        command: |
+          curl -Ls https://pypi.org/pypi/jrnl/json > api_response.json
+          # if query doesn't have our version yet, give it some time before trying again
+          [[ "null" == "$(jq ".releases[\"${PYPI_VERSION}\"][1].url" -r api_response.json)" ]] && exit 1
 
     - name: Update Homebrew Formula
       run: >


### PR DESCRIPTION
The homebrew release depends on the pypi release, but the metadata sometimes takes a few minutes to populate. This makes the pypi query retry every 10 seconds for up to 5 minutes (failing completely after that), before moving on to homebrew formula generation.


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [ ] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have tested this code locally.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->