### PR TITLE
Fix failure to import into directory journal

### DIFF
--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -22,10 +22,10 @@ def get_files(journal_config):
 class Folder(Journal.Journal):
     """A Journal handling multiple files in a folder"""
 
-    def __init__(self, **kwargs):
+    def __init__(self, name="default", **kwargs):
         self.entries = []
         self._diff_entry_dates = []
-        super(Folder, self).__init__(**kwargs)
+        super().__init__(name, **kwargs)
 
     def open(self):
         filenames = []
@@ -43,10 +43,12 @@ class Folder(Journal.Journal):
         # Create a list of dates of modified entries. Start with diff_entry_dates
         modified_dates = self._diff_entry_dates
         seen_dates = set(self._diff_entry_dates)
+
         for e in self.entries:
             if e.modified:
-                if e.date not in seen_dates:
+                if e.date not in modified_dates:
                     modified_dates.append(e.date)
+                if e.date not in seen_dates:
                     seen_dates.add(e.date)
 
         # For every date that had a modified entry, write to a file

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -68,13 +68,11 @@ class Journal:
 
     def import_(self, other_journal_txt):
         imported_entries = self._parse(other_journal_txt)
-        for entry in imported_entries: entry.modified = True
+        for entry in imported_entries:
+            entry.modified = True
 
-        self.entries = list(
-            frozenset(self.entries) | frozenset(imported_entries)
-        )
+        self.entries = list(frozenset(self.entries) | frozenset(imported_entries))
         self.sort()
-
 
     def open(self, filename=None):
         """Opens the journal file defined in the config and parses it into a list of Entries.

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -67,10 +67,14 @@ class Journal:
         return new_journal
 
     def import_(self, other_journal_txt):
+        imported_entries = self._parse(other_journal_txt)
+        for entry in imported_entries: entry.modified = True
+
         self.entries = list(
-            frozenset(self.entries) | frozenset(self._parse(other_journal_txt))
+            frozenset(self.entries) | frozenset(imported_entries)
         )
         self.sort()
+
 
     def open(self, filename=None):
         """Opens the journal file defined in the config and parses it into a list of Entries.
@@ -414,7 +418,7 @@ def open_journal(journal_name, config, legacy=False):
         else:
             from . import FolderJournal
 
-            return FolderJournal.Folder(**config).open()
+            return FolderJournal.Folder(journal_name, **config).open()
 
     if not config["encrypt"]:
         if legacy:

--- a/tests/bdd/features/import.feature
+++ b/tests/bdd/features/import.feature
@@ -11,7 +11,7 @@ Feature: Importing data
         | config_file          |
         | basic_onefile.yaml   |
         | basic_encrypted.yaml |
-        # | basic_folder.yaml    | @todo
+        | basic_folder.yaml    |
         # | basic_dayone.yaml    | @todo
 
     Scenario Outline: --import allows new large entry from stdin
@@ -34,7 +34,7 @@ Feature: Importing data
         | config_file          |
         | basic_onefile.yaml   |
         | basic_encrypted.yaml |
-        # | basic_folder.yaml    | @todo
+        | basic_folder.yaml    |
         # | basic_dayone.yaml    | @todo
 
     Scenario Outline: --import allows multiple new entries from stdin
@@ -56,7 +56,7 @@ Feature: Importing data
         | config_file          |
         | basic_onefile.yaml   |
         | basic_encrypted.yaml |
-        # | basic_folder.yaml    | @todo
+        | basic_folder.yaml    |
         # | basic_dayone.yaml    | @todo
 
     Scenario: --import allows import new entries from file


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
Fixes #999.

A couple issues were at fault:
- the FolderJournal only writes entries with the "modified" property set to True. However, imported entries weren't marked as "modified"
- the FolderJournal writing method wasn't identifying new ("modified") dates appropriately

There are some larger issues with this whole object model, mainly that it's not really hiding complexity. Whether you're calling or inheriting a Journal, you've got to know how its innards work, and that makes it difficult to extend. But first and foremost, I wanted to get this bug fixed.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
