### PR TITLE
Fix changelog generator

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -112,6 +112,7 @@ jobs:
           releaseUrl: https://pypi.org/project/jrnl/%s/
           releaseBranch: develop
           verbose: false
+          author: true
 
       - name: Small fixes
         run: |

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -140,7 +140,7 @@ jobs:
           git push origin $BRANCH
 
       - name: Merge to Release branch
-        if: env.FULL_RELEASE
+        if: env.FULL_RELEASE == 'true'
         run: |
           git checkout release
           git merge --ff-only $BRANCH

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Prep changelog file (clear out old lines)
         run: |
           # delete the top of the changelog up to the correct tag
-          tagline=$(grep -n "^## \[\?${SINCE_TAG}\]\?" "$FILENAME" | awk '{print $1}' FS=':' | head -1)
+          tagline=$(grep -n "^## \[${SINCE_TAG}\]" "$FILENAME" | awk '{print $1}' FS=':' | head -1)
           echo "tagline: ${tagline}"
 
           if [[ -z $tagline ]]; then


### PR DESCRIPTION
This provides a few small fixes to the changelog generator tool:
- In github actions, booleans always end up as strings. So, it's not enough to test `env.FULL_RELEASE` because both 'true' and 'false' will evaluate as true. This fixes the conditional to check for the string value 'true' instead of relying on a boolean.
- This updates the regex to find the version header in our changelog.  There was a bug that affected patch, alpha, and beta versions. For example, if we were looking for "v2.5" we might find "v2.5.1" or "v2.5.1-alpha" or other versions like that. This led to the changelog not being cleared properly on update, and old versions sticking around longer than they should.
- Re-add option to include author link for merged PRs in changelog.  This option was accidentally left out when migrating the changelog generator tool to github actions.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls) for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->