### PR TITLE
Allow emoji in config file in Windows by always opening it as unicode

### DIFF
--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -20,6 +20,7 @@ DEFAULT_JOURNAL_NAME = "journal.txt"
 DEFAULT_JOURNAL_KEY = "default"
 
 YAML_SEPARATOR = ": "
+YAML_FILE_ENCODING = "utf-8"
 
 
 def make_yaml_valid_dict(input: list) -> dict:
@@ -48,9 +49,13 @@ def make_yaml_valid_dict(input: list) -> dict:
 
 def save_config(config):
     config["version"] = __version__
-    with open(get_config_path(), "w") as f:
+    with open(get_config_path(), "w", encoding=YAML_FILE_ENCODING) as f:
         yaml.safe_dump(
-            config, f, encoding="utf-8", allow_unicode=True, default_flow_style=False
+            config,
+            f,
+            encoding=YAML_FILE_ENCODING,
+            allow_unicode=True,
+            default_flow_style=False,
         )
 
 
@@ -139,7 +144,7 @@ def verify_config_colors(config):
 
 def load_config(config_path):
     """Tries to load a config file from YAML."""
-    with open(config_path) as f:
+    with open(config_path, encoding=YAML_FILE_ENCODING) as f:
         return yaml.load(f, Loader=yaml.SafeLoader)
 
 

--- a/tests/bdd/features/multiple_journals.feature
+++ b/tests/bdd/features/multiple_journals.feature
@@ -88,3 +88,9 @@ Feature: Multiple journals
             these three eyes
             n
         Then the output should contain "Encrypted journal 'new_encrypted' created"
+
+   Scenario: Read and write to journal with emoji name
+        Given we use the config "multiple.yaml"
+        When we run "jrnl ✨ Adding entry to sparkly journal"
+        When we run "jrnl ✨ -1"
+        Then the output should contain "Adding entry to sparkly journal"

--- a/tests/data/configs/multiple.yaml
+++ b/tests/data/configs/multiple.yaml
@@ -12,6 +12,7 @@ journals:
   new_encrypted:
     encrypt: true
     journal: features/journals/new_encrypted.journal
+  ✨: features/journals/simple.journal
 linewrap: 80
 tagsymbols: '@'
 timeformat: '%Y-%m-%d %H:%M'


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

Fixes #1162. I forced utf-8 encoding on open, since apparently Python won't use that in Windows by default.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
