### PR TITLE
Emphasize installing dependencies before testing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,9 @@ You can find an inventory of commands in the `makefile`. \*nix users can run the
 
 A typical development workflow includes:
 
+ * Installing dependencies: `poetry install`
  * Running tests: `make test`
  * Running the source in a virtual environment:
-   * `poetry install`
    * `poetry shell`
    * `jrnl` (with or without arguments as necessary)
  * Linting the code to standardize its style: `make lint`


### PR DESCRIPTION
As a beginner in Python, it was unclear `poetry install` needed to be run before `make test` for instance., which resulted in a subjectively obscure error until I figured it out. This is an extremely minor proposal that from a newbie's perspective, ensuring one of the most appropriate command for installing dependencies is the very first instruction could help reduce some friction when considering contributing.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
