### PR TITLE
Add delimiters in YAML format

### DIFF
--- a/features/format.feature
+++ b/features/format.feature
@@ -415,26 +415,26 @@ Feature: Custom formats
         date: 2020-08-29 11:11
         starred: False
         tags: tagone, ipsum, tagtwo
+        body: |
+            Lorem @ipsum dolor sit amet, consectetur adipiscing elit. Praesent malesuada
+            quis est ac dignissim. Aliquam dignissim rutrum pretium. Phasellus pellentesque
+            augue et venenatis facilisis. Suspendisse potenti. Sed dignissim sed nisl eu
+            consequat. Aenean ante ex, elementum ut interdum et, mattis eget lacus. In
+            commodo nulla nec tellus placerat, sed ultricies metus bibendum. Duis eget
+            venenatis erat. In at dolor dui. @tagone and maybe also @tagtwo.
+
+            Curabitur accumsan nunc ac neque tristique, eleifend faucibus justo
+            ullamcorper. Suspendisse at mattis nunc. Nullam eget lacinia urna. Suspendisse
+            potenti. Ut urna est, venenatis sed ante in, ultrices congue mi. Maecenas eget
+            molestie metus. Mauris porttitor dui ornare gravida porta. Quisque sed lectus
+            hendrerit, lacinia ante eget, vulputate ante. Aliquam vitae erat non felis
+            feugiat sagittis. Phasellus quis arcu fringilla, mattis ligula id, vestibulum
+            urna. Vivamus facilisis leo a mi tincidunt condimentum. Donec eu euismod enim.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu ligula eget
+            velit scelerisque fringilla. Phasellus pharetra justo et nulla fringilla, ac
+            porta sapien accumsan. Class aptent taciti sociosqu ad litora torquent per
+            conubia nostra, per inceptos himenaeos.        
         ...
-
-        Lorem @ipsum dolor sit amet, consectetur adipiscing elit. Praesent malesuada
-        quis est ac dignissim. Aliquam dignissim rutrum pretium. Phasellus pellentesque
-        augue et venenatis facilisis. Suspendisse potenti. Sed dignissim sed nisl eu
-        consequat. Aenean ante ex, elementum ut interdum et, mattis eget lacus. In
-        commodo nulla nec tellus placerat, sed ultricies metus bibendum. Duis eget
-        venenatis erat. In at dolor dui. @tagone and maybe also @tagtwo.
-
-        Curabitur accumsan nunc ac neque tristique, eleifend faucibus justo
-        ullamcorper. Suspendisse at mattis nunc. Nullam eget lacinia urna. Suspendisse
-        potenti. Ut urna est, venenatis sed ante in, ultrices congue mi. Maecenas eget
-        molestie metus. Mauris porttitor dui ornare gravida porta. Quisque sed lectus
-        hendrerit, lacinia ante eget, vulputate ante. Aliquam vitae erat non felis
-        feugiat sagittis. Phasellus quis arcu fringilla, mattis ligula id, vestibulum
-        urna. Vivamus facilisis leo a mi tincidunt condimentum. Donec eu euismod enim.
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam eu ligula eget
-        velit scelerisque fringilla. Phasellus pharetra justo et nulla fringilla, ac
-        porta sapien accumsan. Class aptent taciti sociosqu ad litora torquent per
-        conubia nostra, per inceptos himenaeos.
         """
 
         Examples: configs
@@ -465,18 +465,18 @@ Feature: Custom formats
         date: 2020-09-24 09:14
         starred: False
         tags: tagone, tagthree
-        ...
-        
-        I'm so excited about emojis. 💯 🎶 💩
+        body: |
+            I'm so excited about emojis. 💯 🎶 💩
 
-        Donec semper pellentesque iaculis. Nullam cursus et justo sit amet venenatis.
-        Vivamus tempus ex dictum metus vehicula gravida. Aliquam sed sem dolor. Nulla
-        eget ultrices purus. Quisque at nunc at quam pharetra consectetur vitae quis
-        dolor. Fusce ultricies purus eu est feugiat, quis scelerisque nibh malesuada.
-        Quisque egestas semper nibh in hendrerit. Nam finibus ex in mi mattis
-        vulputate. Sed mauris urna, consectetur in justo eu, volutpat accumsan justo.
-        Phasellus aliquam lacus placerat convallis vestibulum. Curabitur maximus at
-        ante eget fringilla. @tagthree and also @tagone
+            Donec semper pellentesque iaculis. Nullam cursus et justo sit amet venenatis.
+            Vivamus tempus ex dictum metus vehicula gravida. Aliquam sed sem dolor. Nulla
+            eget ultrices purus. Quisque at nunc at quam pharetra consectetur vitae quis
+            dolor. Fusce ultricies purus eu est feugiat, quis scelerisque nibh malesuada.
+            Quisque egestas semper nibh in hendrerit. Nam finibus ex in mi mattis
+            vulputate. Sed mauris urna, consectetur in justo eu, volutpat accumsan justo.
+            Phasellus aliquam lacus placerat convallis vestibulum. Curabitur maximus at
+            ante eget fringilla. @tagthree and also @tagone        
+        ...
         """
 
         Examples: configs

--- a/features/format.feature
+++ b/features/format.feature
@@ -410,10 +410,12 @@ Feature: Custom formats
         """
         And the content of file "2020-08-29_entry-the-first.md" in the cache should be
         """
+        ---
         title: Entry the first.
         date: 2020-08-29 11:11
         starred: False
         tags: tagone, ipsum, tagtwo
+        ...
 
         Lorem @ipsum dolor sit amet, consectetur adipiscing elit. Praesent malesuada
         quis est ac dignissim. Aliquam dignissim rutrum pretium. Phasellus pellentesque
@@ -458,11 +460,13 @@ Feature: Custom formats
         """
         And the content of file "2020-09-24_the-third-entry-finally-after-weeks-without-writing.md" in the cache should be
         """
+        ---
         title: The third entry finally after weeks without writing.
         date: 2020-09-24 09:14
         starred: False
         tags: tagone, tagthree
-
+        ...
+        
         I'm so excited about emojis. 💯 🎶 💩
 
         Donec semper pellentesque iaculis. Nullam cursus et justo sit amet venenatis.

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -75,6 +75,11 @@ class YAMLExporter(TextExporter):
         if previous_line not in ["\r", "\n", "\r\n", "\n\r"]:
             newbody = newbody + os.linesep
 
+        # set indentation for YAML body block
+        spacebody = "\t"
+        for line in newbody.splitlines(True):
+            spacebody = spacebody + "\t" + line
+
         if warn_on_heading_level is True:
             print(
                 "{}WARNING{}: Headings increased past H6 on export - {} {}".format(
@@ -113,14 +118,14 @@ class YAMLExporter(TextExporter):
         # source directory is  entry.journal.config['journal']
         # output directory is...?
 
-        return "{start}\ntitle: {title}\ndate: {date}\nstarred: {starred}\ntags: {tags}\n{dayone}{end}\n{body}".format(
+        return "{start}\ntitle: {title}\ndate: {date}\nstarred: {starred}\ntags: {tags}\n{dayone}body: |{body}{end}".format(
             start="---",
             date=date_str,
             title=entry.title,
             starred=entry.starred,
             tags=", ".join([tag[1:] for tag in entry.tags]),
             dayone=dayone_attributes,
-            body=newbody,
+            body=spacebody,
             end="...",
         )
 

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -113,14 +113,15 @@ class YAMLExporter(TextExporter):
         # source directory is  entry.journal.config['journal']
         # output directory is...?
 
-        return "title: {title}\ndate: {date}\nstarred: {starred}\ntags: {tags}\n{dayone} {body} {space}".format(
+        return "{start}\ntitle: {title}\ndate: {date}\nstarred: {starred}\ntags: {tags}\n{dayone}{end}\n{body}".format(
+            start="---",
             date=date_str,
             title=entry.title,
             starred=entry.starred,
             tags=", ".join([tag[1:] for tag in entry.tags]),
             dayone=dayone_attributes,
             body=newbody,
-            space="",
+            end="...",
         )
 
     @classmethod


### PR DESCRIPTION
This is an intended fix for issue #1065. The yaml export now functions as shown in the "Expected Behavior" described in that bug report. 

### Example Output:

```
---
title: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod
date: 2021-01-05 11:26
starred: False
tags: 
...

Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
```


<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have written new tests for these changes, as needed.
- [X] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
