### PR TITLE
Support title splitting for fullwidth CJK terminals

### DIFF
--- a/features/write.feature
+++ b/features/write.feature
@@ -28,6 +28,20 @@ Feature: Writing new entries.
         | basic_folder    |
         | basic_dayone    |
 
+    Scenario Outline: CJK entry should be split at fullwidth period without following space.
+        Given we use the config "<config_file>.yaml"
+        And we use the password "test" if prompted
+        When we run "jrnl 七転び。八起"
+        And we run "jrnl -1"
+        Then the output should contain "| 八起"
+
+        Examples: configs
+        | config_file     |
+        | basic_onefile   |
+        | basic_encrypted |
+        | basic_folder    |
+        | basic_dayone    |
+
     Scenario Outline: Writing an entry from command line should store the entry
         Given we use the config "<config_file>.yaml"
         And we use the password "bad doggie no biscuit" if prompted

--- a/features/write.feature
+++ b/features/write.feature
@@ -31,9 +31,9 @@ Feature: Writing new entries.
     Scenario Outline: CJK entry should be split at fullwidth period without following space.
         Given we use the config "<config_file>.yaml"
         And we use the password "test" if prompted
-        When we run "jrnl 七転び。八起"
+        When we run "jrnl 七転び。八起き"
         And we run "jrnl -1"
-        Then the output should contain "| 八起"
+        Then the output should contain "| 八起き"
 
         Examples: configs
         | config_file     |

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -204,14 +204,17 @@ class Entry:
 # https://github.com/fnl/segtok
 SENTENCE_SPLITTER = re.compile(
     r"""
-(                       # A sentence ends at one of two sequences:
-    [.!?\u2026\u203C\u203D\u2047\u2048\u2049\u22EF\u3002\uFE52\uFE57\uFF01\uFF0E\uFF1F\uFF61]                # Either, a sequence starting with a sentence terminal,
+    (
+    [.!?\u2026\u203C\u203D\u2047\u2048\u2049\u22EF\uFE52\uFE57] # Sequence starting with a sentence terminal,
     [\'\u2019\"\u201D]? # an optional right quote,
-    [\]\)]*             # optional closing brackets and
-    \s+                 # a sequence of required spaces.
-)""",
+    [\]\)]*             # optional closing bracket
+    \s+                 # AND a sequence of required spaces.
+    )
+    |[\uFF01\uFF0E\uFF1F\uFF61\u3002] # CJK full/half width terminals usually do not have following spaces.
+    """,
     re.VERBOSE,
 )
+
 SENTENCE_SPLITTER_ONLY_NEWLINE = re.compile("\n")
 
 


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
Small change to sentence_splitter to allow for titles to be split by fullwidth or halfwidth CJK sentence terminals without spaces following them. 

This is the actual solution to #1041.

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have written new tests for these changes, as needed.
- [X] All tests pass.

