### PR TITLE
Clarify editor documentation for PATH variable and VS Code

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -162,10 +162,13 @@ in your `jrnl.yaml` file. (See [advanced usage](./advanced.md) for details).
 !!! note
     To save and log any entry edits, save and close the file.
 
+If your editor is not in your operating system's `PATH` environment variable,
+then you will have to enter in the full path of your editor.
+
 ### Sublime Text
 
-To use Sublime Text, install the command line tools for Sublime Text and
-configure your `jrnl.yaml` like this:
+To use [Sublime Text](https://www.sublimetext.com/), install the command line
+tools for Sublime Text and configure your `jrnl.yaml` like this:
 
 ```yaml
 editor: "subl -w"
@@ -174,9 +177,21 @@ editor: "subl -w"
 Note the `-w` flag to make sure jrnl waits for Sublime Text to close the
 file before writing into the journal.
 
+### Visual Studio Code
+
+[Visual Studio Code](https://code.visualstudio.com) also requires a flag
+that tells the process to wait until the file is closed before exiting:
+
+```yaml
+editor: "code --wait"
+```
+
+On Windows, `code` is not added to the path by default, so you'll need to
+enter the full path to your `code.exe` file, or add it to the `PATH` variable.
+
 ### MacVim
 
-Similar to Sublime Text, MacVim must be started with a flag that tells
+Also similar to Sublime Text, MacVim must be started with a flag that tells
 the the process to wait until the file is closed before passing control
 back to journal. In the case of MacVim, this is `-f`:
 
@@ -219,29 +234,3 @@ editor: "C:\\Program Files (x86)\\Notepad++\\notepad++.exe -multiInst -nosession
 The double backslashes are needed so jrnl can read the file path
 correctly. The `-multiInst -nosession` options will cause jrnl to open
 its own Notepad++ window.
-
-### Visual Studio Code
-
-To set [Visual Studo Code](https://code.visualstudio.com) as your editor on Linux, edit `jrnl.yaml` like this:
-
-```yaml
-editor: "/usr/bin/code --wait"
-```
-
-The `--wait` argument tells VS Code to wait for files to be written out before handing back control to jrnl.
-
-On MacOS you will need to add VS Code to your PATH. You can do that by adding:
-
-```sh
-export PATH="\$PATH:/Applications/Visual Studio Code.app/Contents/Resources/app/bin"
-```
-
-to your `.bash_profile`, or by running the **Install 'code' command in PATH** command from the command pallet in VS Code.
-
-Then you can add:
-
-```yaml
-editor: "code --wait"
-```
-
-to `jrnl.yaml`. See also the [Visual Studio Code documentation](https://code.visualstudio.com/docs/setup/mac)


### PR DESCRIPTION
Fixes #1155. There were VS code instructions for Mac and Linux, but not Windows. This unifies the instructions for all OSes since the `--wait` argument works the same everywhere.

The instructions were also needlessly complicated and revolved around the PATH variable, so I added a preamble paragraph to the editors section about using the PATH variable.

I also moved up the VS Code instructions since they're very similar to Sublime's, and I added a link to Sublime while I was in there.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
