### PR TITLE
More graceful handling of low linewrap values 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ coverage.xml
 .coverage
 .vscode/tasks.json
 todo.txt
+
+tags
+.vimrc

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,3 @@ coverage.xml
 .coverage
 .vscode/tasks.json
 todo.txt
-
-tags
-.vimrc

--- a/features/format.feature
+++ b/features/format.feature
@@ -302,9 +302,9 @@ Feature: Custom formats
     Scenario Outline: Export fancy with small linewrap
         Given we use the config "<config>.yaml"
         And we use the password "test" if prompted
-        When we run "jrnl --config-override linewrap 12 --format fancy -3"
+        When we run "jrnl --config-override linewrap 35 --format fancy -3"
         Then we should get no error
-        And the output should be "12" columns wide
+        And the output should be 35 columns wide
         
         Examples: configs
         | config          |

--- a/features/format.feature
+++ b/features/format.feature
@@ -297,6 +297,22 @@ Feature: Custom formats
         | basic_folder    |
         | basic_dayone    |
 
+    
+    
+    Scenario Outline: Export fancy with small linewrap
+        Given we use the config "<config>.yaml"
+        And we use the password "test" if prompted
+        When we run "jrnl --config-override linewrap 12 --format fancy -3"
+        Then we should get no error
+        And the output should be "12" columns wide
+        
+        Examples: configs
+        | config          |
+        | basic_onefile   |
+        | basic_encrypted |
+        | basic_folder    |
+        | basic_dayone    |
+
     @todo
     Scenario Outline: Exporting fancy
         # Needs better emoji support

--- a/features/steps/export_steps.py
+++ b/features/steps/export_steps.py
@@ -12,6 +12,14 @@ from behave import given
 from behave import then
 
 
+@then("the output should be {width:d} columns wide")
+def check_output_width(context, width):
+    out = context.stdout_capture.getvalue()
+    out_lines = out.splitlines()
+    for line in out_lines:
+        assert len(line) <= width
+
+
 @then("the output should be parsable as json")
 def check_output_json(context):
     out = context.stdout_capture.getvalue()

--- a/jrnl/exception.py
+++ b/jrnl/exception.py
@@ -33,8 +33,10 @@ class JrnlError(Exception):
             ),
             "LineWrapTooSmallForDateFormat": textwrap.dedent(
                 """
-                The provided linewrap value of {config_linewrap} is too small
-                to display the timestamps in the configured time format.
+                The provided linewrap value of {config_linewrap} is too small by {columns} columns
+                to display the timestamps in the configured time format for journal {journal}.
+
+                You can avoid this error by specifying a linewrap value that is larger by at least {columns} in the configuration file or by using --config-override at the command line 
                 """
             ),
         }

--- a/jrnl/exception.py
+++ b/jrnl/exception.py
@@ -30,7 +30,21 @@ class JrnlError(Exception):
 
                 Removing this file will allow jrnl to save its configuration.
             """
-            )
+            ),
+            "LineWrapTooSmallForDateFormat": textwrap.dedent(
+                """
+                The provided linewrap value of {config_linewrap} is too small
+                to display the timestamps in the configured time format.
+                """
+            ),
+            "LineWrapTooSmallForFancy": textwrap.dedent(
+                """
+                The provided linewrap value of {config_linewrap} is too small 
+                to properly format journal contents in fancy/boxed format. 
+                Either provide a larger value for the linewrap or display the
+                journal in another format.
+                """
+            ),
         }
 
         return error_messages[self.error_type].format(**kwargs)

--- a/jrnl/exception.py
+++ b/jrnl/exception.py
@@ -37,14 +37,6 @@ class JrnlError(Exception):
                 to display the timestamps in the configured time format.
                 """
             ),
-            "LineWrapTooSmallForFancy": textwrap.dedent(
-                """
-                The provided linewrap value of {config_linewrap} is too small 
-                to properly format journal contents in fancy/boxed format. 
-                Either provide a larger value for the linewrap or display the
-                journal in another format.
-                """
-            ),
         }
 
         return error_messages[self.error_type].format(**kwargs)

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -91,5 +91,3 @@ def check_provided_linewrap_viability(linewrap, card, journal):
             columns=width_violation,
             journal=journal,
         )
-    else:
-        pass

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -41,7 +41,8 @@ class FancyExporter(TextExporter):
         card = [
             cls.border_a + cls.border_b * (initial_linewrap) + cls.border_c + date_str
         ]
-        cls.check_linewrap(linewrap, card)
+        check_provided_linewrap_viability(linewrap, card, entry.journal)
+
         w = TextWrapper(
             width=initial_linewrap,
             initial_indent=cls.border_g + " ",
@@ -76,13 +77,19 @@ class FancyExporter(TextExporter):
         return "\n".join(card)
 
     @classmethod
-    def check_linewrap(cls, linewrap, card):
-        if len(card[0]) > linewrap:
-            raise JrnlError("LineWrapTooSmallForDateFormat", config_linewrap=linewrap)
-        else:
-            pass
-
-    @classmethod
     def export_journal(cls, journal):
         """Returns a unicode representation of an entire journal."""
         return "\n".join(cls.export_entry(entry) for entry in journal)
+
+
+def check_provided_linewrap_viability(linewrap, card, journal):
+    if len(card[0]) > linewrap:
+        width_violation = len(card[0]) - linewrap
+        raise JrnlError(
+            "LineWrapTooSmallForDateFormat",
+            config_linewrap=linewrap,
+            columns=width_violation,
+            journal=journal,
+        )
+    else:
+        pass

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,6 +1,5 @@
 from jrnl.exception import JrnlError
-from jrnl.plugins.fancy_exporter import FancyExporter
-
+from jrnl.plugins.fancy_exporter import check_provided_linewrap_viability
 
 import pytest
 
@@ -30,10 +29,11 @@ def build_card_header(datestr):
 class TestFancy:
     def test_too_small_linewrap(self, datestr):
 
+        journal = "test_journal"
         content = build_card_header(datestr)
 
         total_linewrap = 12
 
         with pytest.raises(JrnlError) as e:
-            FancyExporter.check_linewrap(total_linewrap, [content])
+            check_provided_linewrap_viability(total_linewrap, [content], journal)
         assert e.value.error_type == "LineWrapTooSmallForDateFormat"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -8,6 +8,7 @@ import pytest
 def datestr():
     yield "2020-10-20 16:59"
 
+
 def build_card_header(datestr):
     top_left_corner = "┎─╮"
     content = top_left_corner + datestr

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,39 @@
+from jrnl.exception import JrnlError
+from jrnl.plugins.fancy_exporter import FancyExporter
+
+
+import pytest
+
+
+@pytest.fixture()
+def datestr():
+
+    yield "2020-10-20 16:59"
+
+
+from textwrap import TextWrapper
+
+
+def provide_date_wrapper(initial_linewrap):
+    wrapper = TextWrapper(
+        width=initial_linewrap, initial_indent=" ", subsequent_indent=" "
+    )
+    return wrapper
+
+
+def build_card_header(datestr):
+    top_left_corner = "┎─╮"
+    content = top_left_corner + datestr
+    return content
+
+
+class TestFancy:
+    def test_too_small_linewrap(self, datestr):
+
+        content = build_card_header(datestr)
+
+        total_linewrap = 12
+
+        with pytest.raises(JrnlError) as e:
+            FancyExporter.check_linewrap(total_linewrap, [content])
+        assert e.value.error_type == "LineWrapTooSmallForDateFormat"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -6,19 +6,7 @@ import pytest
 
 @pytest.fixture()
 def datestr():
-
     yield "2020-10-20 16:59"
-
-
-from textwrap import TextWrapper
-
-
-def provide_date_wrapper(initial_linewrap):
-    wrapper = TextWrapper(
-        width=initial_linewrap, initial_indent=" ", subsequent_indent=" "
-    )
-    return wrapper
-
 
 def build_card_header(datestr):
     top_left_corner = "┎─╮"


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
This is intended to fix #1201 in the following manner:
1. Enforce a positive initial linewrap
2. If the the total linewrap is not big enough to accommodate the date string in its entirety, throw an error explaining so. 

I tried another direction where the date string is wrapped as well and the top left corner is extended downwards until all of the date can be chopped up and wrapped. It's pretty tricky to do gracefully so I'm not confident of checking that in yet. You can see the code [at the branch](https://github.com/sriniv27/jrnl/tree/format-fancy-low-linewrap) if you like.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
