### PR TITLE
Fix failing contrast test in accessibility tools on docs site

### DIFF
--- a/docs_theme/assets/index.css
+++ b/docs_theme/assets/index.css
@@ -66,6 +66,7 @@ h3 {
 }
 
 header {
+  background-color: --mid-purple;
   background-image: linear-gradient(211deg, var(--mid-purple) 0%, var(--dark-purple) 100%);
   color: var(--white);
   border: 0px solid transparent;
@@ -202,6 +203,7 @@ nav a:visited:hover {
 nav a.cta {
   display: inline-block;
   color: var(--white);
+  background-color: --mid-purple;
   background-image: linear-gradient(259deg, var(--mid-purple) 0%, var(--dark-purple) 100%);
   box-shadow: 0 2px 8px 0 var(--blacker-shadow);
   border-radius: 50px;
@@ -213,6 +215,7 @@ nav a.cta {
 
 nav a.cta:hover {
   text-decoration: none;
+  background-color: --mid-purple;
   background-image: linear-gradient(259deg, var(--bright-purple) 0%, var(--dark-purple) 100%);
   box-shadow: 0 4px 16px 0 var(--black-shadow);
   color: var(--off-white);

--- a/docs_theme/assets/theme.css
+++ b/docs_theme/assets/theme.css
@@ -76,6 +76,7 @@ div.rst-content {
 }
 
 .wy-nav-top {
+  background-color: --mid-purple;
   background-image: linear-gradient(-211deg, var(--light-purple) 0%, var(--dark-purple) 100%);
 }
 
@@ -172,6 +173,7 @@ a.icon-home:before {
 
 
 .wy-nav-side {
+  background-color: --mid-purple;
   background-image: linear-gradient(211deg, var(--mid-purple) 0%, var(--dark-purple) 100%);
   font-weight: 300;
   height: 100%;

--- a/docs_theme/assets/theme.css
+++ b/docs_theme/assets/theme.css
@@ -77,7 +77,7 @@ div.rst-content {
 
 .wy-nav-top {
   background-color: --mid-purple;
-  background-image: linear-gradient(-211deg, var(--light-purple) 0%, var(--dark-purple) 100%);
+  background-image: linear-gradient(-211deg, var(--mid-purple) 0%, var(--dark-purple) 100%);
 }
 
 .wy-nav-top .fa-bars {


### PR DESCRIPTION
There were just a few remaining accessibility fixes needed for [jrnl.sh](https://jrnl.sh). These don't really affect newer browsers, but the older browsers that are built in to some accessibility tools get confused by the way we were doing gradients. Our test suite detected everything properly, but some other tools (like color.a11y.com) use older browsers, so we were still failing tests there.

So, other than one small color change, this PR shouldn't affect what the site looks like at all, and is mostly to make sure public accessibility tools pass for our site (and to assure users we care).


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->