### PR TITLE
Change all YAML FullLoader calls to SafeLoader

### DIFF
--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -17,7 +17,7 @@ import keyring
 
 import toml
 import yaml
-from yaml.loader import FullLoader
+from yaml.loader import SafeLoader
 
 
 import jrnl.time
@@ -409,7 +409,7 @@ def run(context, command, text=""):
 
     if "config_path" in context and context.config_path is not None:
         with open(context.config_path) as f:
-            context.jrnl_config = yaml.load(f, Loader=yaml.FullLoader)
+            context.jrnl_config = yaml.load(f, Loader=yaml.SafeLoader)
     else:
         context.jrnl_config = None
 
@@ -418,7 +418,7 @@ def run(context, command, text=""):
         command = command.format(cache_dir=cache_dir)
     if "config_path" in context and context.config_path is not None:
         with open(context.config_path, "r") as f:
-            cfg = yaml.load(f, Loader=FullLoader)
+            cfg = yaml.load(f, Loader=SafeLoader)
         context.jrnl_config = cfg
 
     args = split_args(command)
@@ -675,7 +675,7 @@ def check_journal_entries(context, number, journal_name="default"):
 @when("the journal directory is listed")
 def list_journal_directory(context, journal="default"):
     with open(context.config_path) as config_file:
-        configuration = yaml.load(config_file, Loader=yaml.FullLoader)
+        configuration = yaml.load(config_file, Loader=yaml.SafeLoader)
     journal_path = configuration["journals"][journal]
     for root, dirnames, f in os.walk(journal_path):
         for file in f:

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -41,7 +41,7 @@ def make_yaml_valid_dict(input: list) -> dict:
 
     # yaml compatible strings are of the form Key:Value
     yamlstr = YAML_SEPARATOR.join(input)
-    runtime_modifications = yaml.load(yamlstr, Loader=yaml.FullLoader)
+    runtime_modifications = yaml.load(yamlstr, Loader=yaml.SafeLoader)
 
     return runtime_modifications
 
@@ -140,7 +140,7 @@ def verify_config_colors(config):
 def load_config(config_path):
     """Tries to load a config file from YAML."""
     with open(config_path) as f:
-        return yaml.load(f, Loader=yaml.FullLoader)
+        return yaml.load(f, Loader=yaml.SafeLoader)
 
 
 def is_config_json(config_path):

--- a/jrnl/plugins/template.py
+++ b/jrnl/plugins/template.py
@@ -26,7 +26,7 @@ class Template:
     def from_file(cls, filename):
         with open(filename) as f:
             front_matter, body = f.read().strip("-\n").split("---", 2)
-            front_matter = yaml.load(front_matter, Loader=yaml.FullLoader)
+            front_matter = yaml.load(front_matter, Loader=yaml.SafeLoader)
             template = cls(body)
         template.__dict__.update(front_matter)
         return template


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

The pyyaml project has some security issues with its FullLoader. It's not a huge deal for jrnl users, given that it's from the config file rather than untrusted input (such as user supplied data to a web server), but since all the tests are passing with SafeLoader, there's no harm in switching to this.

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [X] I have tested this code locally.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [X] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
