### PR TITLE
Fix --config-override typo in --help output

### DIFF
--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -331,7 +331,7 @@ def parse_args(args=[]):
 
         Examples: \n
         \t - Use a different editor for this jrnl entry, call: \n
-            \t jrnl --config-override editor: "nano" \n
+            \t jrnl --config-override editor "nano" \n
         \t - Override color selections\n
            \t jrnl --config-override colors.body blue --config-override colors.title green
         """,


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
I copy-pasted the first `--config-override` example from the command line `--help` and it didn't work to due the extraneous colon. This PR fixes that.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
- [ ] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
