### PR TITLE
Fix homebrew release, add options for release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,18 @@ on:
       version:
         description: 'Version (e.g. v2.5, v2.5.1-beta, v2.6-beta2)'
         required: true
+      include_repo_version:
+        description: 'Update version in repo? (yes/no)'
+        require: true
+        default: yes
+      include_pypi:
+        description: 'Publish to PyPI? (yes/no)'
+        required: true
+        default: yes
+      include_brew:
+        description: 'Publish to Homebrew? (yes/no)'
+        required: true
+        default: yes
 
 jobs:
   validate:
@@ -65,12 +77,13 @@ jobs:
       run: pip install poetry
 
     - name: Update version in files
+      if: {{ github.event.inputs.include_repo_version == 'yes' }}
       run: |
         poetry version "$JRNL_VERSION"
         echo __version__ = \"$JRNL_VERSION\" > jrnl/__version__.py
 
     - name: Commit updated files
-      if: ${{ github.repository == env.HOME_REPO }}
+      if: ${{ github.event.inputs.include_repo_version == 'yes' && github.repository == env.HOME_REPO }}
       run: |
         git add pyproject.toml jrnl/__version__.py
         git commit -m "Increment version to ${JRNL_VERSION}"
@@ -82,7 +95,7 @@ jobs:
       run: poetry build
 
     - name: Deploy to PyPI
-      if: ${{ github.repository == env.HOME_REPO }}
+      if: ${{ github.event.inputs.include_pypi == 'yes' && github.repository == env.HOME_REPO }}
       env:
         POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
       run: poetry publish
@@ -94,6 +107,7 @@ jobs:
         echo "::set-output name=pypi_version::$pypi_version"
 
   release_homebrew:
+    if: ${{ github.event.inputs.include_brew == 'yes' }}
     needs: release_pypi
     name: "Release to Homebrew"
     runs-on: macos-latest
@@ -155,6 +169,7 @@ jobs:
         BRANCH_NAME="jrnl-${JRNL_VERSION}--${RANDOM}"
         git remote rename origin upstream
         git remote add origin "https://github.com/${BOT_REPO}.git"
+        git fetch --unshallow upstream
         git fetch origin
         git checkout -b $BRANCH_NAME
         git push -u origin $BRANCH_NAME


### PR DESCRIPTION
This adds a fix so that the jrnl bot can open a PR as intended in the release pipeline.

It also adds some options to control the release pipeline a bit more (in case we need to retry, which we sometimes need to do).

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [n/a] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [n/a] I have written new tests for these changes, as needed.
- [n/a] All tests pass.