### PR TITLE
Remove old GitHub issue template

### DIFF
--- a/issue_template.md
+++ b/issue_template.md
@@ -1,8 +1,0 @@
-# Stop
-
-Please don't file a blank issue.
-
-Fill out one of the templates from the link below and we'll be better able to
-help you.
-
-https://github.com/jrnl-org/jrnl/issues/new/choose


### PR DESCRIPTION
This seems to be superseeded by the `.github/ISSUE_TEMPLATE` folder and should no longer be needed.