### PR TITLE
[WIP] Override (select) configuration values during invocation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ site/
 coverage.xml
 .vscode/launch.json
 .coverage
+.vscode/tasks.json

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ exp/
 _extras/
 *.sublime-*
 site/
+
+.vscode/settings.json
+coverage.xml
+.vscode/launch.json
+.coverage

--- a/features/data/configs/tiny.yaml
+++ b/features/data/configs/tiny.yaml
@@ -1,7 +1,8 @@
 journals:
-  default: /tmp/journal.jrnl 
+  default: features/journals/simple.journal
 colors:
   body: none 
   title: green 
 editor: "vim"
 encrypt: false
+#

--- a/features/data/configs/tiny.yaml
+++ b/features/data/configs/tiny.yaml
@@ -1,0 +1,6 @@
+journals:
+  default: /tmp/journal.jrnl 
+colors:
+  body: none 
+  title: green 
+editor: "vim"

--- a/features/data/configs/tiny.yaml
+++ b/features/data/configs/tiny.yaml
@@ -4,3 +4,4 @@ colors:
   body: none 
   title: green 
 editor: "vim"
+encrypt: false

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -2,12 +2,12 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
 
 Scenario: Override configured editor with built-in input === editor:''
 Given we use the config "editor-args.yaml"
-When we run "jrnl --config-override '{\"editor\": \"\""}'"
+When we run "jrnl --config-override '{"editor": """}'"
 Then the editor "" should have been called 
 
 Scenario: Override configured editor with 'nano'
 Given we use the config "editor.yaml" 
-When we run "jrnl --config-override '{\"editor\": \"nano\"}'"
+When we run "jrnl --config-override '{"editor": "nano"}'"
 Then the editor "nano" should have been called
 
 Scenario: Override configured linewrap with a value of 23
@@ -28,4 +28,12 @@ Then the output should be
 ┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
 ┃ But I'm better.     │
 ┖─────────────────────┘
+"""
+
+Scenario: Override color selections with runtime overrides 
+Given we use the config "no_colors.yaml"
+When we run "jrnl --config-override '{"colors.body": "blue"}'"
+Then the config should have "colors" set to 
+"""
+'body': 'blue'
 """

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -1,0 +1,6 @@
+Feature: Implementing Runtime Overrides for Select Configuration Keys
+
+Scenario: Override configured editor with built-in input === editor:''
+Given we use the config "editor-args.yaml"
+When we run "jrnl --override '{\"editor\": \"\"}'"
+Then the editor "" should have been called 

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -32,5 +32,5 @@ Then the output should be
 
 Scenario: Override color selections with runtime overrides 
 Given we use the config "editor.yaml"
-When we run "jrnl -1 --config-override '{"colors.body": "blue"}' "
+When we run jrnl with "-1 --config-override '{"colors.body": "blue"}' "
 Then the runtime config should have colors.body set to blue

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -48,3 +48,12 @@ Given we use the config "tiny.yaml"
 When we run jrnl with -1 --config-override colors.body:green,editor:"nano"
 Then the runtime config should have colors.body set to green 
 And the runtime config should have editor set to nano
+        Scenario Outline: Override configured editor
+        Given we use the config "tiny.yaml" 
+        When we run jrnl with --config-override editor:"<editor>"
+        Then the editor <editor> should have been called
+        Examples: Editor Commands
+        | editor            |
+        | nano              |
+        | vi -c startinsert | 
+        | code -w -         | 

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -36,3 +36,10 @@ Scenario: Override color selections with runtime overrides
 Given we use the config "tiny.yaml"
 When we run jrnl with -1 --config-override '{"colors.body": "blue"}' 
 Then the runtime config should have colors.body set to blue
+
+@skip_win 
+Scenario: Apply multiple config overrides 
+Given we use the config "tiny.yaml" 
+When we run jrnl with -1 --config-override '{"colors.body": "green", "editor": "nano"}'
+Then the runtime config should have colors.body set to green 
+And the runtime config should have editor set to nano

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -2,5 +2,30 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
 
 Scenario: Override configured editor with built-in input === editor:''
 Given we use the config "editor-args.yaml"
-When we run "jrnl --override '{\"editor\": \"\"}'"
+When we run "jrnl --override '{\"editor\": \"\""}'"
 Then the editor "" should have been called 
+
+Scenario: Override configured editor with 'nano'
+Given we use the config "editor.yaml" 
+When we run "jrnl --override '{\"editor\": \"nano\"}'"
+Then the editor "nano" should have been called
+
+Scenario: Override configured linewrap with a value of 23
+Given we use the config "editor.yaml"
+When we run "jrnl -2 --override '{"linewrap": 23}' --format fancy"
+Then the output should be
+"""
+┎─────╮2013-06-09 15:39
+┃ My  ╘═══════════════╕
+┃ fir st  ent ry.     │
+┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+┃ Everything is       │
+┃ alright             │
+┖─────────────────────┘
+┎─────╮2013-06-10 15:40
+┃ Lif ╘═══════════════╕
+┃ e is  goo d.        │
+┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+┃ But I'm better.     │
+┖─────────────────────┘
+"""

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -31,6 +31,6 @@ Then the output should be
 """
 
 Scenario: Override color selections with runtime overrides 
-Given we use the config "editor.yaml"
-When we run jrnl with "-1 --config-override '{"colors.body": "blue"}' "
+Given we use the config "tiny.yaml"
+When we run jrnl with -1 --config-override '{"colors.body": "blue"}' 
 Then the runtime config should have colors.body set to blue

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -36,7 +36,7 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
         @skip_win 
         Scenario: Apply multiple config overrides 
         Given we use the config "tiny.yaml" 
-        When we run jrnl with -1 --config-override colors.body:green, editor:"nano"
+        When we run jrnl with -1 --config-override colors.body:green,editor:"nano"
         Then the runtime config should have colors.body set to green 
         And the runtime config should have editor set to nano
 

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -10,6 +10,7 @@ Given we use the config "editor.yaml"
 When we run "jrnl --config-override '{"editor": "nano"}'"
 Then the editor "nano" should have been called
 
+@skip_win
 Scenario: Override configured linewrap with a value of 23
 Given we use the config "editor.yaml"
 When we run "jrnl -2 --config-override '{"linewrap": 23}' --format fancy"
@@ -30,6 +31,7 @@ Then the output should be
 ┖─────────────────────┘
 """
 
+@skip_win
 Scenario: Override color selections with runtime overrides 
 Given we use the config "tiny.yaml"
 When we run jrnl with -1 --config-override '{"colors.body": "blue"}' 

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -2,17 +2,17 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
 
 Scenario: Override configured editor with built-in input === editor:''
 Given we use the config "editor-args.yaml"
-When we run "jrnl --override '{\"editor\": \"\""}'"
+When we run "jrnl --config-override '{\"editor\": \"\""}'"
 Then the editor "" should have been called 
 
 Scenario: Override configured editor with 'nano'
 Given we use the config "editor.yaml" 
-When we run "jrnl --override '{\"editor\": \"nano\"}'"
+When we run "jrnl --config-override '{\"editor\": \"nano\"}'"
 Then the editor "nano" should have been called
 
 Scenario: Override configured linewrap with a value of 23
 Given we use the config "editor.yaml"
-When we run "jrnl -2 --override '{"linewrap": 23}' --format fancy"
+When we run "jrnl -2 --config-override '{"linewrap": 23}' --format fancy"
 Then the output should be
 """
 ┎─────╮2013-06-09 15:39

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -28,7 +28,6 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
         """
 
         @skip_win
-        @wip
         Scenario: Override color selections with runtime overrides 
         Given we use the config "tiny.yaml"
         When we run jrnl with -1 --config-override colors.body:blue

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -1,53 +1,47 @@
 Feature: Implementing Runtime Overrides for Select Configuration Keys
 
-Scenario: Override configured editor with built-in input === editor:''
-Given we use the config "editor-args.yaml"
-When we run jrnl with --config-override editor:""
-Then the editor "" should have been called 
+        Scenario: Override configured editor with built-in input === editor:''
+        Given we use the config "tiny.yaml"
+        When we run jrnl with --config-override editor:''
+        Then the stdin prompt must be launched 
 
-Scenario Outline: Override configured editor
-Given we use the config "editor.yaml" 
-When we run jrnl with --config-override editor:"<editor>"
-Then the editor "<editor>" should have been called
-Examples: Editor Commands
-|editor|
-|nano|
-|vi -c startinsert| 
-|code -w - | 
+        @skip_win
+        Scenario: Override configured linewrap with a value of 23
+        Given we use the config "tiny.yaml"
+        When we run "jrnl  -2 --config-override linewrap:23 --format fancy"
+        Then the output should be
 
-@skip_win
-Scenario: Override configured linewrap with a value of 23
-Given we use the config "editor.yaml"
-When we run "jrnl -2 --config-override linewrap:23 --format fancy"
-Then the output should be
-"""
-┎─────╮2013-06-09 15:39
-┃ My  ╘═══════════════╕
-┃ fir st  ent ry.     │
-┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-┃ Everything is       │
-┃ alright             │
-┖─────────────────────┘
-┎─────╮2013-06-10 15:40
-┃ Lif ╘═══════════════╕
-┃ e is  goo d.        │
-┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
-┃ But I'm better.     │
-┖─────────────────────┘
-"""
+        """
+        ┎─────╮2013-06-09 15:39
+        ┃ My  ╘═══════════════╕
+        ┃ fir st  ent ry.     │
+        ┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        ┃ Everything is       │
+        ┃ alright             │
+        ┖─────────────────────┘
+        ┎─────╮2013-06-10 15:40
+        ┃ Lif ╘═══════════════╕
+        ┃ e is  goo d.        │
+        ┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
+        ┃ But I'm better.     │
+        ┖─────────────────────┘
+        """
 
-@skip_win
-Scenario: Override color selections with runtime overrides 
-Given we use the config "tiny.yaml"
-When we run jrnl with -1 --config-override colors.body:blue' 
-Then the runtime config should have colors.body set to blue
+        @skip_win
+        @wip
+        Scenario: Override color selections with runtime overrides 
+        Given we use the config "tiny.yaml"
+        When we run jrnl with -1 --config-override colors.body:blue
+        Then the runtime config should have colors.body set to blue
 
-@skip_win 
-Scenario: Apply multiple config overrides 
-Given we use the config "tiny.yaml" 
-When we run jrnl with -1 --config-override colors.body:green,editor:"nano"
-Then the runtime config should have colors.body set to green 
-And the runtime config should have editor set to nano
+        @skip_win 
+        Scenario: Apply multiple config overrides 
+        Given we use the config "tiny.yaml" 
+        When we run jrnl with -1 --config-override colors.body:green,editor:"nano"
+        Then the runtime config should have colors.body set to green 
+        And the runtime config should have editor set to nano
+
+
         Scenario Outline: Override configured editor
         Given we use the config "tiny.yaml" 
         When we run jrnl with --config-override editor:"<editor>"

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -36,7 +36,7 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
         @skip_win 
         Scenario: Apply multiple config overrides 
         Given we use the config "tiny.yaml" 
-        When we run jrnl with -1 --config-override colors.body:green,editor:"nano"
+        When we run jrnl with -1 --config-override colors.body:green, editor:"nano"
         Then the runtime config should have colors.body set to green 
         And the runtime config should have editor set to nano
 

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -2,7 +2,7 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
 
 Scenario: Override configured editor with built-in input === editor:''
 Given we use the config "editor-args.yaml"
-When we run "jrnl --config-override '{"editor": """}'"
+When we run "jrnl --config-override '{"editor": ""}'"
 Then the editor "" should have been called 
 
 Scenario: Override configured editor with 'nano'
@@ -31,9 +31,6 @@ Then the output should be
 """
 
 Scenario: Override color selections with runtime overrides 
-Given we use the config "no_colors.yaml"
-When we run "jrnl --config-override '{"colors.body": "blue"}'"
-Then the config should have "colors" set to 
-"""
-'body': 'blue'
-"""
+Given we use the config "editor.yaml"
+When we run "jrnl -1 --config-override '{"colors.body": "blue"}' "
+Then the runtime config should have colors.body set to blue

--- a/features/overrides.feature
+++ b/features/overrides.feature
@@ -2,18 +2,23 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
 
 Scenario: Override configured editor with built-in input === editor:''
 Given we use the config "editor-args.yaml"
-When we run "jrnl --config-override '{"editor": ""}'"
+When we run jrnl with --config-override editor:""
 Then the editor "" should have been called 
 
-Scenario: Override configured editor with 'nano'
+Scenario Outline: Override configured editor
 Given we use the config "editor.yaml" 
-When we run "jrnl --config-override '{"editor": "nano"}'"
-Then the editor "nano" should have been called
+When we run jrnl with --config-override editor:"<editor>"
+Then the editor "<editor>" should have been called
+Examples: Editor Commands
+|editor|
+|nano|
+|vi -c startinsert| 
+|code -w - | 
 
 @skip_win
 Scenario: Override configured linewrap with a value of 23
 Given we use the config "editor.yaml"
-When we run "jrnl -2 --config-override '{"linewrap": 23}' --format fancy"
+When we run "jrnl -2 --config-override linewrap:23 --format fancy"
 Then the output should be
 """
 ┎─────╮2013-06-09 15:39
@@ -34,12 +39,12 @@ Then the output should be
 @skip_win
 Scenario: Override color selections with runtime overrides 
 Given we use the config "tiny.yaml"
-When we run jrnl with -1 --config-override '{"colors.body": "blue"}' 
+When we run jrnl with -1 --config-override colors.body:blue' 
 Then the runtime config should have colors.body set to blue
 
 @skip_win 
 Scenario: Apply multiple config overrides 
 Given we use the config "tiny.yaml" 
-When we run jrnl with -1 --config-override '{"colors.body": "green", "editor": "nano"}'
+When we run jrnl with -1 --config-override colors.body:green,editor:"nano"
 Then the runtime config should have colors.body set to green 
 And the runtime config should have editor set to nano

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -13,7 +13,6 @@ from behave import given
 from behave import then
 from behave import when
 import keyring
-import mock
 
 import toml
 import yaml

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -213,15 +213,18 @@ def open_editor_and_enter(context, method, text=""):
             context.exit_status = e.code
 
     # fmt: on
-    
+
+
 @then("the runtime config should have {key_as_dots} set to {override_value}")
-def config_override(context, key_as_dots:str, override_value: str): 
+def config_override(context, key_as_dots: str, override_value: str):
     with open(context.config_path) as f:
         loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)
-        loaded_cfg['journal']='features/journals/simple.journal'
+        loaded_cfg["journal"] = "features/journals/simple.journal"
     base_cfg = loaded_cfg.copy()
-    def _mock_callback(**args): 
+
+    def _mock_callback(**args):
         print("callback executed")
+
     # fmt: off
     try: 
         with \
@@ -241,6 +244,8 @@ def config_override(context, key_as_dots:str, override_value: str):
     except SystemExit as e :
         context.exit_status = e.code
     # fmt: on
+
+
 @then("the editor {editor} should have been called")
 def editor_override(context, editor):
     def _mock_editor(command_and_journal_file):

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -232,7 +232,7 @@ def editor_override(context, editor):
         patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
     :
         try :
-                cli(['--override','{"editor": "%s"}'%editor])
+                cli(['--config-override','{"editor": "%s"}'%editor])
                 context.exit_status = 0
                 context.editor = mock_editor
                 assert mock_editor.assert_called_once_with(editor, context.tmpfile)

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -14,6 +14,7 @@ from behave import then
 from behave import when
 import keyring
 import mock
+
 import toml
 import yaml
 
@@ -212,60 +213,6 @@ def open_editor_and_enter(context, method, text=""):
         except SystemExit as e:
             context.exit_status = e.code
 
-    # fmt: on
-
-
-@then("the runtime config should have {key_as_dots} set to {override_value}")
-def config_override(context, key_as_dots: str, override_value: str):
-    with open(context.config_path) as f:
-        loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)
-        loaded_cfg["journal"] = "features/journals/simple.journal"
-    # base_cfg = loaded_cfg.copy()
-
-    def _mock_callback(**args):
-        print("callback executed")
-
-    # fmt: off
-    try: 
-        with \
-        mock.patch.object(jrnl.override,"recursively_apply",wraps=jrnl.override.recursively_apply) as mock_recurse, \
-        patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
-        patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
-        : 
-            cli(['-1','--config-override', '{"%s": "%s"}'%(key_as_dots,override_value)])
-        mock_recurse.assert_called()
-            
-        
-    except SystemExit as e :
-        context.exit_status = e.code
-    # fmt: on
-
-
-@then("the editor {editor} should have been called")
-def editor_override(context, editor):
-    def _mock_editor(command_and_journal_file):
-        editor = command_and_journal_file[0]
-        tmpfile = command_and_journal_file[-1]
-        context.tmpfile = tmpfile
-        print("%s has been launched" % editor)
-        return tmpfile
-
-    # fmt: off
-    # see: https://github.com/psf/black/issues/664
-    with \
-        patch("subprocess.call", side_effect=_mock_editor) as mock_editor, \
-        patch("sys.stdin.isatty", return_value=True), \
-        patch("jrnl.time.parse", side_effect=_mock_time_parse(context)), \
-        patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
-        patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
-    :
-        try :
-                cli(['--config-override','{"editor": "%s"}'%editor])
-                context.exit_status = 0
-                context.editor = mock_editor
-                assert mock_editor.assert_called_once_with(editor, context.tmpfile)
-        except SystemExit as e:
-            context.exit_status = e.code
     # fmt: on
 
 

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -212,7 +212,9 @@ def open_editor_and_enter(context, method, text=""):
 
     # fmt: on
 
-
+@then("the editor {editor} should have been called")
+def editor_override(context, editor): 
+    
 @then("the editor should have been called")
 @then("the editor should have been called with {num} arguments")
 def count_editor_args(context, num=None):

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -212,32 +212,35 @@ def open_editor_and_enter(context, method, text=""):
 
     # fmt: on
 
+
 @then("the editor {editor} should have been called")
-def editor_override(context, editor): 
-    
-    def _mock_editor(command_and_journal_file): 
+def editor_override(context, editor):
+    def _mock_editor(command_and_journal_file):
         editor = command_and_journal_file[0]
-        context.tmpfile = command_and_journal_file[-1]
-        print("%s has been launched"%editor)
+        tmpfile = command_and_journal_file[-1]
+        context.tmpfile = tmpfile
+        print("%s has been launched" % editor)
         return tmpfile
-    
-    try :
-                # fmt: off
-        # see: https://github.com/psf/black/issues/664
-        with \
-            patch("subprocess.call", side_effect=_mock_editor) as mock_editor, \
-            patch("sys.stdin.isatty", return_value=True), \
-            patch("jrnl.time.parse", side_effect=_mock_time_parse(context)), \
-            patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
-            patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
-        :
-            cli(['--override','{"editor": "%s"}'%editor])
-            context.exit_status = 0
-            context.editor = mock_editor
-            assert mock_editor.assert_called_once_with(editor, context.tmpfile)
-    except SystemExit as e:
-        context.exit_status = e.code
-    
+
+    # fmt: off
+    # see: https://github.com/psf/black/issues/664
+    with \
+        patch("subprocess.call", side_effect=_mock_editor) as mock_editor, \
+        patch("sys.stdin.isatty", return_value=True), \
+        patch("jrnl.time.parse", side_effect=_mock_time_parse(context)), \
+        patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
+        patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
+    :
+        try :
+                cli(['--override','{"editor": "%s"}'%editor])
+                context.exit_status = 0
+                context.editor = mock_editor
+                assert mock_editor.assert_called_once_with(editor, context.tmpfile)
+        except SystemExit as e:
+            context.exit_status = e.code
+    # fmt: on
+
+
 @then("the editor should have been called")
 @then("the editor should have been called with {num} arguments")
 def count_editor_args(context, num=None):

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -16,10 +16,10 @@ import keyring
 import mock
 import toml
 import yaml
-from yaml.loader import FullLoader
+
 
 import jrnl.time
-from jrnl import Journal, override
+from jrnl import Journal
 from jrnl import __version__
 from jrnl import plugins
 from jrnl.cli import cli
@@ -220,7 +220,7 @@ def config_override(context, key_as_dots: str, override_value: str):
     with open(context.config_path) as f:
         loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)
         loaded_cfg["journal"] = "features/journals/simple.journal"
-    base_cfg = loaded_cfg.copy()
+    # base_cfg = loaded_cfg.copy()
 
     def _mock_callback(**args):
         print("callback executed")
@@ -233,13 +233,8 @@ def config_override(context, key_as_dots: str, override_value: str):
         patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
         : 
             cli(['-1','--config-override', '{"%s": "%s"}'%(key_as_dots,override_value)])
-            # mock_recurse.assert_any_call(base_cfg,key_as_dots.split('.'),override_value)
-            keys_list = key_as_dots.split('.')
-            callList = [
-                (base_cfg,keys_list,override_value),
-                (base_cfg,keys_list[1], override_value)
-            ]
-            mock_recurse.call_args_list
+        mock_recurse.assert_called()
+            
         
     except SystemExit as e :
         context.exit_status = e.code

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -215,6 +215,29 @@ def open_editor_and_enter(context, method, text=""):
 @then("the editor {editor} should have been called")
 def editor_override(context, editor): 
     
+    def _mock_editor(command_and_journal_file): 
+        editor = command_and_journal_file[0]
+        context.tmpfile = command_and_journal_file[-1]
+        print("%s has been launched"%editor)
+        return tmpfile
+    
+    try :
+                # fmt: off
+        # see: https://github.com/psf/black/issues/664
+        with \
+            patch("subprocess.call", side_effect=_mock_editor) as mock_editor, \
+            patch("sys.stdin.isatty", return_value=True), \
+            patch("jrnl.time.parse", side_effect=_mock_time_parse(context)), \
+            patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
+            patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
+        :
+            cli(['--override','{"editor": "%s"}'%editor])
+            context.exit_status = 0
+            context.editor = mock_editor
+            assert mock_editor.assert_called_once_with(editor, context.tmpfile)
+    except SystemExit as e:
+        context.exit_status = e.code
+    
 @then("the editor should have been called")
 @then("the editor should have been called with {num} arguments")
 def count_editor_args(context, num=None):

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -1,3 +1,5 @@
+from tests.test_config import expected_override
+from jrnl.editor import get_text_from_stdin
 from jrnl.jrnl import run
 from jrnl.os_compat import split_args
 from unittest import mock
@@ -10,7 +12,16 @@ import yaml
 from yaml.loader import FullLoader
 
 import jrnl
-from jrnl.cli import cli
+def _mock_time_parse(context):
+        original_parse = jrnl.time.parse
+        if "now" not in context:
+            return original_parse
+
+        def wrapper(input, *args, **kwargs):
+            input = context.now if input == "now" else input
+            return original_parse(input, *args, **kwargs)
+
+        return wrapper
 
 
 @given("we use the config {config_file}")
@@ -31,13 +42,9 @@ def run_command(context, args):
 @then("the runtime config should have {key_as_dots} set to {override_value}")
 def config_override(context, key_as_dots: str, override_value: str):
     key_as_vec = key_as_dots.split(".")
-    expected_call_args_list = [
-        (context.cfg, key_as_vec, override_value),
-        (context.cfg[key_as_vec[0]], key_as_vec[1], override_value),
-    ]
-    with open(context.config_path) as f:
-        loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)
-        loaded_cfg["journal"] = "features/journals/simple.journal"
+    # with open(context.config_path) as f:
+    #     loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)
+    #     loaded_cfg["journal"] = "features/journals/simple.journal"
 
     def _mock_callback(**args):
         print("callback executed")
@@ -45,16 +52,20 @@ def config_override(context, key_as_dots: str, override_value: str):
     # fmt: off
     try: 
         with \
+        mock.patch("jrnl.jrnl.search_mode"), \
         mock.patch.object(jrnl.override,"_recursively_apply",wraps=jrnl.override._recursively_apply) as mock_recurse, \
         mock.patch('jrnl.install.load_or_install_jrnl', return_value=context.cfg), \
+        mock.patch('jrnl.time.parse', side_effect=_mock_time_parse(context)), \
         mock.patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
         mock.patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
         : 
             run(context.parser)
-        
-        assert mock_recurse.call_count >= 2
-        mock_recurse.call_args_list = expected_call_args_list
-        
+        runtime_cfg = mock_recurse.call_args_list[0][0][0]
+        assert mock_recurse.call_count == key_as_vec.__len__()
+        for k in key_as_vec: 
+            runtime_cfg = runtime_cfg['%s'%k]
+
+        assert runtime_cfg == override_value
     except SystemExit as e :
         context.exit_status = e.code
     # fmt: on
@@ -62,27 +73,49 @@ def config_override(context, key_as_dots: str, override_value: str):
 
 @then("the editor {editor} should have been called")
 def editor_override(context, editor):
-    def _mock_editor(command_and_journal_file):
-        editor = command_and_journal_file[0]
-        tmpfile = command_and_journal_file[-1]
-        context.tmpfile = tmpfile
-        print("%s has been launched" % editor)
-        return tmpfile
-
+    
+    def _mock_write_in_editor(config):
+        editor = config['editor']
+        journal = '/tmp/journal.jrnl'
+        context.tmpfile = journal
+        print("%s has been launched"%editor)
+        return journal
+    
+    
     # fmt: off
     # see: https://github.com/psf/black/issues/664
     with \
-        mock.patch("subprocess.call", side_effect=_mock_editor) as mock_editor, \
+        mock.patch("jrnl.jrnl._write_in_editor", side_effect=_mock_write_in_editor(context.cfg)) as mock_write_in_editor, \
         mock.patch("sys.stdin.isatty", return_value=True), \
-        mock.patch("jrnl.time.parse"), \
+        mock.patch("jrnl.time.parse", side_effect = _mock_time_parse(context)), \
         mock.patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
         mock.patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
     :
         try :
-                cli(['--config-override','{"editor": "%s"}'%editor])
+                run(context.parser)
                 context.exit_status = 0
-                context.editor = mock_editor
-                assert mock_editor.assert_called_once_with(editor, context.tmpfile)
+                context.editor = mock_write_in_editor
+                expected_config = context.cfg
+                expected_config['editor'] = '%s'%editor 
+                expected_config['journal'] ='/tmp/journal.jrnl'
+
+                assert mock_write_in_editor.call_count == 1
+                assert mock_write_in_editor.call_args[0][0]['editor']==editor
         except SystemExit as e:
             context.exit_status = e.code
     # fmt: on
+
+@then("the stdin prompt must be launched")
+def override_editor_to_use_stdin(context): 
+
+    try: 
+        with \
+        mock.patch('sys.stdin.read', return_value='Zwei peanuts walk into a bar und one of zem was a-salted')as mock_stdin_read, \
+        mock.patch("jrnl.install.load_or_install_jrnl", return_value=context.cfg), \
+        mock.patch("jrnl.Journal.open_journal", spec=False, return_value='/tmp/journal.jrnl'):
+            run(context.parser)
+            context.exit_status = 0
+        mock_stdin_read.assert_called_once()
+
+    except SystemExit as e :
+        context.exit_status = e.code

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -61,7 +61,7 @@ def config_override(context, key_as_dots: str, override_value: str):
         : 
             run(context.parser)
         runtime_cfg = mock_recurse.call_args_list[0][0][0]
-        assert mock_recurse.call_count == key_as_vec.__len__()
+        
         for k in key_as_vec: 
             runtime_cfg = runtime_cfg['%s'%k]
 
@@ -76,7 +76,7 @@ def editor_override(context, editor):
     
     def _mock_write_in_editor(config):
         editor = config['editor']
-        journal = '/tmp/journal.jrnl'
+        journal = 'features/journals/journal.jrnl'
         context.tmpfile = journal
         print("%s has been launched"%editor)
         return journal
@@ -97,7 +97,7 @@ def editor_override(context, editor):
                 context.editor = mock_write_in_editor
                 expected_config = context.cfg
                 expected_config['editor'] = '%s'%editor 
-                expected_config['journal'] ='/tmp/journal.jrnl'
+                expected_config['journal'] ='features/journals/journal.jrnl'
 
                 assert mock_write_in_editor.call_count == 1
                 assert mock_write_in_editor.call_args[0][0]['editor']==editor
@@ -112,7 +112,7 @@ def override_editor_to_use_stdin(context):
         with \
         mock.patch('sys.stdin.read', return_value='Zwei peanuts walk into a bar und one of zem was a-salted')as mock_stdin_read, \
         mock.patch("jrnl.install.load_or_install_jrnl", return_value=context.cfg), \
-        mock.patch("jrnl.Journal.open_journal", spec=False, return_value='/tmp/journal.jrnl'):
+        mock.patch("jrnl.Journal.open_journal", spec=False, return_value='features/journals/journal.jrnl'):
             run(context.parser)
             context.exit_status = 0
         mock_stdin_read.assert_called_once()

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -1,0 +1,82 @@
+from jrnl.os_compat import split_args
+from unittest import mock
+
+# from __future__ import with_statement
+from jrnl.args import parse_args
+import os
+from behave import given, when, then
+import yaml
+from yaml.loader import FullLoader
+
+import jrnl
+from jrnl.override import apply_overrides, _recursively_apply
+from jrnl.cli import cli
+from jrnl.jrnl import run
+
+
+@given("we use the config {config_file}")
+def load_config(context, config_file):
+    filepath = os.path.join("features/configs", config_file)
+    context.config_path = os.path.abspath(filepath)
+    with open(context.config_path) as cfg:
+        context.config = yaml.load(cfg, Loader=FullLoader)
+
+
+@when("we run jrnl with {args}")
+def run_command(context, args):
+    context.args = split_args("%s" % args)
+    context.parser = parse_args(context.args)
+
+
+@then("the runtime config should have {key_as_dots} set to {override_value}")
+def config_override(context, key_as_dots: str, override_value: str):
+    with open(context.config_path) as f:
+        loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)
+        loaded_cfg["journal"] = "features/journals/simple.journal"
+    # base_cfg = loaded_cfg.copy()
+
+    def _mock_callback(**args):
+        print("callback executed")
+
+    # fmt: off
+    try: 
+        with \
+        mock.patch.object(jrnl.override,"recursively_apply",wraps=jrnl.override.recursively_apply) as mock_recurse, \
+        mock.patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
+        mock.patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
+        : 
+            cli(['-1','--config-override', '{"%s": "%s"}'%(key_as_dots,override_value)])
+        mock_recurse.assert_called()
+            
+        
+    except SystemExit as e :
+        context.exit_status = e.code
+    # fmt: on
+
+
+@then("the editor {editor} should have been called")
+def editor_override(context, editor):
+    def _mock_editor(command_and_journal_file):
+        editor = command_and_journal_file[0]
+        tmpfile = command_and_journal_file[-1]
+        context.tmpfile = tmpfile
+        print("%s has been launched" % editor)
+        return tmpfile
+
+    # fmt: off
+    # see: https://github.com/psf/black/issues/664
+    with \
+        mock.patch("subprocess.call", side_effect=_mock_editor) as mock_editor, \
+        mock.patch("sys.stdin.isatty", return_value=True), \
+        mock.patch("jrnl.time.parse"), \
+        mock.patch("jrnl.config.get_config_path", side_effect=lambda: context.config_path), \
+        mock.patch("jrnl.install.get_config_path", side_effect=lambda: context.config_path) \
+    :
+        try :
+                cli(['--config-override','{"editor": "%s"}'%editor])
+                context.exit_status = 0
+                context.editor = mock_editor
+                assert mock_editor.assert_called_once_with(editor, context.tmpfile)
+        except SystemExit as e:
+            context.exit_status = e.code
+    # fmt: on

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -1,4 +1,4 @@
-from jrnl import override
+
 from jrnl.jrnl import run
 from jrnl.os_compat import split_args
 from unittest import mock
@@ -18,21 +18,20 @@ from jrnl.cli import cli
 def load_config(context, config_file):
     filepath = os.path.join("features/configs", config_file)
     context.config_path = os.path.abspath(filepath)
-    
 
 
 @when("we run jrnl with {args}")
 def run_command(context, args):
     context.args = split_args("%s" % args)
     context.parser = parse_args(context.args)
-    with open(context.config_path,'r') as f: 
-        cfg = yaml.load(f,Loader=FullLoader)
-    context.cfg = cfg 
+    with open(context.config_path, "r") as f:
+        cfg = yaml.load(f, Loader=FullLoader)
+    context.cfg = cfg
 
 
 @then("the runtime config should have {key_as_dots} set to {override_value}")
 def config_override(context, key_as_dots: str, override_value: str):
-    key_as_vec = key_as_dots.split('.')
+    key_as_vec = key_as_dots.split(".")
 
     with open(context.config_path) as f:
         loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -52,7 +52,7 @@ def config_override(context, key_as_dots: str, override_value: str):
         : 
             run(context.parser)
         
-        assert mock_recurse.call_count == 2
+        assert mock_recurse.call_count >= 2
         mock_recurse.call_args_list = expected_call_args_list
         
     except SystemExit as e :

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -1,5 +1,3 @@
-from tests.test_config import expected_override
-from jrnl.editor import get_text_from_stdin
 from jrnl.jrnl import run
 from jrnl.os_compat import split_args
 from unittest import mock
@@ -12,16 +10,18 @@ import yaml
 from yaml.loader import FullLoader
 
 import jrnl
+
+
 def _mock_time_parse(context):
-        original_parse = jrnl.time.parse
-        if "now" not in context:
-            return original_parse
+    original_parse = jrnl.time.parse
+    if "now" not in context:
+        return original_parse
 
-        def wrapper(input, *args, **kwargs):
-            input = context.now if input == "now" else input
-            return original_parse(input, *args, **kwargs)
+    def wrapper(input, *args, **kwargs):
+        input = context.now if input == "now" else input
+        return original_parse(input, *args, **kwargs)
 
-        return wrapper
+    return wrapper
 
 
 @given("we use the config {config_file}")
@@ -73,15 +73,13 @@ def config_override(context, key_as_dots: str, override_value: str):
 
 @then("the editor {editor} should have been called")
 def editor_override(context, editor):
-    
     def _mock_write_in_editor(config):
-        editor = config['editor']
-        journal = 'features/journals/journal.jrnl'
+        editor = config["editor"]
+        journal = "features/journals/journal.jrnl"
         context.tmpfile = journal
-        print("%s has been launched"%editor)
+        print("%s has been launched" % editor)
         return journal
-    
-    
+
     # fmt: off
     # see: https://github.com/psf/black/issues/664
     with \
@@ -105,17 +103,24 @@ def editor_override(context, editor):
             context.exit_status = e.code
     # fmt: on
 
-@then("the stdin prompt must be launched")
-def override_editor_to_use_stdin(context): 
 
-    try: 
-        with \
-        mock.patch('sys.stdin.read', return_value='Zwei peanuts walk into a bar und one of zem was a-salted')as mock_stdin_read, \
-        mock.patch("jrnl.install.load_or_install_jrnl", return_value=context.cfg), \
-        mock.patch("jrnl.Journal.open_journal", spec=False, return_value='features/journals/journal.jrnl'):
+@then("the stdin prompt must be launched")
+def override_editor_to_use_stdin(context):
+
+    try:
+        with mock.patch(
+            "sys.stdin.read",
+            return_value="Zwei peanuts walk into a bar und one of zem was a-salted",
+        ) as mock_stdin_read, mock.patch(
+            "jrnl.install.load_or_install_jrnl", return_value=context.cfg
+        ), mock.patch(
+            "jrnl.Journal.open_journal",
+            spec=False,
+            return_value="features/journals/journal.jrnl",
+        ):
             run(context.parser)
             context.exit_status = 0
         mock_stdin_read.assert_called_once()
 
-    except SystemExit as e :
+    except SystemExit as e:
         context.exit_status = e.code

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -42,7 +42,7 @@ def run_command(context, args):
 @then("the runtime config should have {key_as_dots} set to {override_value}")
 def config_override(context, key_as_dots: str, override_value: str):
     key_as_vec = key_as_dots.split(".")
-    
+
     def _mock_callback(**args):
         print("callback executed")
 

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -1,4 +1,3 @@
-
 from jrnl.jrnl import run
 from jrnl.os_compat import split_args
 from unittest import mock
@@ -32,14 +31,13 @@ def run_command(context, args):
 @then("the runtime config should have {key_as_dots} set to {override_value}")
 def config_override(context, key_as_dots: str, override_value: str):
     key_as_vec = key_as_dots.split(".")
-    expected_call_args_list =  [
-                (context.cfg, key_as_vec, override_value),
-                (context.cfg[key_as_vec[0]], key_as_vec[1], override_value)
-            ]
+    expected_call_args_list = [
+        (context.cfg, key_as_vec, override_value),
+        (context.cfg[key_as_vec[0]], key_as_vec[1], override_value),
+    ]
     with open(context.config_path) as f:
         loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)
         loaded_cfg["journal"] = "features/journals/simple.journal"
-    
 
     def _mock_callback(**args):
         print("callback executed")

--- a/features/steps/override.py
+++ b/features/steps/override.py
@@ -42,10 +42,7 @@ def run_command(context, args):
 @then("the runtime config should have {key_as_dots} set to {override_value}")
 def config_override(context, key_as_dots: str, override_value: str):
     key_as_vec = key_as_dots.split(".")
-    # with open(context.config_path) as f:
-    #     loaded_cfg = yaml.load(f, Loader=yaml.FullLoader)
-    #     loaded_cfg["journal"] = "features/journals/simple.journal"
-
+    
     def _mock_callback(**args):
         print("callback executed")
 

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -4,7 +4,6 @@
 import argparse
 import re
 import textwrap
-import json
 
 from .commands import postconfig_decrypt
 from .commands import postconfig_encrypt
@@ -24,11 +23,11 @@ def deserialize_config_args(input: str) -> dict:
     for _p in _kvpairs:
         l, r = _p.strip().split(":")
         r = r.strip()
-        if r.isdigit(): 
-            r = int(r) 
-        elif r.lower() == "true": 
-            r = True 
-        elif r.lower() == "false": 
+        if r.isdigit():
+            r = int(r)
+        elif r.lower() == "true":
+            r = True
+        elif r.lower() == "false":
             r = False
         runtime_modifications[l] = r
     return runtime_modifications

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -330,11 +330,11 @@ def parse_args(args=[]):
         help="""
         Override configured key-value pairs with CONFIG_KV_PAIR for this command invocation only. 
 
-        Examples: 
-        - Use a different editor for this jrnl entry, call: 
-            jrnl --config-override '{"editor": "nano"}' 
-        - Override color selections
-            jrnl --config-override '{"colors.body":"blue", "colors.title": "green"}
+        Examples: \n
+        \t - Use a different editor for this jrnl entry, call: \n
+            \t jrnl --config-override '{"editor": "nano"}' \n
+        \t - Override color selections\n
+           \t jrnl --config-override '{"colors.body":"blue", "colors.title": "green"}
         """,
     )
 

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -2,8 +2,10 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import argparse
+from jrnl import config
 import re
 import textwrap
+import json
 
 from .commands import postconfig_decrypt
 from .commands import postconfig_encrypt
@@ -312,6 +314,24 @@ def parse_args(args=[]):
         "-o",
         dest="filename",
         help=argparse.SUPPRESS,
+    )
+
+    overrides = parser.add_argument_group("Config file overrides",textwrap.dedent('These are one-off overrides of the config file options'))
+    overrides.add_argument(
+        "--override",
+        dest="config_override",
+        action="store",
+        type=json.loads,
+        nargs="?",
+        default={},
+        metavar="CONFIG_KV_PAIR",
+        help="""
+        Override configured key-value pairs with CONFIG_KV_PAIR for this command invocation only. 
+
+        For example, to use a different editor for this jrnl entry, call: 
+            jrnl --override '{"editor": "nano"}' 
+        
+        """
     )
 
     # Handle '-123' as a shortcut for '-n 123'

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -2,7 +2,6 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import argparse
-from jrnl import config
 import re
 import textwrap
 import json

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -17,7 +17,14 @@ from .plugins import EXPORT_FORMATS
 from .plugins import IMPORT_FORMATS
 from .plugins import util
 
-
+def deserialize_config_args(input: str) -> dict: 
+    _kvpairs = input.strip(' ').split(',')
+    runtime_modifications = {} 
+    for _p in _kvpairs: 
+        l,r = _p.strip().split(':')
+        runtime_modifications[l] = r
+    return runtime_modifications
+    
 class WrappingFormatter(argparse.RawTextHelpFormatter):
     """Used in help screen"""
 
@@ -323,9 +330,9 @@ def parse_args(args=[]):
         "--config-override",
         dest="config_override",
         action="store",
-        type=json.loads,
+        type=deserialize_config_args,
         nargs="?",
-        default={},
+        default=None,
         metavar="CONFIG_KV_PAIR",
         help="""
         Override configured key-value pairs with CONFIG_KV_PAIR for this command invocation only. 
@@ -342,4 +349,6 @@ def parse_args(args=[]):
     num = re.compile(r"^-(\d+)$")
     args = [num.sub(r"-n \1", arg) for arg in args]
 
-    return parser.parse_intermixed_args(args)
+    
+    parsed_args = parser.parse_intermixed_args(args)
+    return parsed_args

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -320,7 +320,7 @@ def parse_args(args=[]):
         textwrap.dedent("These are one-off overrides of the config file options"),
     )
     overrides.add_argument(
-        "--override",
+        "--config-override",
         dest="config_override",
         action="store",
         type=json.loads,
@@ -331,7 +331,7 @@ def parse_args(args=[]):
         Override configured key-value pairs with CONFIG_KV_PAIR for this command invocation only. 
 
         For example, to use a different editor for this jrnl entry, call: 
-            jrnl --override '{"editor": "nano"}' 
+            jrnl --config-override '{"editor": "nano"}' 
         
         """,
     )

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -23,6 +23,13 @@ def deserialize_config_args(input: str) -> dict:
     runtime_modifications = {}
     for _p in _kvpairs:
         l, r = _p.strip().split(":")
+        r = r.strip()
+        if r.isdigit(): 
+            r = int(r) 
+        elif r.lower() == "true": 
+            r = True 
+        elif r.lower() == "false": 
+            r = False
         runtime_modifications[l] = r
     return runtime_modifications
 
@@ -341,9 +348,9 @@ def parse_args(args=[]):
 
         Examples: \n
         \t - Use a different editor for this jrnl entry, call: \n
-            \t jrnl --config-override '{"editor": "nano"}' \n
+            \t jrnl --config-override editor: "nano" \n
         \t - Override color selections\n
-           \t jrnl --config-override '{"colors.body":"blue", "colors.title": "green"}
+           \t jrnl --config-override colors.body: blue, colors.title: green
         """,
     )
 

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -17,14 +17,16 @@ from .plugins import EXPORT_FORMATS
 from .plugins import IMPORT_FORMATS
 from .plugins import util
 
-def deserialize_config_args(input: str) -> dict: 
-    _kvpairs = input.strip(' ').split(',')
-    runtime_modifications = {} 
-    for _p in _kvpairs: 
-        l,r = _p.strip().split(':')
+
+def deserialize_config_args(input: str) -> dict:
+    _kvpairs = input.strip(" ").split(",")
+    runtime_modifications = {}
+    for _p in _kvpairs:
+        l, r = _p.strip().split(":")
         runtime_modifications[l] = r
     return runtime_modifications
-    
+
+
 class WrappingFormatter(argparse.RawTextHelpFormatter):
     """Used in help screen"""
 
@@ -349,6 +351,5 @@ def parse_args(args=[]):
     num = re.compile(r"^-(\d+)$")
     args = [num.sub(r"-n \1", arg) for arg in args]
 
-    
     parsed_args = parser.parse_intermixed_args(args)
     return parsed_args

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -315,11 +315,11 @@ def parse_args(args=[]):
         help=argparse.SUPPRESS,
     )
 
-    overrides = parser.add_argument_group(
+    config_overrides = parser.add_argument_group(
         "Config file overrides",
         textwrap.dedent("These are one-off overrides of the config file options"),
     )
-    overrides.add_argument(
+    config_overrides.add_argument(
         "--config-override",
         dest="config_override",
         action="store",
@@ -330,9 +330,11 @@ def parse_args(args=[]):
         help="""
         Override configured key-value pairs with CONFIG_KV_PAIR for this command invocation only. 
 
-        For example, to use a different editor for this jrnl entry, call: 
+        Examples: 
+        - Use a different editor for this jrnl entry, call: 
             jrnl --config-override '{"editor": "nano"}' 
-        
+        - Override color selections
+            jrnl --config-override '{"colors.body":"blue", "colors.title": "green"}
         """,
     )
 

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -316,7 +316,10 @@ def parse_args(args=[]):
         help=argparse.SUPPRESS,
     )
 
-    overrides = parser.add_argument_group("Config file overrides",textwrap.dedent('These are one-off overrides of the config file options'))
+    overrides = parser.add_argument_group(
+        "Config file overrides",
+        textwrap.dedent("These are one-off overrides of the config file options"),
+    )
     overrides.add_argument(
         "--override",
         dest="config_override",
@@ -331,7 +334,7 @@ def parse_args(args=[]):
         For example, to use a different editor for this jrnl entry, call: 
             jrnl --override '{"editor": "nano"}' 
         
-        """
+        """,
     )
 
     # Handle '-123' as a shortcut for '-n 123'

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -51,10 +51,9 @@ def run(args):
 
     # Apply config overrides
     overrides = args.config_override
-    # TODO: substitute overriden KV pairs in config dict ONLY AFTER ADDING TESTS
-    for k in overrides:
-        logging.debug("Overriding %s from %s to %s" % (k, config[k], overrides[k]))
-        config[k] = overrides[k]
+    from .override import apply_overrides
+    config = apply_overrides(overrides,config)
+    
     # --- All the standalone commands are now done --- #
 
     # Get the journal we're going to be working with

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -16,6 +16,7 @@ from .editor import get_text_from_editor
 from .editor import get_text_from_stdin
 from .exception import UserAbort
 from . import time
+from .override import apply_overrides
 
 
 def run(args):
@@ -51,9 +52,8 @@ def run(args):
 
     # Apply config overrides
     overrides = args.config_override
-    from .override import apply_overrides
-
-    config = apply_overrides(overrides, config)
+    if overrides:
+        config = apply_overrides(overrides, config)
 
     # --- All the standalone commands are now done --- #
 

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -51,9 +51,9 @@ def run(args):
 
     # Apply config overrides
     overrides = args.config_override
-    #TODO: substitute overriden KV pairs in config dict ONLY AFTER ADDING TESTS
-    for k in overrides: 
-        logging.debug("Overriding %s from %s to %s"%(k,config[k],overrides[k]))
+    # TODO: substitute overriden KV pairs in config dict ONLY AFTER ADDING TESTS
+    for k in overrides:
+        logging.debug("Overriding %s from %s to %s" % (k, config[k], overrides[k]))
         config[k] = overrides[k]
     # --- All the standalone commands are now done --- #
 

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -49,6 +49,10 @@ def run(args):
             args=args, config=config, original_config=original_config
         )
 
+    # Apply config overrides
+    overrides = args.config_override
+    #TODO: substitute overriden KV pairs in config dict ONLY AFTER ADDING TESTS
+    
     # --- All the standalone commands are now done --- #
 
     # Get the journal we're going to be working with

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -52,7 +52,9 @@ def run(args):
     # Apply config overrides
     overrides = args.config_override
     #TODO: substitute overriden KV pairs in config dict ONLY AFTER ADDING TESTS
-    
+    for k in overrides: 
+        logging.debug("Overriding %s from %s to %s"%(k,config[k],overrides[k]))
+        config[k] = overrides[k]
     # --- All the standalone commands are now done --- #
 
     # Get the journal we're going to be working with

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -52,8 +52,9 @@ def run(args):
     # Apply config overrides
     overrides = args.config_override
     from .override import apply_overrides
-    config = apply_overrides(overrides,config)
-    
+
+    config = apply_overrides(overrides, config)
+
     # --- All the standalone commands are now done --- #
 
     # Get the journal we're going to be working with

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -1,0 +1,8 @@
+import logging 
+def apply_overrides(overrides: dict, base_config: dict) -> dict:
+    config = base_config.copy() 
+    for k in overrides:
+        logging.debug("Overriding %s from %s to %s" % (k, config[k], overrides[k]))
+        config[k] = overrides[k]
+
+    return config 

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -10,7 +10,7 @@ def apply_overrides(overrides: dict, base_config: dict) -> dict:
 def recursively_apply(config: dict, nodes: list, override_value) -> dict:
     """Recurse through configuration and apply overrides at the leaf of the config tree
 
-    See: https://stackoverflow.com/a/47276490 for algorithm
+    Credit to iJames on SO: https://stackoverflow.com/a/47276490 for algorithm
 
     Args:
         config (dict): loaded configuration from YAML
@@ -18,11 +18,18 @@ def recursively_apply(config: dict, nodes: list, override_value) -> dict:
         override_value (str): runtime override passed from the command-line
     """
     key = nodes[0]
-    config[key] = (
-        override_value
-        if len(nodes) == 1
-        else recursively_apply(
-            config[key] if key in config else {}, nodes[1:], override_value
-        )
-    )
+    if len(nodes) == 1:
+        config[key] = override_value
+    else:
+        next_key = nodes[1:]
+        _recursively_apply(_get_config_node(config, key), next_key, override_value)
+
     return config
+
+
+def _get_config_node(config: dict, key: str):
+    if key in config:
+        pass
+    else:
+        config[key] = None
+    return config[key]

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -1,25 +1,28 @@
-# import logging 
+# import logging
 def apply_overrides(overrides: dict, base_config: dict) -> dict:
-    config = base_config.copy() 
-    for k in overrides: 
-        nodes = k.split('.') 
-        config = recursively_apply(config, nodes, overrides[k]) 
-    return config 
+    config = base_config.copy()
+    for k in overrides:
+        nodes = k.split(".")
+        config = recursively_apply(config, nodes, overrides[k])
+    return config
 
 
 def recursively_apply(config: dict, nodes: list, override_value) -> dict:
-    """Recurse through configuration and apply overrides at the leaf of the config tree 
-    
+    """Recurse through configuration and apply overrides at the leaf of the config tree
+
     See: https://stackoverflow.com/a/47276490 for algorithm
 
     Args:
         config (dict): loaded configuration from YAML
-        nodes (list): vector of override keys; the length of the vector indicates tree depth 
+        nodes (list): vector of override keys; the length of the vector indicates tree depth
         override_value (str): runtime override passed from the command-line
     """
-    key = nodes[0] 
-    config[key] = override_value \
-        if len(nodes) == 1 \
-        else \
-        recursively_apply(config[key] if key in config else {}, nodes[1:], override_value)
-    return config 
+    key = nodes[0]
+    config[key] = (
+        override_value
+        if len(nodes) == 1
+        else recursively_apply(
+            config[key] if key in config else {}, nodes[1:], override_value
+        )
+    )
+    return config

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -1,8 +1,25 @@
-import logging 
+# import logging 
 def apply_overrides(overrides: dict, base_config: dict) -> dict:
     config = base_config.copy() 
-    for k in overrides:
-        logging.debug("Overriding %s from %s to %s" % (k, config[k], overrides[k]))
-        config[k] = overrides[k]
+    for k in overrides: 
+        nodes = k.split('.') 
+        config = recursively_apply(config, nodes, overrides[k]) 
+    return config 
 
+
+def recursively_apply(config: dict, nodes: list, override_value) -> dict:
+    """Recurse through configuration and apply overrides at the leaf of the config tree 
+    
+    See: https://stackoverflow.com/a/47276490 for algorithm
+
+    Args:
+        config (dict): loaded configuration from YAML
+        nodes (list): vector of override keys; the length of the vector indicates tree depth 
+        override_value (str): runtime override passed from the command-line
+    """
+    key = nodes[0] 
+    config[key] = override_value \
+        if len(nodes) == 1 \
+        else \
+        recursively_apply(config[key] if key in config else {}, nodes[1:], override_value)
     return config 

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -3,11 +3,11 @@ def apply_overrides(overrides: dict, base_config: dict) -> dict:
     config = base_config.copy()
     for k in overrides:
         nodes = k.split(".")
-        config = recursively_apply(config, nodes, overrides[k])
+        config = _recursively_apply(config, nodes, overrides[k])
     return config
 
 
-def recursively_apply(config: dict, nodes: list, override_value) -> dict:
+def _recursively_apply(config: dict, nodes: list, override_value) -> dict:
     """Recurse through configuration and apply overrides at the leaf of the config tree
 
     Credit to iJames on SO: https://stackoverflow.com/a/47276490 for algorithm

--- a/poetry.lock
+++ b/poetry.lock
@@ -128,6 +128,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "coverage"
+version = "5.3.1"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+toml = ["toml"]
+
+[[package]]
 name = "cryptography"
 version = "3.3.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -156,18 +167,19 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "3.1.1"
+version = "3.4.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
+typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -204,8 +216,8 @@ i18n = ["Babel (>=0.8)"]
 
 [[package]]
 name = "joblib"
-version = "0.17.0"
-description = "Lightweight pipelining: using Python functions as pipeline jobs."
+version = "1.0.0"
+description = "Lightweight pipelining with Python functions"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
@@ -296,6 +308,19 @@ PyYAML = ">=3.10"
 tornado = ">=5.0"
 
 [[package]]
+name = "mock"
+version = "4.0.3"
+description = "Rolling backport of unittest.mock for all Pythons"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+build = ["twine", "wheel", "blurb"]
+docs = ["sphinx"]
+test = ["pytest (<5.4)", "pytest-cov"]
+
+[[package]]
 name = "mypy-extensions"
 version = "0.4.3"
 description = "Experimental type system extensions for programs checked with the mypy typechecker."
@@ -338,7 +363,7 @@ pyparsing = ">=2.0.2"
 
 [[package]]
 name = "parse"
-version = "1.18.0"
+version = "1.19.0"
 description = "parse() is the opposite of format()"
 category = "dev"
 optional = false
@@ -445,6 +470,35 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "2.11.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+coverage = ">=5.2.1"
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests (==2.0.2)", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.5.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "tox", "pytest-asyncio"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.1"
 description = "Extensions to the standard Python datetime module"
@@ -481,11 +535,11 @@ python-versions = "*"
 
 [[package]]
 name = "pyyaml"
-version = "5.3.1"
+version = "5.4.1"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [[package]]
 name = "regex"
@@ -541,18 +595,19 @@ python-versions = ">= 3.5"
 
 [[package]]
 name = "tqdm"
-version = "4.54.1"
+version = "4.56.0"
 description = "Fast, Extensible Progress Meter"
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.extras]
-dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown", "wheel"]
+dev = ["py-make (>=0.1.0)", "twine", "wheel"]
+telegram = ["requests"]
 
 [[package]]
 name = "typed-ast"
-version = "1.4.1"
+version = "1.4.2"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
 category = "dev"
 optional = false
@@ -562,7 +617,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -616,7 +671,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.0, <3.10"
-content-hash = "1757c9f22bd1c3e2e4c6b7785d4c8e14a670334a21ab5de2137faf0fd10819b9"
+content-hash = "fb7f55245f566cc5dcb849ce3a2f186e2ed090c802e6a2aba84fb70359ed69ea"
 
 [metadata.files]
 ansiwrap = [
@@ -695,6 +750,57 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+coverage = [
+    {file = "coverage-5.3.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:fabeeb121735d47d8eab8671b6b031ce08514c86b7ad8f7d5490a7b6dcd6267d"},
+    {file = "coverage-5.3.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:7e4d159021c2029b958b2363abec4a11db0ce8cd43abb0d9ce44284cb97217e7"},
+    {file = "coverage-5.3.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:378ac77af41350a8c6b8801a66021b52da8a05fd77e578b7380e876c0ce4f528"},
+    {file = "coverage-5.3.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:e448f56cfeae7b1b3b5bcd99bb377cde7c4eb1970a525c770720a352bc4c8044"},
+    {file = "coverage-5.3.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:cc44e3545d908ecf3e5773266c487ad1877be718d9dc65fc7eb6e7d14960985b"},
+    {file = "coverage-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:08b3ba72bd981531fd557f67beee376d6700fba183b167857038997ba30dd297"},
+    {file = "coverage-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:8dacc4073c359f40fcf73aede8428c35f84639baad7e1b46fce5ab7a8a7be4bb"},
+    {file = "coverage-5.3.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:ee2f1d1c223c3d2c24e3afbb2dd38be3f03b1a8d6a83ee3d9eb8c36a52bee899"},
+    {file = "coverage-5.3.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:9a9d4ff06804920388aab69c5ea8a77525cf165356db70131616acd269e19b36"},
+    {file = "coverage-5.3.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:782a5c7df9f91979a7a21792e09b34a658058896628217ae6362088b123c8500"},
+    {file = "coverage-5.3.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:fda29412a66099af6d6de0baa6bd7c52674de177ec2ad2630ca264142d69c6c7"},
+    {file = "coverage-5.3.1-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:f2c6888eada180814b8583c3e793f3f343a692fc802546eed45f40a001b1169f"},
+    {file = "coverage-5.3.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:8f33d1156241c43755137288dea619105477961cfa7e47f48dbf96bc2c30720b"},
+    {file = "coverage-5.3.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b239711e774c8eb910e9b1ac719f02f5ae4bf35fa0420f438cdc3a7e4e7dd6ec"},
+    {file = "coverage-5.3.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:f54de00baf200b4539a5a092a759f000b5f45fd226d6d25a76b0dff71177a714"},
+    {file = "coverage-5.3.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:be0416074d7f253865bb67630cf7210cbc14eb05f4099cc0f82430135aaa7a3b"},
+    {file = "coverage-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:c46643970dff9f5c976c6512fd35768c4a3819f01f61169d8cdac3f9290903b7"},
+    {file = "coverage-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9a4f66259bdd6964d8cf26142733c81fb562252db74ea367d9beb4f815478e72"},
+    {file = "coverage-5.3.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c6e5174f8ca585755988bc278c8bb5d02d9dc2e971591ef4a1baabdf2d99589b"},
+    {file = "coverage-5.3.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:3911c2ef96e5ddc748a3c8b4702c61986628bb719b8378bf1e4a6184bbd48fe4"},
+    {file = "coverage-5.3.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c5ec71fd4a43b6d84ddb88c1df94572479d9a26ef3f150cef3dacefecf888105"},
+    {file = "coverage-5.3.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f51dbba78d68a44e99d484ca8c8f604f17e957c1ca09c3ebc2c7e3bbd9ba0448"},
+    {file = "coverage-5.3.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:a2070c5affdb3a5e751f24208c5c4f3d5f008fa04d28731416e023c93b275277"},
+    {file = "coverage-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:535dc1e6e68fad5355f9984d5637c33badbdc987b0c0d303ee95a6c979c9516f"},
+    {file = "coverage-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:a4857f7e2bc6921dbd487c5c88b84f5633de3e7d416c4dc0bb70256775551a6c"},
+    {file = "coverage-5.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fac3c432851038b3e6afe086f777732bcf7f6ebbfd90951fa04ee53db6d0bcdd"},
+    {file = "coverage-5.3.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cd556c79ad665faeae28020a0ab3bda6cd47d94bec48e36970719b0b86e4dcf4"},
+    {file = "coverage-5.3.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a66ca3bdf21c653e47f726ca57f46ba7fc1f260ad99ba783acc3e58e3ebdb9ff"},
+    {file = "coverage-5.3.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ab110c48bc3d97b4d19af41865e14531f300b482da21783fdaacd159251890e8"},
+    {file = "coverage-5.3.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e52d3d95df81c8f6b2a1685aabffadf2d2d9ad97203a40f8d61e51b70f191e4e"},
+    {file = "coverage-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:fa10fee7e32213f5c7b0d6428ea92e3a3fdd6d725590238a3f92c0de1c78b9d2"},
+    {file = "coverage-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:ce6f3a147b4b1a8b09aae48517ae91139b1b010c5f36423fa2b866a8b23df879"},
+    {file = "coverage-5.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:93a280c9eb736a0dcca19296f3c30c720cb41a71b1f9e617f341f0a8e791a69b"},
+    {file = "coverage-5.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3102bb2c206700a7d28181dbe04d66b30780cde1d1c02c5f3c165cf3d2489497"},
+    {file = "coverage-5.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8ffd4b204d7de77b5dd558cdff986a8274796a1e57813ed005b33fd97e29f059"},
+    {file = "coverage-5.3.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a607ae05b6c96057ba86c811d9c43423f35e03874ffb03fbdcd45e0637e8b631"},
+    {file = "coverage-5.3.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:3a3c3f8863255f3c31db3889f8055989527173ef6192a283eb6f4db3c579d830"},
+    {file = "coverage-5.3.1-cp38-cp38-win32.whl", hash = "sha256:ff1330e8bc996570221b450e2d539134baa9465f5cb98aff0e0f73f34172e0ae"},
+    {file = "coverage-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:3498b27d8236057def41de3585f317abae235dd3a11d33e01736ffedb2ef8606"},
+    {file = "coverage-5.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ceb499d2b3d1d7b7ba23abe8bf26df5f06ba8c71127f188333dddcf356b4b63f"},
+    {file = "coverage-5.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:3b14b1da110ea50c8bcbadc3b82c3933974dbeea1832e814aab93ca1163cd4c1"},
+    {file = "coverage-5.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:76b2775dda7e78680d688daabcb485dc87cf5e3184a0b3e012e1d40e38527cc8"},
+    {file = "coverage-5.3.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:cef06fb382557f66d81d804230c11ab292d94b840b3cb7bf4450778377b592f4"},
+    {file = "coverage-5.3.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f61319e33222591f885c598e3e24f6a4be3533c1d70c19e0dc59e83a71ce27d"},
+    {file = "coverage-5.3.1-cp39-cp39-win32.whl", hash = "sha256:cc6f8246e74dd210d7e2b56c76ceaba1cc52b025cd75dbe96eb48791e0250e98"},
+    {file = "coverage-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:2757fa64e11ec12220968f65d086b7a29b6583d16e9a544c889b22ba98555ef1"},
+    {file = "coverage-5.3.1-pp36-none-any.whl", hash = "sha256:723d22d324e7997a651478e9c5a3120a0ecbc9a7e94071f7e1954562a8806cf3"},
+    {file = "coverage-5.3.1-pp37-none-any.whl", hash = "sha256:c89b558f8a9a5a6f2cfc923c304d49f0ce629c3bd85cb442ca258ec20366394c"},
+    {file = "coverage-5.3.1.tar.gz", hash = "sha256:38f16b1317b8dd82df67ed5daa5f5e7c959e46579840d77a67a4ceb9cef0a50b"},
+]
 cryptography = [
     {file = "cryptography-3.3.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:c366df0401d1ec4e548bebe8f91d55ebcc0ec3137900d214dd7aac8427ef3030"},
     {file = "cryptography-3.3.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9f6b0492d111b43de5f70052e24c1f0951cb9e6022188ebcb1cc3a3d301469b0"},
@@ -715,8 +821,8 @@ future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-3.1.1-py3-none-any.whl", hash = "sha256:6112e21359ef8f344e7178aa5b72dc6e62b38b0d008e6d3cb212c5b84df72013"},
-    {file = "importlib_metadata-3.1.1.tar.gz", hash = "sha256:b0c2d3b226157ae4517d9625decf63591461c66b3a808c2666d538946519d170"},
+    {file = "importlib_metadata-3.4.0-py3-none-any.whl", hash = "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771"},
+    {file = "importlib_metadata-3.4.0.tar.gz", hash = "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -731,8 +837,8 @@ jinja2 = [
     {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
 ]
 joblib = [
-    {file = "joblib-0.17.0-py3-none-any.whl", hash = "sha256:698c311779f347cf6b7e6b8a39bb682277b8ee4aba8cf9507bc0cf4cd4737b72"},
-    {file = "joblib-0.17.0.tar.gz", hash = "sha256:9e284edd6be6b71883a63c9b7f124738a3c16195513ad940eae7e3438de885d5"},
+    {file = "joblib-1.0.0-py3-none-any.whl", hash = "sha256:75ead23f13484a2a414874779d69ade40d4fa1abe62b222a23cd50d4bc822f6f"},
+    {file = "joblib-1.0.0.tar.gz", hash = "sha256:7ad866067ac1fdec27d51c8678ea760601b70e32ff1881d4dc8e1171f2b64b24"},
 ]
 keyring = [
     {file = "keyring-21.8.0-py3-none-any.whl", hash = "sha256:4be9cbaaaf83e61d6399f733d113ede7d1c73bc75cb6aeb64eee0f6ac39b30ea"},
@@ -788,6 +894,10 @@ mkdocs = [
     {file = "mkdocs-1.1.2-py3-none-any.whl", hash = "sha256:096f52ff52c02c7e90332d2e53da862fde5c062086e1b5356a6e392d5d60f5e9"},
     {file = "mkdocs-1.1.2.tar.gz", hash = "sha256:f0b61e5402b99d7789efa032c7a74c90a20220a9c81749da06dbfbcbd52ffb39"},
 ]
+mock = [
+    {file = "mock-4.0.3-py3-none-any.whl", hash = "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62"},
+    {file = "mock-4.0.3.tar.gz", hash = "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
@@ -800,7 +910,7 @@ packaging = [
     {file = "packaging-20.8.tar.gz", hash = "sha256:78598185a7008a470d64526a8059de9aaa449238f280fc9eb6b13ba6c4109093"},
 ]
 parse = [
-    {file = "parse-1.18.0.tar.gz", hash = "sha256:91666032d6723dc5905248417ef0dc9e4c51df9526aaeef271eacad6491f06a4"},
+    {file = "parse-1.19.0.tar.gz", hash = "sha256:9ff82852bcb65d139813e2a5197627a94966245c897796760a3a2a8eb66f020b"},
 ]
 parse-type = [
     {file = "parse_type-0.5.2-py2.py3-none-any.whl", hash = "sha256:089a471b06327103865dfec2dd844230c3c658a4a1b5b4c8b6c16c8f77577f9e"},
@@ -838,6 +948,14 @@ pytest = [
     {file = "pytest-6.2.1-py3-none-any.whl", hash = "sha256:1969f797a1a0dbd8ccf0fecc80262312729afea9c17f1d70ebf85c5e76c6f7c8"},
     {file = "pytest-6.2.1.tar.gz", hash = "sha256:66e419b1899bc27346cb2c993e12c5e5e8daba9073c1fbce33b9807abc95c306"},
 ]
+pytest-cov = [
+    {file = "pytest-cov-2.11.1.tar.gz", hash = "sha256:359952d9d39b9f822d9d29324483e7ba04a3a17dd7d05aa6beb7ea01e359e5f7"},
+    {file = "pytest_cov-2.11.1-py2.py3-none-any.whl", hash = "sha256:bdb9fdb0b85a7cc825269a4c56b48ccaa5c7e365054b6038772c32ddcdc969da"},
+]
+pytest-mock = [
+    {file = "pytest-mock-3.5.1.tar.gz", hash = "sha256:a1e2aba6af9560d313c642dae7e00a2a12b022b80301d9d7fc8ec6858e1dd9fc"},
+    {file = "pytest_mock-3.5.1-py3-none-any.whl", hash = "sha256:379b391cfad22422ea2e252bdfc008edd08509029bcde3c25b2c0bd741e0424e"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
@@ -855,19 +973,27 @@ pyxdg = [
     {file = "pyxdg-0.27.tar.gz", hash = "sha256:80bd93aae5ed82435f20462ea0208fb198d8eec262e831ee06ce9ddb6b91c5a5"},
 ]
 pyyaml = [
-    {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
-    {file = "PyYAML-5.3.1-cp27-cp27m-win_amd64.whl", hash = "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76"},
-    {file = "PyYAML-5.3.1-cp35-cp35m-win32.whl", hash = "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2"},
-    {file = "PyYAML-5.3.1-cp35-cp35m-win_amd64.whl", hash = "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c"},
-    {file = "PyYAML-5.3.1-cp36-cp36m-win32.whl", hash = "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2"},
-    {file = "PyYAML-5.3.1-cp36-cp36m-win_amd64.whl", hash = "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648"},
-    {file = "PyYAML-5.3.1-cp37-cp37m-win32.whl", hash = "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"},
-    {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
-    {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
-    {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
-    {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
+    {file = "PyYAML-5.4.1-cp27-cp27m-win_amd64.whl", hash = "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8"},
+    {file = "PyYAML-5.4.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win32.whl", hash = "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5"},
+    {file = "PyYAML-5.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win32.whl", hash = "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b"},
+    {file = "PyYAML-5.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf"},
+    {file = "PyYAML-5.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46"},
+    {file = "PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win32.whl", hash = "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc"},
+    {file = "PyYAML-5.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696"},
+    {file = "PyYAML-5.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77"},
+    {file = "PyYAML-5.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
+    {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
+    {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
 ]
 regex = [
     {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
@@ -972,40 +1098,40 @@ tornado = [
     {file = "tornado-6.1.tar.gz", hash = "sha256:33c6e81d7bd55b468d2e793517c909b139960b6c790a60b7991b9b6b76fb9791"},
 ]
 tqdm = [
-    {file = "tqdm-4.54.1-py2.py3-none-any.whl", hash = "sha256:d4f413aecb61c9779888c64ddf0c62910ad56dcbe857d8922bb505d4dbff0df1"},
-    {file = "tqdm-4.54.1.tar.gz", hash = "sha256:38b658a3e4ecf9b4f6f8ff75ca16221ae3378b2e175d846b6b33ea3a20852cf5"},
+    {file = "tqdm-4.56.0-py2.py3-none-any.whl", hash = "sha256:4621f6823bab46a9cc33d48105753ccbea671b68bab2c50a9f0be23d4065cb5a"},
+    {file = "tqdm-4.56.0.tar.gz", hash = "sha256:fe3d08dd00a526850568d542ff9de9bbc2a09a791da3c334f3213d8d0bbbca65"},
 ]
 typed-ast = [
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win32.whl", hash = "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919"},
-    {file = "typed_ast-1.4.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:fcf135e17cc74dbfbc05894ebca928ffeb23d9790b3167a674921db19082401f"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win32.whl", hash = "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1"},
-    {file = "typed_ast-1.4.1-cp36-cp36m-win_amd64.whl", hash = "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f208eb7aff048f6bea9586e61af041ddf7f9ade7caed625742af423f6bae3298"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win32.whl", hash = "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe"},
-    {file = "typed_ast-1.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355"},
-    {file = "typed_ast-1.4.1-cp38-cp38-macosx_10_15_x86_64.whl", hash = "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:7e4c9d7658aaa1fc80018593abdf8598bf91325af6af5cce4ce7c73bc45ea53d"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win32.whl", hash = "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c"},
-    {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
-    {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92c325624e304ebf0e025d1224b77dd4e6393f18aab8d829b5b7e04afe9b7a2c"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d648b8e3bf2fe648745c8ffcee3db3ff903d0817a01a12dd6a6ea7a8f4889072"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:fac11badff8313e23717f3dada86a15389d0708275bddf766cca67a84ead3e91"},
-    {file = "typed_ast-1.4.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:0d8110d78a5736e16e26213114a38ca35cb15b6515d535413b090bd50951556d"},
-    {file = "typed_ast-1.4.1-cp39-cp39-win32.whl", hash = "sha256:b52ccf7cfe4ce2a1064b18594381bccf4179c2ecf7f513134ec2f993dd4ab395"},
-    {file = "typed_ast-1.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:3742b32cf1c6ef124d57f95be609c473d7ec4c14d0090e5a5e05a15269fb4d0c"},
-    {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7703620125e4fb79b64aa52427ec192822e9f45d37d4b6625ab37ef403e1df70"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c9aadc4924d4b5799112837b226160428524a9a45f830e0d0f184b19e4090487"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:9ec45db0c766f196ae629e509f059ff05fc3148f9ffd28f3cfe75d4afb485412"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:85f95aa97a35bdb2f2f7d10ec5bbdac0aeb9dafdaf88e17492da0504de2e6400"},
+    {file = "typed_ast-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:9044ef2df88d7f33692ae3f18d3be63dec69c4fb1b5a4a9ac950f9b4ba571606"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c1c876fd795b36126f773db9cbb393f19808edd2637e00fd6caba0e25f2c7b64"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5dcfc2e264bd8a1db8b11a892bd1647154ce03eeba94b461effe68790d8b8e07"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8db0e856712f79c45956da0c9a40ca4246abc3485ae0d7ecc86a20f5e4c09abc"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d003156bb6a59cda9050e983441b7fa2487f7800d76bdc065566b7d728b4581a"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:4c790331247081ea7c632a76d5b2a265e6d325ecd3179d06e9cf8d46d90dd151"},
+    {file = "typed_ast-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:d175297e9533d8d37437abc14e8a83cbc68af93cc9c1c59c2c292ec59a0697a3"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf54cfa843f297991b7388c281cb3855d911137223c6b6d2dd82a47ae5125a41"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b4fcdcfa302538f70929eb7b392f536a237cbe2ed9cba88e3bf5027b39f5f77f"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:987f15737aba2ab5f3928c617ccf1ce412e2e321c77ab16ca5a293e7bbffd581"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:37f48d46d733d57cc70fd5f30572d11ab8ed92da6e6b28e024e4a3edfb456e37"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:36d829b31ab67d6fcb30e185ec996e1f72b892255a745d3a82138c97d21ed1cd"},
+    {file = "typed_ast-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8368f83e93c7156ccd40e49a783a6a6850ca25b556c0fa0240ed0f659d2fe496"},
+    {file = "typed_ast-1.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:963c80b583b0661918718b095e02303d8078950b26cc00b5e5ea9ababe0de1fc"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e683e409e5c45d5c9082dc1daf13f6374300806240719f95dc783d1fc942af10"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:84aa6223d71012c68d577c83f4e7db50d11d6b1399a9c779046d75e24bed74ea"},
+    {file = "typed_ast-1.4.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a38878a223bdd37c9709d07cd357bb79f4c760b29210e14ad0fb395294583787"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win32.whl", hash = "sha256:a2c927c49f2029291fbabd673d51a2180038f8cd5a5b2f290f78c4516be48be2"},
+    {file = "typed_ast-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:c0c74e5579af4b977c8b932f40a5464764b2f86681327410aa028a22d2f54937"},
+    {file = "typed_ast-1.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:07d49388d5bf7e863f7fa2f124b1b1d89d8aa0e2f7812faff0a5658c01c59aa1"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:240296b27397e4e37874abb1df2a608a92df85cf3e2a04d0d4d61055c8305ba6"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:d746a437cdbca200622385305aedd9aef68e8a645e385cc483bdc5e488f07166"},
+    {file = "typed_ast-1.4.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:14bf1522cdee369e8f5581238edac09150c765ec1cb33615855889cf33dcb92d"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win32.whl", hash = "sha256:cc7b98bf58167b7f2db91a4327da24fb93368838eb84a44c472283778fc2446b"},
+    {file = "typed_ast-1.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:7147e2a76c75f0f64c4319886e7639e490fee87c9d25cb1d4faef1d8cf83a440"},
+    {file = "typed_ast-1.4.2.tar.gz", hash = "sha256:9fc0b3cb5d1720e7141d103cf4819aea239f7d136acf9ee4a69b047b7986175a"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ pyyaml = ">=5.1"
 # dayone-only deps
 pytz = ">=2020"          # https://pythonhosted.org/pytz/#issues-limitations
 tzlocal = ">2.0, <3.0"   # https://github.com/regebro/tzlocal/blob/master/CHANGES.txt
+mock = "^4.0.3"
 
 [tool.poetry.dev-dependencies]
 behave = "^1.2"
@@ -45,8 +46,9 @@ black = {version = "^20.8b1",allow-prereleases = true}
 toml = ">=0.10"
 pyflakes = ">=2.2.0"
 pytest = ">=6.2"
+pytest-mock = "^3.5.1"
+pytest-cov = "^2.11.1"
 yq = ">=2.11"
-
 [tool.poetry.scripts]
 jrnl = 'jrnl.cli:cli'
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,8 @@ def test_override_configured_editor(
     cli_args = ["--config-override", '{"editor": "nano"}']
     parser = parse_args(cli_args)
     assert parser.config_override.__len__() == 1
-    assert "editor" in parser.config_override.keys() 
+    assert "editor" in parser.config_override.keys()
+
     def mock_editor_launch(editor):
         print("%s launched! Success!" % editor)
 
@@ -56,21 +57,21 @@ def test_override_configured_editor(
         run(parser)
     mock_write_in_editor.assert_called_once_with(expected_override)
 
+
 @pytest.fixture()
-def expected_color_override(minimal_config): 
-    exp_out_cfg = minimal_config.copy() 
+def expected_color_override(minimal_config):
+    exp_out_cfg = minimal_config.copy()
     exp_out_cfg["colors"] = {"body": "blue"}
     exp_out_cfg["journal"] = "features/journals/simple.journal"
     yield exp_out_cfg
 
+
 # @mock.patch.object(install,'load_or_install_jrnl')
 # @mock.patch('subprocess.call')
-# def test_override_configured_colors(mock_load_or_install, mock_subprocess_call, minimal_config, expected_color_override, capsys): 
+# def test_override_configured_colors(mock_load_or_install, mock_subprocess_call, minimal_config, expected_color_override, capsys):
 #     mock_load_or_install.return_value = minimal_config
-    
+
 #     cli_args=["--config-override",'{"colors.body": "blue"}']
 #     parser = parse_args(cli_args)
-#     assert "colors.body" in parser.config_override.keys() 
+#     assert "colors.body" in parser.config_override.keys()
 #     run(parser)
-
-    

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -12,31 +12,31 @@ from jrnl import install, editor
 @pytest.fixture()
 def minimal_config():
     with open("features/data/configs/editor.yaml", "r") as cfg_file:
-        cfg =  yaml.load(cfg_file.read())
-    yield cfg 
+        cfg = yaml.load(cfg_file.read())
+    yield cfg
+
 
 @pytest.fixture()
 def expected_override(minimal_config):
     exp_out_cfg = minimal_config.copy()
-    exp_out_cfg['editor'] = 'nano'
-    exp_out_cfg['journal'] =  'features/journals/simple.journal'
+    exp_out_cfg["editor"] = "nano"
+    exp_out_cfg["journal"] = "features/journals/simple.journal"
     yield exp_out_cfg
 
 
 from jrnl import jrnl
 
 
-
-@mock.patch('sys.stdin.isatty')
+@mock.patch("sys.stdin.isatty")
 @mock.patch.object(install, "load_or_install_jrnl")
-@mock.patch('subprocess.call')
+@mock.patch("subprocess.call")
 def test_override_configured_editor(
     mock_subprocess_call,
-    mock_load_or_install, 
-    mock_isatty, 
-    minimal_config, 
+    mock_load_or_install,
+    mock_isatty,
+    minimal_config,
     expected_override,
-    capsys
+    capsys,
 ):
     mock_load_or_install.return_value = minimal_config
     mock_isatty.return_value = True
@@ -44,11 +44,15 @@ def test_override_configured_editor(
     cli_args = ["--override", '{"editor": "nano"}']
     parser = parse_args(cli_args)
     assert parser.config_override.__len__() == 1
-    def mock_editor_launch(editor): 
-        print("%s launched! Success!"%editor)
-    with mock.patch.object(jrnl,'_write_in_editor', side_effect=mock_editor_launch(parser.config_override['editor']), return_value = 'note_contents') as mock_write_in_editor:
+
+    def mock_editor_launch(editor):
+        print("%s launched! Success!" % editor)
+
+    with mock.patch.object(
+        jrnl,
+        "_write_in_editor",
+        side_effect=mock_editor_launch(parser.config_override["editor"]),
+        return_value="note_contents",
+    ) as mock_write_in_editor:
         run(parser)
     mock_write_in_editor.assert_called_once_with(expected_override)
-
-
-    

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 import mock

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ import mock
 
 import yaml
 from jrnl.args import parse_args
-from jrnl.jrnl import run
+from jrnl.jrnl import run, search_mode
 from jrnl import install
 
 
@@ -43,7 +43,7 @@ def test_override_configured_editor(
     cli_args = ["--config-override", '{"editor": "nano"}']
     parser = parse_args(cli_args)
     assert parser.config_override.__len__() == 1
-
+    assert "editor" in parser.config_override.keys() 
     def mock_editor_launch(editor):
         print("%s launched! Success!" % editor)
 
@@ -55,3 +55,22 @@ def test_override_configured_editor(
     ) as mock_write_in_editor:
         run(parser)
     mock_write_in_editor.assert_called_once_with(expected_override)
+
+@pytest.fixture()
+def expected_color_override(minimal_config): 
+    exp_out_cfg = minimal_config.copy() 
+    exp_out_cfg["colors"] = {"body": "blue"}
+    exp_out_cfg["journal"] = "features/journals/simple.journal"
+    yield exp_out_cfg
+
+# @mock.patch.object(install,'load_or_install_jrnl')
+# @mock.patch('subprocess.call')
+# def test_override_configured_colors(mock_load_or_install, mock_subprocess_call, minimal_config, expected_color_override, capsys): 
+#     mock_load_or_install.return_value = minimal_config
+    
+#     cli_args=["--config-override",'{"colors.body": "blue"}']
+#     parser = parse_args(cli_args)
+#     assert "colors.body" in parser.config_override.keys() 
+#     run(parser)
+
+    

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,12 @@
 import pytest
-
 import mock
 
 import yaml
+
 from jrnl.args import parse_args
 from jrnl.jrnl import run
 from jrnl import install
+from jrnl import jrnl
 
 
 @pytest.fixture()
@@ -15,13 +16,9 @@ def minimal_config():
         "default": "/tmp/journal.jrnl",
         "editor": "vim",
         "encrypt": False,
-        "journals": {
-            "default": "/tmp/journals/journal.jrnl"
-        }
-
+        "journals": {"default": "/tmp/journals/journal.jrnl"},
     }
     yield cfg
-
 
 
 @pytest.fixture()
@@ -30,9 +27,6 @@ def expected_override(minimal_config):
     exp_out_cfg["editor"] = "nano"
     exp_out_cfg["journal"] = "/tmp/journals/journal.jrnl"
     yield exp_out_cfg
-
-
-from jrnl import jrnl
 
 
 @mock.patch("sys.stdin.isatty")
@@ -70,13 +64,15 @@ def test_override_configured_editor(
 @pytest.fixture()
 def expected_color_override(minimal_config):
     exp_out_cfg = minimal_config.copy()
-    exp_out_cfg["colors"]["body"] =  "blue"
+    exp_out_cfg["colors"]["body"] = "blue"
     exp_out_cfg["journal"] = "/tmp/journals/journal.jrnl"
     yield exp_out_cfg
 
 
 @mock.patch("sys.stdin.isatty")
-@mock.patch("jrnl.install.load_or_install_jrnl", wraps=jrnl.install.load_or_install_jrnl)
+@mock.patch(
+    "jrnl.install.load_or_install_jrnl", wraps=jrnl.install.load_or_install_jrnl
+)
 @mock.patch("subprocess.call")
 def test_override_configured_colors(
     mock_isatty,
@@ -94,7 +90,7 @@ def test_override_configured_colors(
     with mock.patch.object(
         jrnl,
         "_write_in_editor",
-        side_effect= print("side effect!"),
+        side_effect=print("side effect!"),
         return_value="note_contents",
     ) as mock_write_in_editor:
         run(parser)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,7 +40,7 @@ def test_override_configured_editor(
     mock_load_or_install.return_value = minimal_config
     mock_isatty.return_value = True
 
-    cli_args = ["--override", '{"editor": "nano"}']
+    cli_args = ["--config-override", '{"editor": "nano"}']
     parser = parse_args(cli_args)
     assert parser.config_override.__len__() == 1
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,12 +1,12 @@
-from typing import Any
+
 import pytest
-import pytest_mock
+
 import mock
 
 import yaml
 from jrnl.args import parse_args
 from jrnl.jrnl import run
-from jrnl import install, editor
+from jrnl import install
 
 
 @pytest.fixture()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -85,7 +85,7 @@ def test_override_configured_colors(
 ):
     mock_load_or_install.return_value = minimal_config
 
-    cli_args = shlex.split('--config-override colors.body:blue')
+    cli_args = shlex.split("--config-override colors.body:blue")
     parser = parse_args(cli_args)
     assert "colors.body" in parser.config_override.keys()
     with mock.patch.object(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import shlex
 import pytest
 import mock
 
@@ -43,7 +44,7 @@ def test_override_configured_editor(
     mock_load_or_install.return_value = minimal_config
     mock_isatty.return_value = True
 
-    cli_args = ["--config-override", '{"editor": "nano"}']
+    cli_args = shlex.split('--config-override editor:"nano"')
     parser = parse_args(cli_args)
     assert parser.config_override.__len__() == 1
     assert "editor" in parser.config_override.keys()
@@ -84,7 +85,7 @@ def test_override_configured_colors(
 ):
     mock_load_or_install.return_value = minimal_config
 
-    cli_args = ["--config-override", '{"colors.body": "blue"}']
+    cli_args = shlex.split('--config-override colors.body:blue')
     parser = parse_args(cli_args)
     assert "colors.body" in parser.config_override.keys()
     with mock.patch.object(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+from typing import Any
 import pytest
 import pytest_mock
 import mock
@@ -5,27 +6,49 @@ import mock
 import yaml
 from jrnl.args import parse_args
 from jrnl.jrnl import run
-from jrnl import install
+from jrnl import install, editor
 
 
 @pytest.fixture()
 def minimal_config():
     with open("features/data/configs/editor.yaml", "r") as cfg_file:
-        yield yaml.load(cfg_file.read())
+        cfg =  yaml.load(cfg_file.read())
+    yield cfg 
+
+@pytest.fixture()
+def expected_override(minimal_config):
+    exp_out_cfg = minimal_config.copy()
+    exp_out_cfg['editor'] = 'nano'
+    exp_out_cfg['journal'] =  'features/journals/simple.journal'
+    yield exp_out_cfg
 
 
 from jrnl import jrnl
 
 
-@mock.patch.object(jrnl, "write_mode")
+
+@mock.patch('sys.stdin.isatty')
 @mock.patch.object(install, "load_or_install_jrnl")
+@mock.patch('subprocess.call')
 def test_override_configured_editor(
-    mock_load_or_install, mock_write_mode, minimal_config
+    mock_subprocess_call,
+    mock_load_or_install, 
+    mock_isatty, 
+    minimal_config, 
+    expected_override,
+    capsys
 ):
     mock_load_or_install.return_value = minimal_config
+    mock_isatty.return_value = True
+
     cli_args = ["--override", '{"editor": "nano"}']
     parser = parse_args(cli_args)
     assert parser.config_override.__len__() == 1
-    with mock.patch("subprocess.call"):
-        res = run(parser)
-    assert res == None
+    def mock_editor_launch(editor): 
+        print("%s launched! Success!"%editor)
+    with mock.patch.object(jrnl,'_write_in_editor', side_effect=mock_editor_launch(parser.config_override['editor']), return_value = 'note_contents') as mock_write_in_editor:
+        run(parser)
+    mock_write_in_editor.assert_called_once_with(expected_override)
+
+
+    

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,25 +1,31 @@
-import pytest 
-import pytest_mock 
+import pytest
+import pytest_mock
 import mock
 
 import yaml
 from jrnl.args import parse_args
-from jrnl.jrnl import run 
-from jrnl import install 
+from jrnl.jrnl import run
+from jrnl import install
+
 
 @pytest.fixture()
 def minimal_config():
-    with open('features/data/configs/editor.yaml','r') as cfg_file:
+    with open("features/data/configs/editor.yaml", "r") as cfg_file:
         yield yaml.load(cfg_file.read())
 
+
 from jrnl import jrnl
-@mock.patch.object(jrnl,'write_mode')
-@mock.patch.object(install,'load_or_install_jrnl')
-def test_override_configured_editor(mock_load_or_install, mock_write_mode, minimal_config): 
+
+
+@mock.patch.object(jrnl, "write_mode")
+@mock.patch.object(install, "load_or_install_jrnl")
+def test_override_configured_editor(
+    mock_load_or_install, mock_write_mode, minimal_config
+):
     mock_load_or_install.return_value = minimal_config
-    cli_args = ['--override','{\"editor\": \"nano\"}' ]
+    cli_args = ["--override", '{"editor": "nano"}']
     parser = parse_args(cli_args)
     assert parser.config_override.__len__() == 1
-    with mock.patch('subprocess.call'):
+    with mock.patch("subprocess.call"):
         res = run(parser)
-    assert res==None 
+    assert res == None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@ import shlex
 import pytest
 import mock
 
-import yaml
 
 from jrnl.args import parse_args
 from jrnl.jrnl import run

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,14 +4,14 @@ import mock
 
 import yaml
 from jrnl.args import parse_args
-from jrnl.jrnl import run, search_mode
+from jrnl.jrnl import run
 from jrnl import install
 
 
 @pytest.fixture()
 def minimal_config():
     with open("features/data/configs/editor.yaml", "r") as cfg_file:
-        cfg = yaml.load(cfg_file.read())
+        cfg = yaml.load(cfg_file.read(), Loader=yaml.FullLoader)
     yield cfg
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+import pytest 
+import pytest_mock 
+import mock
+
+import yaml
+from jrnl.args import parse_args
+from jrnl.jrnl import run 
+from jrnl import install 
+
+@pytest.fixture()
+def minimal_config():
+    with open('features/data/configs/editor.yaml','r') as cfg_file:
+        yield yaml.load(cfg_file.read())
+
+from jrnl import jrnl
+@mock.patch.object(jrnl,'write_mode')
+@mock.patch.object(install,'load_or_install_jrnl')
+def test_override_configured_editor(mock_load_or_install, mock_write_mode, minimal_config): 
+    mock_load_or_install.return_value = minimal_config
+    cli_args = ['--override','{\"editor\": \"nano\"}' ]
+    parser = parse_args(cli_args)
+    assert parser.config_override.__len__() == 1
+    with mock.patch('subprocess.call'):
+        res = run(parser)
+    assert res==None 

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -34,6 +34,7 @@ def test_multiple_overrides(minimal_config):
         "editor": "nano",
         "journals.burner": "/tmp/journals/burner.jrnl",
     }  # as returned by parse_args, saved in parser.config_override
+
     cfg = apply_overrides(overrides, minimal_config.copy())
     assert cfg["editor"] == "nano"
     assert cfg["colors"]["title"] == "magenta"

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -9,6 +9,10 @@ def minimal_config():
         "colors": {"body": "red", "date": "green"},
         "default": "/tmp/journal.jrnl",
         "editor": "vim",
+        "journals": {
+            "default": "/tmp/journals/journal.jrnl"
+        }
+
     }
     yield cfg
 
@@ -26,6 +30,17 @@ def test_override_dot_notation(minimal_config):
     cfg = apply_overrides(overrides=overrides, base_config=cfg)
     assert cfg["colors"] == {"body": "blue", "date": "green"}
 
+def test_multiple_overrides(minimal_config): 
+    overrides = { 
+        "colors.title": "magenta", 
+        "editor": "nano", 
+        "journals.burner": "/tmp/journals/burner.jrnl"
+    } # as returned by parse_args, saved in parser.config_override 
+    cfg = apply_overrides(overrides, minimal_config.copy())
+    assert cfg["editor"] == "nano" 
+    assert cfg["colors"]["title"] == "magenta"
+    assert "burner" in cfg["journals"]
+    assert cfg["journals"]["burner"] == "/tmp/journals/burner.jrnl"
 
 def test_recursively_apply():
     cfg = {"colors": {"body": "red", "title": "green"}}
@@ -34,6 +49,6 @@ def test_recursively_apply():
 
 
 def test_get_config_node(minimal_config):
-    assert len(minimal_config.keys()) == 3
+    assert len(minimal_config.keys()) == 4
     assert _get_config_node(minimal_config, "editor") == "vim"
     assert _get_config_node(minimal_config, "display_format") == None

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -1,41 +1,34 @@
 import pytest
 
 from jrnl.override import apply_overrides, recursively_apply
+
+
 @pytest.fixture()
-def minimal_config(): 
-    cfg = { 
-        "colors":{ 
-            "body":"red",
-            "date":"green"
-        },
-        "default":"/tmp/journal.jrnl",
-        "editor":"vim"
+def minimal_config():
+    cfg = {
+        "colors": {"body": "red", "date": "green"},
+        "default": "/tmp/journal.jrnl",
+        "editor": "vim",
     }
-    yield cfg 
+    yield cfg
 
-def test_apply_override(minimal_config): 
+
+def test_apply_override(minimal_config):
     config = minimal_config.copy()
-    overrides = {
-        'editor':'nano'
-    }
+    overrides = {"editor": "nano"}
     config = apply_overrides(overrides, config)
-    assert config['editor']=='nano'
+    assert config["editor"] == "nano"
 
-def test_override_dot_notation(minimal_config): 
-    cfg = minimal_config.copy() 
-    overrides = { 
-        "colors.body": "blue"
-    }
+
+def test_override_dot_notation(minimal_config):
+    cfg = minimal_config.copy()
+    overrides = {"colors.body": "blue"}
     cfg = apply_overrides(overrides=overrides, base_config=cfg)
-    assert cfg["colors"] == {"body": "blue", "date":"green"}
+    assert cfg["colors"] == {"body": "blue", "date": "green"}
 
-def test_recursive_override(minimal_config): 
-    
-    cfg = { 
-        "colors": { 
-            "body": "red",
-            "title": "green"
-        }
-    }
-    cfg = recursively_apply(cfg,["colors",'body'],"blue")
+
+def test_recursive_override(minimal_config):
+
+    cfg = {"colors": {"body": "red", "title": "green"}}
+    cfg = recursively_apply(cfg, ["colors", "body"], "blue")
     assert cfg["colors"]["body"] == "blue"

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -1,0 +1,27 @@
+import pytest
+
+import mock
+
+from jrnl.args import parse_args
+from jrnl.jrnl import run, search_mode
+from jrnl import install
+from jrnl.override import apply_overrides
+@pytest.fixture()
+def minimal_config(): 
+    cfg = { 
+        "colors":{ 
+            "body":"red",
+            "date":"green"
+        },
+        "default":"/tmp/journal.jrnl",
+        "editor":"vim"
+    }
+    yield cfg 
+
+def test_apply_override(minimal_config): 
+    config = minimal_config.copy()
+    overrides = {
+        'editor':'nano'
+    }
+    config = apply_overrides(overrides, config)
+    assert config['editor']=='nano'

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -1,11 +1,6 @@
 import pytest
 
-import mock
-
-from jrnl.args import parse_args
-from jrnl.jrnl import run, search_mode
-from jrnl import install
-from jrnl.override import apply_overrides
+from jrnl.override import apply_overrides, recursively_apply
 @pytest.fixture()
 def minimal_config(): 
     cfg = { 
@@ -25,3 +20,22 @@ def test_apply_override(minimal_config):
     }
     config = apply_overrides(overrides, config)
     assert config['editor']=='nano'
+
+def test_override_dot_notation(minimal_config): 
+    cfg = minimal_config.copy() 
+    overrides = { 
+        "colors.body": "blue"
+    }
+    cfg = apply_overrides(overrides=overrides, base_config=cfg)
+    assert cfg["colors"] == {"body": "blue", "date":"green"}
+
+def test_recursive_override(minimal_config): 
+    
+    cfg = { 
+        "colors": { 
+            "body": "red",
+            "title": "green"
+        }
+    }
+    cfg = recursively_apply(cfg,["colors",'body'],"blue")
+    assert cfg["colors"]["body"] == "blue"

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -9,10 +9,7 @@ def minimal_config():
         "colors": {"body": "red", "date": "green"},
         "default": "/tmp/journal.jrnl",
         "editor": "vim",
-        "journals": {
-            "default": "/tmp/journals/journal.jrnl"
-        }
-
+        "journals": {"default": "/tmp/journals/journal.jrnl"},
     }
     yield cfg
 
@@ -30,17 +27,19 @@ def test_override_dot_notation(minimal_config):
     cfg = apply_overrides(overrides=overrides, base_config=cfg)
     assert cfg["colors"] == {"body": "blue", "date": "green"}
 
-def test_multiple_overrides(minimal_config): 
-    overrides = { 
-        "colors.title": "magenta", 
-        "editor": "nano", 
-        "journals.burner": "/tmp/journals/burner.jrnl"
-    } # as returned by parse_args, saved in parser.config_override 
+
+def test_multiple_overrides(minimal_config):
+    overrides = {
+        "colors.title": "magenta",
+        "editor": "nano",
+        "journals.burner": "/tmp/journals/burner.jrnl",
+    }  # as returned by parse_args, saved in parser.config_override
     cfg = apply_overrides(overrides, minimal_config.copy())
-    assert cfg["editor"] == "nano" 
+    assert cfg["editor"] == "nano"
     assert cfg["colors"]["title"] == "magenta"
     assert "burner" in cfg["journals"]
     assert cfg["journals"]["burner"] == "/tmp/journals/burner.jrnl"
+
 
 def test_recursively_apply():
     cfg = {"colors": {"body": "red", "title": "green"}}

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -1,6 +1,6 @@
 import pytest
 
-from jrnl.override import apply_overrides, recursively_apply
+from jrnl.override import apply_overrides, _recursively_apply, _get_config_node
 
 
 @pytest.fixture()
@@ -27,10 +27,9 @@ def test_override_dot_notation(minimal_config):
     assert cfg["colors"] == {"body": "blue", "date": "green"}
 
 
-def test_recursive_override(minimal_config):
-
+def test_recursively_apply():
     cfg = {"colors": {"body": "red", "title": "green"}}
-    cfg = recursively_apply(cfg, ["colors", "body"], "blue")
+    cfg = _recursively_apply(cfg, ["colors", "body"], "blue")
     assert cfg["colors"]["body"] == "blue"
 
 

--- a/tests/test_override.py
+++ b/tests/test_override.py
@@ -32,3 +32,9 @@ def test_recursive_override(minimal_config):
     cfg = {"colors": {"body": "red", "title": "green"}}
     cfg = recursively_apply(cfg, ["colors", "body"], "blue")
     assert cfg["colors"]["body"] == "blue"
+
+
+def test_get_config_node(minimal_config):
+    assert len(minimal_config.keys()) == 3
+    assert _get_config_node(minimal_config, "editor") == "vim"
+    assert _get_config_node(minimal_config, "display_format") == None

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -35,6 +35,7 @@ def expected_args(**kwargs):
         "strict": False,
         "tags": False,
         "text": [],
+        "config_override":{}
     }
     return {**default_args, **kwargs}
 
@@ -204,6 +205,10 @@ def test_version_alone():
 
     assert cli_as_dict("--version") == expected_args(preconfig_cmd=preconfig_version)
 
+def test_editor_override():
+    from jrnl.commands import postconfig_override
+
+    assert cli_as_dict("--override '{\"editor\": \"nano\"}'") == expected_args(config_override={'editor':'nano'})
 
 # @see https://github.com/jrnl-org/jrnl/issues/520
 @pytest.mark.parametrize(

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -206,35 +206,35 @@ def test_version_alone():
 
     assert cli_as_dict("--version") == expected_args(preconfig_cmd=preconfig_version)
 
+
 @pytest.mark.parametrize(
     "input_str",
     [
         'editor:"nano", colors.title:blue, default:"/tmp/egg.txt"',
         'editor:"vi -c startinsert", colors.title:blue, default:"/tmp/egg.txt"',
-        'editor:"nano", colors.title:blue, default:"/tmp/eg\ g.txt"'
-    ]
+        'editor:"nano", colors.title:blue, default:"/tmp/eg\ g.txt"',
+    ],
 )
-def test_deserialize_config_args(input_str): 
-    from jrnl.args import deserialize_config_args 
-    
+def test_deserialize_config_args(input_str):
+    from jrnl.args import deserialize_config_args
+
     runtime_config = deserialize_config_args(input_str)
     assert runtime_config.__class__ == dict
     assert "editor" in runtime_config.keys()
     assert "colors.title" in runtime_config.keys()
     assert "default" in runtime_config.keys()
 
+
 def test_editor_override():
 
     parsed_args = cli_as_dict('--config-override editor:"nano"')
-    assert parsed_args == expected_args(
-        config_override={"editor": "nano"}
-    )
+    assert parsed_args == expected_args(config_override={"editor": "nano"})
 
 
 def test_color_override():
-    assert cli_as_dict(
-        '--config-override colors.body:blue'
-    ) == expected_args(config_override={"colors.body": "blue"})
+    assert cli_as_dict("--config-override colors.body:blue") == expected_args(
+        config_override={"colors.body": "blue"}
+    )
 
 
 def test_multiple_overrides():
@@ -243,9 +243,9 @@ def test_multiple_overrides():
     )
     assert parsed_args == expected_args(
         config_override={
-            'colors.title': 'green',
-            'journal.scratchpad': '/tmp/scratchpad',
-            'editor': 'nano',
+            "colors.title": "green",
+            "journal.scratchpad": "/tmp/scratchpad",
+            "editor": "nano",
         }
     )
 

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -1,10 +1,10 @@
-from features.steps.override import config_override
 import shlex
 
 import pytest
 
 from jrnl.args import parse_args
 from jrnl.args import deserialize_config_args
+
 
 def cli_as_dict(str):
     cli = shlex.split(str)
@@ -206,6 +206,7 @@ def test_version_alone():
 
     assert cli_as_dict("--version") == expected_args(preconfig_cmd=preconfig_version)
 
+
 class TestDeserialization:
     @pytest.mark.parametrize(
         "input_str",
@@ -215,8 +216,7 @@ class TestDeserialization:
             'editor:"nano", colors.title:blue, default:"/tmp/eg\ g.txt"',
         ],
     )
-    def test_deserialize_multiword_strings(self,input_str):
-        
+    def test_deserialize_multiword_strings(self, input_str):
 
         runtime_config = deserialize_config_args(input_str)
         assert runtime_config.__class__ == dict
@@ -224,18 +224,19 @@ class TestDeserialization:
         assert "colors.title" in runtime_config.keys()
         assert "default" in runtime_config.keys()
 
-    def test_deserialize_int(self): 
-        input = 'linewrap: 23, default_hour: 19'
+    def test_deserialize_int(self):
+        input = "linewrap: 23, default_hour: 19"
         runtime_config = deserialize_config_args(input)
-        assert runtime_config['linewrap'] == 23 
-        assert runtime_config['default_hour'] == 19
+        assert runtime_config["linewrap"] == 23
+        assert runtime_config["default_hour"] == 19
 
-    def test_deserialize_multiple_datatypes(self): 
+    def test_deserialize_multiple_datatypes(self):
         input = 'linewrap: 23, encrypt: false, editor:"vi -c startinsert"'
-        cfg = deserialize_config_args(input) 
-        assert cfg['encrypt'] == False 
-        assert cfg['linewrap'] == 23 
-        assert cfg['editor'] == '"vi -c startinsert"'
+        cfg = deserialize_config_args(input)
+        assert cfg["encrypt"] == False
+        assert cfg["linewrap"] == 23
+        assert cfg["editor"] == '"vi -c startinsert"'
+
 
 def test_editor_override():
 

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -208,7 +208,7 @@ def test_version_alone():
 
 def test_editor_override():
 
-    assert cli_as_dict('--override \'{"editor": "nano"}\'') == expected_args(
+    assert cli_as_dict('--config-override \'{"editor": "nano"}\'') == expected_args(
         config_override={"editor": "nano"}
     )
 

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -211,10 +211,13 @@ def test_editor_override():
     assert cli_as_dict('--config-override \'{"editor": "nano"}\'') == expected_args(
         config_override={"editor": "nano"}
     )
-def test_color_override(): 
-    assert cli_as_dict('--config-override \'{"colors.body": "blue"}\'') == expected_args(
-        config_override={"colors.body":"blue"}
-    )
+
+
+def test_color_override():
+    assert cli_as_dict(
+        '--config-override \'{"colors.body": "blue"}\''
+    ) == expected_args(config_override={"colors.body": "blue"})
+
 
 # @see https://github.com/jrnl-org/jrnl/issues/520
 @pytest.mark.parametrize(

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -211,7 +211,10 @@ def test_editor_override():
     assert cli_as_dict('--config-override \'{"editor": "nano"}\'') == expected_args(
         config_override={"editor": "nano"}
     )
-
+def test_color_override(): 
+    assert cli_as_dict('--config-override \'{"colors.body": "blue"}\'') == expected_args(
+        config_override={"colors.body":"blue"}
+    )
 
 # @see https://github.com/jrnl-org/jrnl/issues/520
 @pytest.mark.parametrize(

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -1,3 +1,4 @@
+from features.steps.override import config_override
 import shlex
 
 import pytest
@@ -218,6 +219,16 @@ def test_color_override():
         '--config-override \'{"colors.body": "blue"}\''
     ) == expected_args(config_override={"colors.body": "blue"})
 
+def test_multiple_overrides(): 
+    assert cli_as_dict(
+        '--config-override \'{"colors.title": "green", "editor":"", "journal.scratchpad": "/tmp/scratchpad"}\''
+    ) == expected_args(
+        config_override={
+            "colors.title": "green",
+            "journal.scratchpad": "/tmp/scratchpad",
+            "editor": ""
+        }
+    )
 
 # @see https://github.com/jrnl-org/jrnl/issues/520
 @pytest.mark.parametrize(

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -219,16 +219,18 @@ def test_color_override():
         '--config-override \'{"colors.body": "blue"}\''
     ) == expected_args(config_override={"colors.body": "blue"})
 
-def test_multiple_overrides(): 
+
+def test_multiple_overrides():
     assert cli_as_dict(
         '--config-override \'{"colors.title": "green", "editor":"", "journal.scratchpad": "/tmp/scratchpad"}\''
     ) == expected_args(
         config_override={
             "colors.title": "green",
             "journal.scratchpad": "/tmp/scratchpad",
-            "editor": ""
+            "editor": "",
         }
     )
+
 
 # @see https://github.com/jrnl-org/jrnl/issues/520
 @pytest.mark.parametrize(

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -35,7 +35,7 @@ def expected_args(**kwargs):
         "strict": False,
         "tags": False,
         "text": [],
-        "config_override":{}
+        "config_override": {},
     }
     return {**default_args, **kwargs}
 
@@ -205,9 +205,13 @@ def test_version_alone():
 
     assert cli_as_dict("--version") == expected_args(preconfig_cmd=preconfig_version)
 
+
 def test_editor_override():
 
-    assert cli_as_dict("--override '{\"editor\": \"nano\"}'") == expected_args(config_override={'editor':'nano'})
+    assert cli_as_dict('--override \'{"editor": "nano"}\'') == expected_args(
+        config_override={"editor": "nano"}
+    )
+
 
 # @see https://github.com/jrnl-org/jrnl/issues/520
 @pytest.mark.parametrize(

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -206,7 +206,7 @@ def test_version_alone():
     assert cli_as_dict("--version") == expected_args(preconfig_cmd=preconfig_version)
 
 def test_editor_override():
-    from jrnl.commands import postconfig_override
+    
 
     assert cli_as_dict("--override '{\"editor\": \"nano\"}'") == expected_args(config_override={'editor':'nano'})
 

--- a/tests/test_parse_args.py
+++ b/tests/test_parse_args.py
@@ -206,7 +206,6 @@ def test_version_alone():
     assert cli_as_dict("--version") == expected_args(preconfig_cmd=preconfig_version)
 
 def test_editor_override():
-    
 
     assert cli_as_dict("--override '{\"editor\": \"nano\"}'") == expected_args(config_override={'editor':'nano'})
 


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:

-->
- What is this new code intended to do?
   Apply one-off overrides to the invocation of jrnl to facilitate specific workflows, while preserving the overall configuration for usual workflows
- Are there any related issues?
   #1157 
   #1068
- What is the motivation for this change?
One that I can think of, which prompted the idea, was to be able to quickly launch a floating terminal with the built-in input prompt so I can log an entry and then Ctrl-D to exit. In my normal writing workflow I prefer to have a highly configured editor instance for writing with all the markdown bells and whistles.


- What is an example of usage, or changes to config files? (if applicable)
Launch a floating terminal with the built-in input prompt for rapid logging: 
 ```shell
alacritty -t floating-jrnl -e jrnl --override '{"editor": ""}'
```
Bind that to a keybinding in my WM (I3): 
`bindsym Mod4+Mod1+j exec --no-startup-id alacritty -t floating-jrnl -e jrnl --override '{\"editor\":\"\"}'`

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
