### PR TITLE
Fix keyring error handling

### DIFF
--- a/features/password.feature
+++ b/features/password.feature
@@ -56,6 +56,30 @@ Feature: Using the installed keyring
     Scenario: Decrypt journal when keyring exists but fails
     # This should ask the user for the password after the keyring fails
 
+    Scenario: Encrypt journal when keyring exists but cannot be unlocked
+        Given we use the config "simple.yaml"
+        And we have a locked keyring
+        When we run "jrnl --encrypt" and enter
+        """
+        karimpwnz
+        karimpwnz
+        y
+        """
+        Then we should get no error
+        And the config for journal "default" should have "encrypt" set to "bool:True"
+        When we run "jrnl -n 1" and enter "karimpwnz"
+        Then we should be prompted for a password
+        And the output should contain "2013-06-10 15:40 Life is good"
+
+    Scenario: Decrypt journal when keyring exists but cannot be unlocked
+        Given we use the config "encrypted.yaml"
+        And we have a locked keyring
+        When we run "jrnl --decrypt" and enter "bad doggie no biscuit"
+        Then we should get no error
+        And the config for journal "default" should have "encrypt" set to "bool:False"
+        And we should see the message "Journal decrypted"
+        And the journal should have 2 entries
+
     Scenario: Mistyping your password
         Given we use the config "simple.yaml"
         When we run "jrnl --encrypt" and enter

--- a/features/password.feature
+++ b/features/password.feature
@@ -24,6 +24,7 @@ Feature: Using the installed keyring
         n
         """
         Then we should get no error
+        And we should not see the message "Failed to retrieve keyring"
 
     Scenario: Encrypt journal with no keyring backend and do store in keyring
         Given we use the config "simple.yaml"
@@ -36,14 +37,11 @@ Feature: Using the installed keyring
         y
         """
         Then we should get no error
+        And we should not see the message "Failed to retrieve keyring"
         # @todo add step to check contents of keyring
 
     @todo
     Scenario: Open an encrypted journal with wrong password in keyring
-    # This should ask the user for the password after the keyring fails
-
-    @todo
-    Scenario: Open encrypted journal when keyring exists but fails
     # This should ask the user for the password after the keyring fails
 
     @todo
@@ -52,33 +50,40 @@ Feature: Using the installed keyring
     @todo
     Scenario: Decrypt journal without a keyring
 
-    @todo
-    Scenario: Decrypt journal when keyring exists but fails
-    # This should ask the user for the password after the keyring fails
-
-    Scenario: Encrypt journal when keyring exists but cannot be unlocked
+    Scenario: Encrypt journal when keyring exists but fails
         Given we use the config "simple.yaml"
-        And we have a locked keyring
+        And we have a failed keyring
         When we run "jrnl --encrypt" and enter
         """
         karimpwnz
         karimpwnz
         y
         """
-        Then we should get no error
+        Then we should see the message "Failed to retrieve keyring" 
+        And we should get no error
+        And we should be prompted for a password
         And the config for journal "default" should have "encrypt" set to "bool:True"
-        When we run "jrnl -n 1" and enter "karimpwnz"
-        Then we should be prompted for a password
-        And the output should contain "2013-06-10 15:40 Life is good"
 
-    Scenario: Decrypt journal when keyring exists but cannot be unlocked
+    Scenario: Decrypt journal when keyring exists but fails
         Given we use the config "encrypted.yaml"
-        And we have a locked keyring
+        And we have a failed keyring
         When we run "jrnl --decrypt" and enter "bad doggie no biscuit"
-        Then we should get no error
-        And the config for journal "default" should have "encrypt" set to "bool:False"
+        Then we should see the message "Failed to retrieve keyring"
+        And we should get no error
+        And we should be prompted for a password
         And we should see the message "Journal decrypted"
+        And the config for journal "default" should have "encrypt" set to "bool:False"
         And the journal should have 2 entries
+
+    Scenario: Open encrypted journal when keyring exists but fails
+    # This should ask the user for the password after the keyring fails
+        Given we use the config "encrypted.yaml"
+        And we have a failed keyring
+        When we run "jrnl -n 1" and enter "bad doggie no biscuit"
+        Then we should see the message "Failed to retrieve keyring"
+        And we should get no error 
+        And we should be prompted for a password
+        And the output should contain "2013-06-10 15:40 Life is good"
 
     Scenario: Mistyping your password
         Given we use the config "simple.yaml"

--- a/features/password.feature
+++ b/features/password.feature
@@ -55,8 +55,8 @@ Feature: Using the installed keyring
         And we have a failed keyring
         When we run "jrnl --encrypt" and enter
         """
-        karimpwnz
-        karimpwnz
+        this password will not be saved in keyring
+        this password will not be saved in keyring
         y
         """
         Then we should see the message "Failed to retrieve keyring" 

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -147,7 +147,7 @@ def use_password(context, password, num=1):
 
 @given("we have a keyring")
 @given("we have a {type} keyring")
-def set_keyring(context, type=None):
+def set_keyring(context, type=""):
     if type == "failed":
         keyring.set_keyring(FailedKeyring())
     else:

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -86,6 +86,23 @@ class FailedKeyring(keyring.backend.KeyringBackend):
         self.keys[servicename][username] = None
 
 
+class LockedKeyring(keyring.backend.KeyringBackend):
+    """
+    A keyring that simulates an environment with a locked keyring.
+    """
+
+    priority = 2
+
+    def set_password(self, servicename, username, password):
+        raise keyring.errors.KeyringLocked
+
+    def get_password(self, servicename, username):
+        raise keyring.errors.KeyringLocked
+
+    def delete_password(self, servicename, username):
+        raise keyring.errors.KeyringLocked
+
+
 # set a default keyring
 keyring.set_keyring(TestKeyring())
 

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -164,10 +164,14 @@ def use_password(context, password, num=1):
     context.password = iter([password] * num)
 
 
-@given("we have a keyring")
-def set_keyring(context):
-    keyring.set_keyring(TestKeyring())
-
+@given("we have a {type} keyring")
+def set_keyring(context, type=None):
+    if type == "locked":
+        keyring.set_keyring(LockedKeyring())
+    elif type == "failed":
+        keyring.set_keyring(FailedKeyring())
+    else:
+        keyring.set_keyring(TestKeyring())
 
 @given("we do not have a keyring")
 def disable_keyring(context):

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -173,6 +173,7 @@ def set_keyring(context, type=None):
     else:
         keyring.set_keyring(TestKeyring())
 
+
 @given("we do not have a keyring")
 def disable_keyring(context):
     keyring.core.set_keyring(NoKeyring())

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -69,38 +69,19 @@ class NoKeyring(keyring.backend.KeyringBackend):
 
 class FailedKeyring(keyring.backend.KeyringBackend):
     """
-    A keyring that simulates an environment with a keyring that has passwords, but fails
-    to return them.
-    """
-
-    priority = 2
-    keys = defaultdict(dict)
-
-    def set_password(self, servicename, username, password):
-        self.keys[servicename][username] = password
-
-    def get_password(self, servicename, username):
-        raise keyring.errors.NoKeyringError
-
-    def delete_password(self, servicename, username):
-        self.keys[servicename][username] = None
-
-
-class LockedKeyring(keyring.backend.KeyringBackend):
-    """
-    An environment with a locked keyring (where unlocking is unavailable or rejected).
+    A keyring that cannot be retrieved.
     """
 
     priority = 2
 
     def set_password(self, servicename, username, password):
-        raise keyring.errors.KeyringLocked
+        raise keyring.errors.KeyringError
 
     def get_password(self, servicename, username):
-        raise keyring.errors.KeyringLocked
+        raise keyring.errors.KeyringError
 
     def delete_password(self, servicename, username):
-        raise keyring.errors.KeyringLocked
+        raise keyring.errors.KeyringError
 
 
 # set a default keyring
@@ -167,9 +148,7 @@ def use_password(context, password, num=1):
 @given("we have a keyring")
 @given("we have a {type} keyring")
 def set_keyring(context, type=None):
-    if type == "locked":
-        keyring.set_keyring(LockedKeyring())
-    elif type == "failed":
+    if type == "failed":
         keyring.set_keyring(FailedKeyring())
     else:
         keyring.set_keyring(TestKeyring())

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -164,6 +164,7 @@ def use_password(context, password, num=1):
     context.password = iter([password] * num)
 
 
+@given("we have a keyring")
 @given("we have a {type} keyring")
 def set_keyring(context, type=None):
     if type == "locked":

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -88,7 +88,7 @@ class FailedKeyring(keyring.backend.KeyringBackend):
 
 class LockedKeyring(keyring.backend.KeyringBackend):
     """
-    A keyring that simulates an environment with a locked keyring.
+    An environment with a locked keyring (where unlocking is unavailable or rejected).
     """
 
     priority = 2

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -176,7 +176,7 @@ def get_keychain(journal_name):
 
     try:
         return keyring.get_password("jrnl", journal_name)
-    except (keyring.errors.KeyringLocked, RuntimeError):
+    except (keyring.errors.KeyringError, RuntimeError):
         return ""
 
 
@@ -186,12 +186,12 @@ def set_keychain(journal_name, password):
     if password is None:
         try:
             keyring.delete_password("jrnl", journal_name)
-        except (keyring.errors.KeyringLocked, keyring.errors.PasswordDeleteError):
+        except keyring.errors.KeyringError:
             pass
     else:
         try:
             keyring.set_password("jrnl", journal_name, password)
-        except (keyring.errors.KeyringLocked):
+        except (keyring.errors.KeyringError):
             pass
         except (keyring.errors.NoKeyringError):
             print(

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -176,7 +176,7 @@ def get_keychain(journal_name):
 
     try:
         return keyring.get_password("jrnl", journal_name)
-    except RuntimeError:
+    except (keyring.errors.KeyringLocked, RuntimeError):
         return ""
 
 

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -186,12 +186,14 @@ def set_keychain(journal_name, password):
     if password is None:
         try:
             keyring.delete_password("jrnl", journal_name)
-        except keyring.errors.PasswordDeleteError:
+        except (keyring.errors.KeyringLocked, keyring.errors.PasswordDeleteError):
             pass
     else:
         try:
             keyring.set_password("jrnl", journal_name, password)
-        except keyring.errors.NoKeyringError:
+        except (keyring.errors.KeyringLocked):
+            pass
+        except (keyring.errors.NoKeyringError):
             print(
                 "Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/",
                 file=sys.stderr,

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -176,7 +176,9 @@ def get_keychain(journal_name):
 
     try:
         return keyring.get_password("jrnl", journal_name)
-    except (keyring.errors.KeyringError, RuntimeError):
+    except keyring.errors.KeyringError as e:
+        if not isinstance(e, keyring.errors.NoKeyringError):
+            print("Failed to retrieve keyring", file=sys.stderr)
         return ""
 
 
@@ -191,10 +193,11 @@ def set_keychain(journal_name, password):
     else:
         try:
             keyring.set_password("jrnl", journal_name, password)
-        except (keyring.errors.KeyringError):
-            pass
-        except (keyring.errors.NoKeyringError):
-            print(
-                "Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/",
-                file=sys.stderr,
-            )
+        except keyring.errors.KeyringError as e:
+            if isinstance(e, keyring.errors.NoKeyringError):
+                print(
+                    "Keyring backend not found. Please install one of the supported backends by visiting: https://pypi.org/project/keyring/",
+                    file=sys.stderr,
+                )
+            else:
+                print("Failed to retrieve keyring", file=sys.stderr)


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

This code is intended to fix how jrnl handles keyring errors: if keyring retrieval fails, the user is now asked to enter the password manually. Additionally, the message "Failed to retrieve keyring" is displayed if the keyring exists. (This fixes #1020.)

I've also generalized the keyring tests and implemented those relevant here. 

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
