### PR TITLE
Fix broken brew release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -206,7 +206,7 @@ jobs:
         max_attempts: 6
         retry_wait_seconds: 30
         command: >
-          brew bump-formula-pr "Formula/${FORMULA_NAME}.rb"
+          brew bump-formula-pr "Formula/${FORMULA_NAME}"
           --url $(jq ".releases[\"${PYPI_VERSION}\"][1].url" -r api_response.json)
           --sha256 $(jq ".releases[\"${PYPI_VERSION}\"][1].digests.sha256" -r api_response.json)
           --version=$PYPI_VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -152,16 +152,10 @@ jobs:
           } >> $GITHUB_ENV
         fi
 
-    - name: Checkout homebrew repo
-      uses: actions/checkout@v2
-      with:
-        token: ${{ secrets.JRNL_BOT_TOKEN }}
-        repository: ${{ env.FORMULA_REPO }}
-
-    - name: Symlink repo into Homebrew's tap directory
+    - name: Tap formula
       run: |
-        mkdir -p "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
-        ln -s "$(pwd)" "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
+        brew tap ${FORMULA_NAME}
+        cd "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
 
     - name: Config git user
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,9 +156,7 @@ jobs:
       run: |
         brew tap ${FORMULA_REPO}
         echo '::debug::Set tap directory'
-          {
-            echo "BREW_TAP_DIRECTORY=$(brew --repository)/Library/Taps/${FORMULA_REPO}"
-          } >> $GITHUB_ENV
+        echo "BREW_TAP_DIRECTORY='$(brew --repository)/Library/Taps/${FORMULA_REPO}'" >> $GITHUB_ENV
 
     - name: Config git user
       working-directory: ${{ env.BREW_TAP_DIRECTORY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -158,10 +158,10 @@ jobs:
         token: ${{ secrets.JRNL_BOT_TOKEN }}
         repository: ${{ env.FORMULA_REPO }}
 
-  - name: Symlink repo into Homebrew's tap directory
-    run: |
-      mkdir -p "$(brew --repository)/Library/Taps/${REPO_NAME}"
-      ln -s "$(pwd)" "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
+    - name: Symlink repo into Homebrew's tap directory
+      run: |
+        mkdir -p "$(brew --repository)/Library/Taps/${REPO_NAME}"
+        ln -s "$(pwd)" "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
 
     - name: Config git user
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,6 +164,7 @@ jobs:
 
     - name: Create branch
       run: |
+        echo "$(PWD)"
         BRANCH_NAME="jrnl-${JRNL_VERSION}--${RANDOM}"
         git remote rename origin upstream
         git remote add origin "https://github.com/${BOT_REPO}.git"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,6 @@ jobs:
             echo "FORMULA_REPO=${REPO_OWNER}/homebrew-prerelease"
             echo "BOT_REPO=jrnl-bot/homebrew-prerelease"
             echo "FORMULA_NAME=jrnl-beta"
-            echo "BREW_TAP_DIRECTORY=$(brew --repository)/Library/Taps/${FORMULA_REPO}"
           } >> $GITHUB_ENV
         else
           echo '::debug::Full release (not a prerelease)'
@@ -150,13 +149,16 @@ jobs:
             echo "FORMULA_REPO=${REPO_OWNER}/homebrew-core"
             echo "BOT_REPO=jrnl-bot/homebrew-core"
             echo "FORMULA_NAME=jrnl"
-            echo "BREW_TAP_DIRECTORY=$(brew --repository)/Library/Taps/${FORMULA_REPO}"
           } >> $GITHUB_ENV
         fi
 
     - name: Tap formula
       run: |
         brew tap ${FORMULA_REPO}
+        echo '::debug::Set tap directory'
+          {
+            echo "BREW_TAP_DIRECTORY=$(brew --repository)/Library/Taps/${FORMULA_REPO}"
+          } >> $GITHUB_ENV
 
     - name: Config git user
       working-directory: ${{ env.BREW_TAP_DIRECTORY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -116,7 +116,6 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOME_REPO: ${{ secrets.HOME_REPO }}
     steps:
-
     - name: Get version
       run: |
         JRNL_VERSION="${{ github.event.inputs.version }}"
@@ -158,6 +157,11 @@ jobs:
       with:
         token: ${{ secrets.JRNL_BOT_TOKEN }}
         repository: ${{ env.FORMULA_REPO }}
+
+  - name: Symlink repo into Homebrew's tap directory
+    run: |
+      mkdir -p "$(brew --repository)/Library/Taps/${REPO_NAME}"
+      ln -s "$(pwd)" "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
 
     - name: Config git user
       run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -169,7 +169,6 @@ jobs:
     - name: Create branch
       working-directory: ${{ env.BREW_TAP_DIRECTORY }}
       run: |
-        echo "$(PWD)"
         BRANCH_NAME="jrnl-${JRNL_VERSION}--${RANDOM}"
         git remote rename origin upstream
         git remote add origin "https://${{ secrets.JRNL_BOT_NAME }}:${{ secrets.JRNL_BOT_TOKEN }}@github.com/${BOT_REPO}.git"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -170,7 +170,8 @@ jobs:
         echo "$(PWD)"
         BRANCH_NAME="jrnl-${JRNL_VERSION}--${RANDOM}"
         git remote rename origin upstream
-        git remote add origin "https://github.com/${BOT_REPO}.git"
+        git remote add origin "https://${{ secrets.JRNL_BOT_NAME }}:${{ secrets.JRNL_BOT_TOKEN }}@github.com/${BOT_REPO}.git"
+
         git fetch upstream
         git fetch origin
         git checkout -b $BRANCH_NAME

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -171,7 +171,7 @@ jobs:
         BRANCH_NAME="jrnl-${JRNL_VERSION}--${RANDOM}"
         git remote rename origin upstream
         git remote add origin "https://github.com/${BOT_REPO}.git"
-        git fetch --unshallow upstream
+        git fetch upstream
         git fetch origin
         git checkout -b $BRANCH_NAME
         git push -u origin $BRANCH_NAME

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -160,7 +160,7 @@ jobs:
 
     - name: Symlink repo into Homebrew's tap directory
       run: |
-        mkdir -p "$(brew --repository)/Library/Taps/${REPO_NAME}"
+        mkdir -p "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
         ln -s "$(pwd)" "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
 
     - name: Config git user

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -206,7 +206,7 @@ jobs:
         max_attempts: 6
         retry_wait_seconds: 30
         command: >
-          brew bump-formula-pr "Formula/${FORMULA_NAME}"
+          brew bump-formula-pr "${FORMULA_NAME}"
           --url $(jq ".releases[\"${PYPI_VERSION}\"][1].url" -r api_response.json)
           --sha256 $(jq ".releases[\"${PYPI_VERSION}\"][1].digests.sha256" -r api_response.json)
           --version=$PYPI_VERSION

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -154,7 +154,7 @@ jobs:
 
     - name: Tap formula
       run: |
-        brew tap ${FORMULA_NAME}
+        brew tap ${FORMULA_REPO}
         cd "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
 
     - name: Config git user

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,6 +138,7 @@ jobs:
             echo "FORMULA_REPO=${REPO_OWNER}/homebrew-prerelease"
             echo "BOT_REPO=jrnl-bot/homebrew-prerelease"
             echo "FORMULA_NAME=jrnl-beta"
+            echo "BREW_TAP_DIRECTORY=$(brew --repository)/Library/Taps/${FORMULA_REPO}"
           } >> $GITHUB_ENV
         else
           echo '::debug::Full release (not a prerelease)'
@@ -149,20 +150,22 @@ jobs:
             echo "FORMULA_REPO=${REPO_OWNER}/homebrew-core"
             echo "BOT_REPO=jrnl-bot/homebrew-core"
             echo "FORMULA_NAME=jrnl"
+            echo "BREW_TAP_DIRECTORY=$(brew --repository)/Library/Taps/${FORMULA_REPO}"
           } >> $GITHUB_ENV
         fi
 
     - name: Tap formula
       run: |
         brew tap ${FORMULA_REPO}
-        cd "$(brew --repository)/Library/Taps/${FORMULA_REPO}"
 
     - name: Config git user
+      working-directory: ${{ env.BREW_TAP_DIRECTORY }}
       run: |
         git config --global user.name "${{ secrets.JRNL_BOT_NAME }}"
         git config --global user.email "${{ secrets.JRNL_BOT_EMAIL }}"
 
     - name: Create branch
+      working-directory: ${{ env.BREW_TAP_DIRECTORY }}
       run: |
         echo "$(PWD)"
         BRANCH_NAME="jrnl-${JRNL_VERSION}--${RANDOM}"
@@ -212,6 +215,7 @@ jobs:
           --verbose
 
     - name: Update commit message
+      working-directory: ${{ env.BREW_TAP_DIRECTORY }}
       run: |
         git commit --amend \
         -m "jrnl ${JRNL_VERSION}" \
@@ -219,11 +223,13 @@ jobs:
         -m '${{ secrets.RELEASE_COAUTHORS }}'
 
     - name: Push commit
+      working-directory: ${{ env.BREW_TAP_DIRECTORY }}
       run: |
         git show head
         git push
 
     - name: Open pull request
+      working-directory: ${{ env.BREW_TAP_DIRECTORY }}
       env:
         GH_TOKEN: ${{ secrets.JRNL_BOT_TOKEN }}
       run: >


### PR DESCRIPTION
Our brew release process broke a while back due to us using an unsupported feature in `brew bump-formula-pr` which stopped working. This PR works around it.

See background in [Homebrew issue 10733](https://github.com/Homebrew/brew/issues/10733). Big thanks to @Rylan12 for support on this issue. I ended up working around this by tapping the formula, then working in the tap directory.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [n/a] I have included a link to the relevant issue number.
- [n/a] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [n/a] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
