### PR TITLE
Restore `__main__.py` functionality

### DIFF
--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# Copyright (C) 2012-2021 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+import sys
+
+from .cli import cli
+
+if __name__ == "__main__":
+    sys.exit(cli())


### PR DESCRIPTION
Allows you to access jrnl by running `python -m jrnl`

This was removed by #1275, but there is nothing in the notes about that pull request to suggest the was done purposefully.
