### PR TITLE
Add packaging label to changelog generator config

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -98,7 +98,7 @@ jobs:
           repo: jrnl-org/jrnl
           token: ${{ secrets.JRNL_BOT_TOKEN }}
           base: CHANGELOG.md
-          addSections: '{"build":{"prefix":"**Build:**","labels":["build"]},"docs":{"prefix":"**Documentation:**","labels":["documentation"]}}'
+          addSections: '{"build":{"prefix":"**Build:**","labels":["build"]},"docs":{"prefix":"**Documentation:**","labels":["documentation"]},"packaging":{"prefix":"**Packaging:**","labels":["packaging"]}}'
           issues: true
           pullRequests: true
           issuesWoLabels: false


### PR DESCRIPTION
More work with #1112

We added dependabot and told it to use a new packaging label. This
change gives that label its own separate section in the changelog.


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->