### PR TITLE
Allow custom extensions when editing (for easier syntax highlighting)

### DIFF
--- a/features/data/configs/editor_markdown_extension.yaml
+++ b/features/data/configs/editor_markdown_extension.yaml
@@ -1,0 +1,18 @@
+default_hour: 9
+default_minute: 0
+editor: ""
+encrypt: false
+highlight: true
+editor: "vim"
+journals:
+  default: features/journals/editor_markdown_extension.journal
+linewrap: 80
+tagsymbols: "@"
+template: features/templates/extension.md
+timeformat: "%Y-%m-%d %H:%M"
+indent_character: "|"
+colors:
+  date: none
+  title: none
+  body: none
+  tags: none

--- a/features/file_storage.feature
+++ b/features/file_storage.feature
@@ -44,3 +44,13 @@ Feature: Journals iteracting with the file system in a way that users can see
         And we change directory to "features"
         And we run "jrnl -n 1"
         Then the output should contain "hello world"
+
+    Scenario: the temporary filename suffix should default to ".jrnl"
+        Given we use the config "editor.yaml"
+        When we run "jrnl --edit"
+        Then the temporary filename suffix should be ".jrnl"
+
+    Scenario: the temporary filename suffix should be "-{template_filename}"
+        Given we use the config "editor_markdown_extension.yaml"
+        When we run "jrnl --edit"
+        Then the temporary filename suffix should be "-extension.md"

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -252,9 +252,8 @@ def contains_editor_file(context, method, text=""):
 def extension_editor_file(context, suffix):
     filename = Path(context.editor_file["name"]).name
     delimiter = "-" if "-" in filename else "."
-    file_suffix = delimiter + filename.split(delimiter)[-1]
-    print(file_suffix, suffix)
-    assert file_suffix == suffix
+    filename_suffix = delimiter + filename.split(delimiter)[-1]
+    assert filename_suffix == suffix
 
 
 def _mock_getpass(inputs):

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -248,6 +248,15 @@ def contains_editor_file(context, method, text=""):
         assert False, f"Method '{method}' not supported"
 
 
+@then('the temporary filename suffix should be "{suffix}"')
+def extension_editor_file(context, suffix):
+    filename = Path(context.editor_file["name"]).name
+    delimiter = "-" if "-" in filename else "."
+    file_suffix = delimiter + filename.split(delimiter)[-1]
+    print(file_suffix, suffix)
+    assert file_suffix == suffix
+
+
 def _mock_getpass(inputs):
     def prompt_return(prompt=""):
         if type(inputs) == str:

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -12,7 +12,8 @@ from .color import RESET_COLOR
 from .os_compat import on_windows
 
 
-def get_text_from_editor(config, template="", suffix=".jrnl"):
+def get_text_from_editor(config, template=""):
+    suffix = ".jrnl"
     if config["template"]:
         template_filename = Path(config["template"]).name
         suffix = "-" + template_filename

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -5,14 +5,18 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+from pathlib import Path
 
 from .color import ERROR_COLOR
 from .color import RESET_COLOR
 from .os_compat import on_windows
 
 
-def get_text_from_editor(config, template=""):
-    filehandle, tmpfile = tempfile.mkstemp(prefix="jrnl", text=True, suffix=".txt")
+def get_text_from_editor(config, template="", suffix=".jrnl"):
+    if config["template"]:
+        template_filename = Path(config["template"]).name
+        suffix = "-" + template_filename
+    filehandle, tmpfile = tempfile.mkstemp(prefix="jrnl", text=True, suffix=suffix)
     os.close(filehandle)
 
     with open(tmpfile, "w", encoding="utf-8") as f:


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

With this PR, the temporary filename's suffix will either be its template filename or ".jrnl". This allows custom extensions and formalizes the ".jrnl" extension for "better text editor integration." I have also created the necessary tests.

This closes #1059 and closes #1080.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
