### PR TITLE
Update absolute URLs to preview images in metatags

### DIFF
--- a/docs_theme/index.html
+++ b/docs_theme/index.html
@@ -7,18 +7,18 @@
     <meta charset="utf-8">
     <title>jrnl - The Command Line Journal</title>
     <meta name="description" content="Collect your thoughts and notes without leaving the command line.">
-    <meta name="image" content="https://jrnl.sh/img/banner.png">
+    <meta name="image" content="https://jrnl.sh/en/stable/img/banner_og.png">
     <meta itemprop="name" content="jrnl - The Command Line Journal">
     <meta itemprop="description" content="Collect your thoughts and notes without leaving the command line.">
-    <meta itemprop="image" content="https://jrnl.sh/img/banner_og.png">
+    <meta itemprop="image" content="https://jrnl.sh/en/stable/img/banner_og.png">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="jrnl - The Command Line Journal">
     <meta name="twitter:description" content="Collect your thoughts and notes without leaving the command line.">
     <meta name="twitter:creator" content="jrnl">
-    <meta name="twitter:image:src" content="https://jrnl.sh/img/banner_twitter.png">
+    <meta name="twitter:image:src" content="https://jrnl.sh/en/stable/img/banner_twitter.png">
     <meta name="og:title" content="jrnl - The Command Line Journal">
     <meta name="og:description" content="Collect your thoughts and notes without leaving the command line.">
-    <meta name="og:image" content="https://jrnl.sh/img/banner_og.png">
+    <meta name="og:image" content="https://jrnl.sh/en/stable/img/banner_og.png">
     <meta name="og:url" content="https://jrnl.sh">
     <meta name="og:site_name" content="jrnl - The Command Line Journal">
     <meta name="og:type" content="website">
@@ -35,8 +35,8 @@
         "name": "jrnl",
         "description": "Collect your thoughts and notes without leaving the command line.",
         "operatingSystem": ["macOS", "Windows", "Linux"],
-        "thumbnailUrl": "https://jrnl.sh/img/banner_og.png",
-        "installUrl": "https://jrnl.sh/installation",
+        "thumbnailUrl": "https://jrnl.sh/en/stable/img/banner_og.png",
+        "installUrl": "https://jrnl.sh/en/stable/installation",
         "softwareVersion": "2.5"
     }
     </script>


### PR DESCRIPTION
When sharing on social media or most messengers, the preview image doesn't show because it now gets published to `en/stable/img/...`:

![image](https://user-images.githubusercontent.com/1047165/114764873-13b8d680-9d2a-11eb-855f-b107536ef092.png)

This fixes it so we can brag about jrnl in all its glory again:

![image](https://user-images.githubusercontent.com/1047165/114764947-2c28f100-9d2a-11eb-9149-4c17e32d1295.png)
