### PR TITLE
`jrnl.__version__` magic works!

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,15 +82,14 @@ jobs:
         poetry version "$JRNL_VERSION"
         {
           echo "# This file is managed automatically by the GitHub release flow"
-          echo ""
+          echo
           echo "import sys"
-          echo ""
+          echo
           echo "__version__ = \"$JRNL_VERSION\""
-          echo ""
-          echo "# this makes the version available at `jrnl.__version__` without requiring a"
-          echo "# `__init__.py` file in the *jrnl* root directory!"
-          echo "sys.modules[\"jrnl.__version__\"] = __version__"
-          echo ""
+          echo
+          echo '# this makes the version available at `jrnl.__version__` without requiring a'
+          echo '# `__init__.py` file in the *jrnl* root directory!'
+          echo 'sys.modules["jrnl.__version__"] = __version__'
         } > jrnl/__version__.py
 
     - name: Commit updated files

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,18 @@ jobs:
       if: ${{ github.event.inputs.include_repo_version == 'true' }}
       run: |
         poetry version "$JRNL_VERSION"
-        echo __version__ = \"$JRNL_VERSION\" > jrnl/__version__.py
+        {
+          echo "# This file is managed automatically by the GitHub release flow"
+          echo ""
+          echo "import sys"
+          echo ""
+          echo "__version__ = \"$JRNL_VERSION\""
+          echo ""
+          echo "# this makes the version available at `jrnl.__version__` without requiring a"
+          echo "# `__init__.py` file in the *jrnl* root directory!"
+          echo "sys.modules[\"jrnl.__version__\"] = __version__"
+          echo ""
+        } > jrnl/__version__.py
 
     - name: Commit updated files
       if: ${{ github.event.inputs.include_repo_version == 'true' && github.repository == env.HOME_REPO }}

--- a/features/steps/core.py
+++ b/features/steps/core.py
@@ -18,7 +18,7 @@ import yaml
 from yaml.loader import SafeLoader
 
 from jrnl import Journal
-from jrnl.__version__ import __version__
+from jrnl import __version__
 from jrnl import plugins
 from jrnl.args import parse_args
 from jrnl.behave_testing import _mock_getpass

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -15,7 +15,7 @@ import tzlocal
 
 from . import Entry
 from . import Journal
-from jrnl.__version__ import __version__
+from . import __version__
 
 
 class DayOne(Journal.Journal):

--- a/jrnl/__version__.py
+++ b/jrnl/__version__.py
@@ -1,1 +1,9 @@
+# This file is managed automatically by the GitHub release flow
+
+import sys
+
 __version__ = "v2.8.1"
+
+# this makes the version available at `jrnl.__version__` without requiring a
+# `__init__.py` file in the *jrnl* root directory
+sys.modules["jrnl.__version__"] = __version__

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -4,9 +4,9 @@
 import logging
 import sys
 
-from .jrnl import run
 from .args import parse_args
 from .exception import JrnlError
+from .jrnl import run
 
 
 def configure_logger(debug=False):

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -16,7 +16,7 @@ import sys
 
 
 def preconfig_diagnostic(_):
-    from jrnl.__version__ import __version__
+    from jrnl import __version__
 
     print(
         f"jrnl: {__version__}\n"
@@ -26,7 +26,7 @@ def preconfig_diagnostic(_):
 
 
 def preconfig_version(_):
-    from jrnl.__version__ import __version__
+    from jrnl import __version__
     from jrnl.plugins.collector import (
         IMPORT_FORMATS,
         EXPORT_FORMATS,

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -6,7 +6,7 @@ import colorama
 import yaml
 import xdg.BaseDirectory
 
-from jrnl.__version__ import __version__
+from . import __version__
 from .exception import JrnlError
 from .color import ERROR_COLOR
 from .color import RESET_COLOR

--- a/jrnl/plugins/exporter/dates.py
+++ b/jrnl/plugins/exporter/dates.py
@@ -4,9 +4,8 @@
 
 from collections import Counter
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseExporter
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/fancy.py
+++ b/jrnl/plugins/exporter/fancy.py
@@ -5,10 +5,9 @@
 
 from textwrap import TextWrapper
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseExporter
 from jrnl.plugins.util import check_provided_linewrap_viability
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/json.py
+++ b/jrnl/plugins/exporter/json.py
@@ -4,10 +4,9 @@
 
 import json
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseExporter
 from jrnl.plugins.util import get_tags_count
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/markdown.py
+++ b/jrnl/plugins/exporter/markdown.py
@@ -6,11 +6,10 @@ import os
 import re
 import sys
 
+from jrnl import __version__
 from jrnl.color import RESET_COLOR
 from jrnl.color import WARNING_COLOR
 from jrnl.plugins.base import BaseExporter
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/pretty.py
+++ b/jrnl/plugins/exporter/pretty.py
@@ -3,9 +3,8 @@
 # Copyright (C) 2012-2021 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseExporter
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/short.py
+++ b/jrnl/plugins/exporter/short.py
@@ -3,9 +3,8 @@
 # Copyright (C) 2012-2021 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseExporter
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/tag.py
+++ b/jrnl/plugins/exporter/tag.py
@@ -3,10 +3,9 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseExporter
 from jrnl.plugins.util import get_tags_count
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/text.py
+++ b/jrnl/plugins/exporter/text.py
@@ -3,9 +3,8 @@
 # Copyright (C) 2012-2021 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseExporter
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/xml.py
+++ b/jrnl/plugins/exporter/xml.py
@@ -4,10 +4,9 @@
 
 from xml.dom import minidom
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseExporter
 from jrnl.plugins.util import get_tags_count
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/exporter/yaml.py
+++ b/jrnl/plugins/exporter/yaml.py
@@ -6,12 +6,11 @@ import os
 import re
 import sys
 
+from jrnl import __version__
 from jrnl.color import ERROR_COLOR
 from jrnl.color import RESET_COLOR
 from jrnl.color import WARNING_COLOR
 from jrnl.plugins.base import BaseExporter
-
-from jrnl.__version__ import __version__
 
 
 class Exporter(BaseExporter):

--- a/jrnl/plugins/importer/jrnl.py
+++ b/jrnl/plugins/importer/jrnl.py
@@ -4,9 +4,8 @@
 
 import sys
 
+from jrnl import __version__
 from jrnl.plugins.base import BaseImporter
-
-from jrnl.__version__ import __version__
 
 
 class Importer(BaseImporter):

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from . import Journal
-from jrnl.__version__ import __version__
+from . import __version__
 from .EncryptedJournal import EncryptedJournal
 from .config import is_config_json
 from .config import load_config


### PR DESCRIPTION
Further to #1006, this allows `from jrnl import __version__` to work even without an `__init__.py` file!

Turns out pretty much everything in Python is mutable, you just have to know what to mutate! :)

Also, apply *isort* to the adjusted imports.

This also tries to address the [release workflow](https://github.com/jrnl-org/jrnl/blob/develop/.github/workflows/release.yaml#L83) which will override the version file. However, bash is **not** my strong suit, so confirm my function will work as expected.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ n/a ] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
