### PR TITLE
Plugin list on Diagnostic

### DIFF
--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -78,7 +78,7 @@ def parse_args(args=[]):
         action="store_const",
         const=preconfig_diagnostic,
         dest="preconfig_cmd",
-        help=argparse.SUPPRESS,
+        help="Print active plugins",
     )
     standalone.add_argument(
         "--list",

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -17,16 +17,6 @@ import sys
 
 def preconfig_diagnostic(_):
     from jrnl import __version__
-
-    print(
-        f"jrnl: {__version__}\n"
-        f"Python: {sys.version}\n"
-        f"OS: {platform.system()} {platform.release()}"
-    )
-
-
-def preconfig_version(_):
-    from jrnl import __version__
     from jrnl.plugins.collector import (
         IMPORT_FORMATS,
         EXPORT_FORMATS,
@@ -34,14 +24,11 @@ def preconfig_version(_):
         get_importer,
     )
 
-    version_str = f"""jrnl version {__version__}
-
-Copyright (C) 2012-2021 jrnl contributors
-
-This is free software, and you are welcome to redistribute it under certain
-conditions; for details, see: https://www.gnu.org/licenses/gpl-3.0.html"""
-
-    print(version_str)
+    print(
+        f"jrnl: {__version__}\n"
+        f"Python: {sys.version}\n"
+        f"OS: {platform.system()} {platform.release()}"
+    )
     print()
     print("Active Plugins:")
     print("    Importers:")
@@ -58,6 +45,19 @@ conditions; for details, see: https://www.gnu.org/licenses/gpl-3.0.html"""
         print(f"        {exporter} : ", end="")
         print(f"{exporter_class.version} from ", end="")
         print(f"{exporter_class().class_path()}")
+
+
+def preconfig_version(_):
+    from jrnl import __version__
+
+    version_str = f"""jrnl version {__version__}
+
+Copyright (C) 2012-2021 jrnl contributors
+
+This is free software, and you are welcome to redistribute it under certain
+conditions; for details, see: https://www.gnu.org/licenses/gpl-3.0.html"""
+
+    print(version_str)
 
 
 def postconfig_list(config, **kwargs):

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -13,7 +13,14 @@ avoid any possible overhead for these standalone commands.
 """
 from itertools import chain
 import platform
+import re
 import sys
+
+
+def remove_prefix(main_string, prefix):
+    # replace with built-in string function in Python 3.9+
+    pattern = rf"^{prefix}"
+    return re.sub(pattern, "", main_string)
 
 
 def preconfig_diagnostic(_):
@@ -21,6 +28,10 @@ def preconfig_diagnostic(_):
     from jrnl.plugins.collector import (
         IMPORT_FORMATS,
         EXPORT_FORMATS,
+        INTERNAL_EXPORTER_CLASS_PATH,
+        INTERNAL_IMPORTER_CLASS_PATH,
+        EXTERNAL_EXPORTER_CLASS_PATH,
+        EXTERNAL_IMPORTER_CLASS_PATH,
         get_exporter,
         get_importer,
     )
@@ -41,14 +52,40 @@ def preconfig_diagnostic(_):
     for importer in IMPORT_FORMATS:
         importer_class = get_importer(importer)
         print(f"        {importer:{plugin_name_length}} : ", end="")
-        print(f"{importer_class.version} from ", end="")
-        print(f"{importer_class().class_path()}")
+        if importer_class().class_path().startswith(INTERNAL_IMPORTER_CLASS_PATH):
+            version_str = remove_prefix(
+                importer_class().class_path(), INTERNAL_IMPORTER_CLASS_PATH
+            )
+            version_str = remove_prefix(version_str, ".")
+            print(f"{version_str} (internal)")
+        elif importer_class().class_path().startswith(EXTERNAL_IMPORTER_CLASS_PATH):
+            version_str = remove_prefix(
+                importer_class().class_path(), EXTERNAL_IMPORTER_CLASS_PATH
+            )
+            version_str = remove_prefix(version_str, ".")
+            print(f"{version_str} {importer_class.version}")
+        else:
+            print(f"{importer_class.version} from ", end="")
+            print(f"{importer_class().class_path()}")
     print("    Exporters:")
     for exporter in EXPORT_FORMATS:
         exporter_class = get_exporter(exporter)
         print(f"        {exporter:{plugin_name_length}} : ", end="")
-        print(f"{exporter_class.version} from ", end="")
-        print(f"{exporter_class().class_path()}")
+        if exporter_class().class_path().startswith(INTERNAL_EXPORTER_CLASS_PATH):
+            version_str = remove_prefix(
+                exporter_class().class_path(), INTERNAL_EXPORTER_CLASS_PATH
+            )
+            version_str = remove_prefix(version_str, ".")
+            print(f"{version_str} (internal)")
+        elif exporter_class().class_path().startswith(EXTERNAL_EXPORTER_CLASS_PATH):
+            version_str = remove_prefix(
+                exporter_class().class_path(), EXTERNAL_EXPORTER_CLASS_PATH
+            )
+            version_str = remove_prefix(version_str, ".")
+            print(f"{version_str} {exporter_class.version}")
+        else:
+            print(f"{exporter_class.version} from ", end="")
+            print(f"{exporter_class().class_path()}")
 
 
 def preconfig_version(_):

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -11,6 +11,7 @@ run.
 Also, please note that all (non-builtin) imports should be scoped to each function to
 avoid any possible overhead for these standalone commands.
 """
+from itertools import chain
 import platform
 import sys
 
@@ -29,20 +30,23 @@ def preconfig_diagnostic(_):
         f"Python: {sys.version}\n"
         f"OS: {platform.system()} {platform.release()}"
     )
+
+    plugin_name_length = max(
+        [len(str(x)) for x in chain(IMPORT_FORMATS, EXPORT_FORMATS)]
+    )
+
     print()
     print("Active Plugins:")
     print("    Importers:")
     for importer in IMPORT_FORMATS:
         importer_class = get_importer(importer)
-        print(
-            f"        {importer} : {importer_class.version} from",
-            f"{importer_class().class_path()}",
-        )
+        print(f"        {importer:{plugin_name_length}} : ", end="")
+        print(f"{importer_class.version} from ", end="")
+        print(f"{importer_class().class_path()}")
     print("    Exporters:")
     for exporter in EXPORT_FORMATS:
         exporter_class = get_exporter(exporter)
-        # print(f"        {exporter} : {exporter_class.version} from {exporter_class().class_path()}")
-        print(f"        {exporter} : ", end="")
+        print(f"        {exporter:{plugin_name_length}} : ", end="")
         print(f"{exporter_class.version} from ", end="")
         print(f"{exporter_class().class_path()}")
 

--- a/jrnl/plugins/collector.py
+++ b/jrnl/plugins/collector.py
@@ -21,30 +21,36 @@ i.e. it is the collection of code that allows plugins to deal with themselves.
 import importlib
 import pkgutil
 
-import jrnl.contrib.exporter
-import jrnl.contrib.importer
-import jrnl.plugins.exporter
-import jrnl.plugins.importer
+INTERNAL_EXPORTER_CLASS_PATH = "jrnl.plugins.exporter"
+INTERNAL_IMPORTER_CLASS_PATH = "jrnl.plugins.importer"
+EXTERNAL_EXPORTER_CLASS_PATH = "jrnl.contrib.exporter"
+EXTERNAL_IMPORTER_CLASS_PATH = "jrnl.contrib.importer"
+
+__internal_exporter_class = importlib.import_module(INTERNAL_EXPORTER_CLASS_PATH)
+__internal_importer_class = importlib.import_module(INTERNAL_IMPORTER_CLASS_PATH)
+__external_exporter_class = importlib.import_module(EXTERNAL_EXPORTER_CLASS_PATH)
+__external_importer_class = importlib.import_module(EXTERNAL_IMPORTER_CLASS_PATH)
+
 
 __exporters_builtin = list(
     pkgutil.iter_modules(
-        jrnl.plugins.exporter.__path__, jrnl.plugins.exporter.__name__ + "."
+        __internal_exporter_class.__path__, __internal_exporter_class.__name__ + "."
     )
 )
 __exporters_contrib = list(
     pkgutil.iter_modules(
-        jrnl.contrib.exporter.__path__, jrnl.contrib.exporter.__name__ + "."
+        __external_exporter_class.__path__, __external_exporter_class.__name__ + "."
     )
 )
 
 __importers_builtin = list(
     pkgutil.iter_modules(
-        jrnl.plugins.importer.__path__, jrnl.plugins.importer.__name__ + "."
+        __internal_importer_class.__path__, __internal_importer_class.__name__ + "."
     )
 )
 __importers_contrib = list(
     pkgutil.iter_modules(
-        jrnl.contrib.importer.__path__, jrnl.contrib.importer.__name__ + "."
+        __external_importer_class.__path__, __external_importer_class.__name__ + "."
     )
 )
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,7 +9,7 @@ from jrnl.plugins.exporter import json as json_exporter
 
 try:
     from jrnl.contrib.exporter import testing as testing_exporter
-except:
+except ImportError:
     testing_exporter = None
 
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,7 +1,7 @@
 import pytest
 
 from jrnl.exception import JrnlError
-from jrnl.plugins.fancy_exporter import check_provided_linewrap_viability
+from jrnl.plugins.util import check_provided_linewrap_viability
 
 
 @pytest.fixture()


### PR DESCRIPTION
Further to #1006, displays active plugins on `--diagnostic` rather than `--version`