### PR TITLE
Fix editor path parsing on Windows 

### DIFF
--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -124,7 +124,7 @@ def read_value_from_string(string):
 
 
 def parse_command(command):
-    return command if not on_windows else command.split(" ")
+    return command if not on_windows else command.split()
 
 
 @given('we use the config "{config_file}"')

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -123,6 +123,10 @@ def read_value_from_string(string):
     return value
 
 
+def parse_command(command):
+    return command if not on_windows else command.split(" ")
+
+
 @given('we use the config "{config_file}"')
 def set_config(context, config_file):
     full_path = os.path.join("features/configs", config_file)
@@ -179,8 +183,8 @@ def open_editor_and_enter(context, method, text=""):
         file_method = "r+"
 
     def _mock_editor(command):
-        context.editor_command = command
-        tmpfile = command[-1]
+        context.editor_command = parse_command(command)
+        tmpfile = context.editor_command[-1]
         with open(tmpfile, file_method) as f:
             f.write(text)
 
@@ -303,8 +307,8 @@ def run_with_input(context, command, inputs=""):
     args = ushlex(command)[1:]
 
     def _mock_editor(command):
-        context.editor_command = command
-        tmpfile = command[-1]
+        context.editor_command = parse_command(command)
+        tmpfile = context.editor_command[-1]
         with open(tmpfile, "r") as editor_file:
             file_content = editor_file.read()
         context.editor_file = {"name": tmpfile, "content": file_content}
@@ -386,8 +390,8 @@ def run(context, command, text=""):
     args = ushlex(command)
 
     def _mock_editor(command):
-        context.editor_command = command
-        tmpfile = command[-1]
+        context.editor_command = parse_command(command)
+        tmpfile = context.editor_command[-1]
         with open(tmpfile, "r") as editor_file:
             file_content = editor_file.read()
         context.editor_file = {"name": tmpfile, "content": file_content}

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -28,7 +28,7 @@ def get_text_from_editor(config, template=""):
         # https://stackoverflow.com/questions/33560364/python-windows-parsing-command-lines-with-shlex
         # https://bugs.python.org/issue1724822
         if on_windows:
-            parsed_editor_path = config["editor"] + tmpfile
+            parsed_editor_path = config["editor"] + " " + tmpfile
         else:
             parsed_editor_path = shlex.split(config["editor"]) + [tmpfile]
         subprocess.call(parsed_editor_path)

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -11,7 +11,6 @@ from .color import ERROR_COLOR
 from .color import RESET_COLOR
 from .os_compat import on_windows
 
-
 def get_text_from_editor(config, template=""):
     suffix = ".jrnl"
     if config["template"]:
@@ -25,7 +24,13 @@ def get_text_from_editor(config, template=""):
             f.write(template)
 
     try:
-        subprocess.call(shlex.split(config["editor"], posix=on_windows) + [tmpfile])
+        # https://stackoverflow.com/questions/33560364/python-windows-parsing-command-lines-with-shlex
+        # https://bugs.python.org/issue1724822
+        if on_windows:
+            parsed_editor_path = config["editor"] + tmpfile 
+        else: 
+            parsed_editor_path = shlex.split(config["editor"]) + [tmpfile]
+        subprocess.call(parsed_editor_path)
     except Exception as e:
         error_msg = f"""
         {ERROR_COLOR}{str(e)}{RESET_COLOR}

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -11,6 +11,7 @@ from .color import ERROR_COLOR
 from .color import RESET_COLOR
 from .os_compat import on_windows
 
+
 def get_text_from_editor(config, template=""):
     suffix = ".jrnl"
     if config["template"]:
@@ -27,8 +28,8 @@ def get_text_from_editor(config, template=""):
         # https://stackoverflow.com/questions/33560364/python-windows-parsing-command-lines-with-shlex
         # https://bugs.python.org/issue1724822
         if on_windows:
-            parsed_editor_path = config["editor"] + tmpfile 
-        else: 
+            parsed_editor_path = config["editor"] + tmpfile
+        else:
             parsed_editor_path = shlex.split(config["editor"]) + [tmpfile]
         subprocess.call(parsed_editor_path)
     except Exception as e:


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

This PR resolves #1096.

I made the path parsing not split on Windows: apparently splitting the input for `subprocess.call` is fruitless (https://stackoverflow.com/questions/33560364/python-windows-parsing-command-lines-with-shlex).

With this, I had to modify how behave mock editors parsed windows commands (since they are a string and not an array now).

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [ ] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
