### PR TITLE
Use relative version imports for plugins

### DIFF
--- a/jrnl/plugins/exporter/dates.py
+++ b/jrnl/plugins/exporter/dates.py
@@ -7,7 +7,7 @@ from collections import Counter
 
 from jrnl.plugins.base import BaseExporter
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/fancy.py
+++ b/jrnl/plugins/exporter/fancy.py
@@ -9,7 +9,7 @@ from textwrap import TextWrapper
 from jrnl.plugins.base import BaseExporter
 from jrnl.plugins.util import check_provided_linewrap_viability
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/json.py
+++ b/jrnl/plugins/exporter/json.py
@@ -8,7 +8,7 @@ import json
 from jrnl.plugins.base import BaseExporter
 from jrnl.plugins.util import get_tags_count
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/markdown.py
+++ b/jrnl/plugins/exporter/markdown.py
@@ -11,7 +11,7 @@ from jrnl.color import RESET_COLOR
 from jrnl.color import WARNING_COLOR
 from jrnl.plugins.base import BaseExporter
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/pretty.py
+++ b/jrnl/plugins/exporter/pretty.py
@@ -5,7 +5,7 @@
 
 from jrnl.plugins.base import BaseExporter
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/short.py
+++ b/jrnl/plugins/exporter/short.py
@@ -5,7 +5,7 @@
 
 from jrnl.plugins.base import BaseExporter
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/tag.py
+++ b/jrnl/plugins/exporter/tag.py
@@ -7,7 +7,7 @@
 from jrnl.plugins.base import BaseExporter
 from jrnl.plugins.util import get_tags_count
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/text.py
+++ b/jrnl/plugins/exporter/text.py
@@ -5,7 +5,7 @@
 
 from jrnl.plugins.base import BaseExporter
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/xml.py
+++ b/jrnl/plugins/exporter/xml.py
@@ -8,7 +8,7 @@ from xml.dom import minidom
 from jrnl.plugins.base import BaseExporter
 from jrnl.plugins.util import get_tags_count
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/yaml.py
+++ b/jrnl/plugins/exporter/yaml.py
@@ -12,7 +12,7 @@ from jrnl.color import RESET_COLOR
 from jrnl.color import WARNING_COLOR
 from jrnl.plugins.base import BaseExporter
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/importer/jrnl.py
+++ b/jrnl/plugins/importer/jrnl.py
@@ -7,7 +7,7 @@ import sys
 
 from jrnl.plugins.base import BaseImporter
 
-from jrnl.__version__ import __version__
+from ...__version__ import __version__
 
 
 class Importer(BaseImporter):


### PR DESCRIPTION
Further to #1275, which changed the import location of `__version__`.

The plugins are using the realitive import here on purpose. On the off chance that jrnl is installed twice (somehow) on a system, I want the plugin to pull it's version from it's jrnl, not from the global one.