### PR TITLE
Remove `--version` from brew release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -188,7 +188,6 @@ jobs:
           brew bump-formula-pr "${FORMULA_NAME}"
           --url $(jq ".releases[\"${PYPI_VERSION}\"][1].url" -r api_response.json)
           --sha256 $(jq ".releases[\"${PYPI_VERSION}\"][1].digests.sha256" -r api_response.json)
-          --version=$PYPI_VERSION
           --no-audit
           --write
           --force


### PR DESCRIPTION
Homebrew doesn't like explicitly declaring a version for a formula, prefers to infer it from the url (as mentioned in homebrew/homebrew-core#67264). This will throw an error on PRs, so this PR removes that part of the workflow.