### PR TITLE
Display error when trying to encrypt folder/DayOne journal types

### DIFF
--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -32,6 +32,7 @@ class DayOne(Journal.Journal):
     def __init__(self, **kwargs):
         self.entries = []
         self._deleted_entries = []
+        self.cannot_be_encrypted = True
         super().__init__(**kwargs)
 
     def open(self):

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -32,7 +32,7 @@ class DayOne(Journal.Journal):
     def __init__(self, **kwargs):
         self.entries = []
         self._deleted_entries = []
-        self.cannot_be_encrypted = True
+        self.can_be_encrypted = False
         super().__init__(**kwargs)
 
     def open(self):

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -25,6 +25,7 @@ class Folder(Journal.Journal):
     def __init__(self, **kwargs):
         self.entries = []
         self._diff_entry_dates = []
+        self.cannot_be_encrypted = True
         super(Folder, self).__init__(**kwargs)
 
     def open(self):

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -25,7 +25,7 @@ class Folder(Journal.Journal):
     def __init__(self, **kwargs):
         self.entries = []
         self._diff_entry_dates = []
-        self.cannot_be_encrypted = True
+        self.can_be_encrypted = False
         super(Folder, self).__init__(**kwargs)
 
     def open(self):

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -69,7 +69,7 @@ def postconfig_encrypt(args, config, original_config, **kwargs):
     # Open the journal
     journal = open_journal(args.journal_name, config)
 
-    if hasattr(journal, "cannot_be_encrypted") and journal.cannot_be_encrypted:
+    if hasattr(journal, "can_be_encrypted") and not journal.can_be_encrypted:
         raise JrnlError(
             "CannotEncryptJournalType",
             journal_name=args.journal_name,

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -13,6 +13,7 @@ avoid any possible overhead for these standalone commands.
 """
 import platform
 import sys
+from .exception import JrnlError
 
 
 def preconfig_diagnostic(_):
@@ -67,6 +68,13 @@ def postconfig_encrypt(args, config, original_config, **kwargs):
 
     # Open the journal
     journal = open_journal(args.journal_name, config)
+
+    if hasattr(journal, "cannot_be_encrypted") and journal.cannot_be_encrypted:
+        raise JrnlError(
+            "CannotEncryptJournalType",
+            journal_name=args.journal_name,
+            journal_type=journal.__class__.__name__,
+        )
 
     journal.config["encrypt"] = True
 

--- a/jrnl/exception.py
+++ b/jrnl/exception.py
@@ -38,6 +38,13 @@ class JrnlError(Exception):
                 by at least {columns} in the configuration file or by using
                 --config-override at the command line
                 """,
+            "CannotEncryptJournalType": """
+                The journal {journal_name} can't be encrypted because it is a
+                {journal_type} journal.
+
+                To encrypt it, create a new journal referencing a file, export
+                this journal to the new journal, then encrypt the new journal.
+                """,
         }
 
         msg = error_messages[self.error_type].format(**kwargs)

--- a/tests/bdd/features/encrypt.feature
+++ b/tests/bdd/features/encrypt.feature
@@ -40,3 +40,12 @@ Feature: Encrypting and decrypting journals
         Then we should be prompted for a password
         And the output should contain "2013-06-10 15:40 Life is good"
 
+    Scenario Outline: Attempt to encrypt a folder or DayOne journal should result in an error
+        Given we use the config "<config_file>"
+        When we run "jrnl --encrypt"
+        Then the error output should contain "can't be encrypted"
+
+        Examples: configs
+        | config_file       |
+        | empty_folder.yaml |
+        | dayone.yaml       |

--- a/tests/bdd/features/encrypt.feature
+++ b/tests/bdd/features/encrypt.feature
@@ -28,17 +28,23 @@ Feature: Encrypting and decrypting journals
     # This should warn the user that the journal is already encrypted
 
 
-    Scenario: Encrypting a journal
+    Scenario Outline: Encrypting a journal
         Given we use the config "simple.yaml"
         When we run "jrnl --encrypt" and enter
             swordfish
             swordfish
             n
-        Then we should see the message "Journal encrypted"
+        Then we should get no error
+        And we should see the message "Journal encrypted"
         And the config for journal "default" should contain "encrypt: true"
         When we run "jrnl -n 1" and enter "swordfish"
         Then we should be prompted for a password
         And the output should contain "2013-06-10 15:40 Life is good"
+
+        Examples: configs
+        | config_file        |
+        | basic_onefile.yaml |
+
 
     Scenario Outline: Attempt to encrypt a folder or DayOne journal should result in an error
         Given we use the config "<config_file>"
@@ -47,14 +53,5 @@ Feature: Encrypting and decrypting journals
 
         Examples: configs
         | config_file       |
-        | empty_folder.yaml |
-        | dayone.yaml       |
-
-    Scenario Outline: Attempt to encrypt basic journal should not result in an error
-        Given we use the config "<config_file>"
-        When we run "jrnl --encrypt"
-        Then we should get no error
-
-        Examples: configs
-        | config_file       |
-        | simple.yaml       |
+        | basic_folder.yaml |
+        | basic_dayone.yaml |

--- a/tests/bdd/features/encrypt.feature
+++ b/tests/bdd/features/encrypt.feature
@@ -49,3 +49,12 @@ Feature: Encrypting and decrypting journals
         | config_file       |
         | empty_folder.yaml |
         | dayone.yaml       |
+
+    Scenario Outline: Attempt to encrypt basic journal should not result in an error
+        Given we use the config "<config_file>"
+        When we run "jrnl --encrypt"
+        Then we should get no error
+
+        Examples: configs
+        | config_file       |
+        | simple.yaml       |


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
Fixes #1243 by raising a much more user-friendly exception.

It would be nice to encrypt folder journals, but in the meantime, we can at least let users know that it can't be down, along with some information on how to encrypt their folder journal as a file journal.

Also, I'm open to input on how to do this in a more Pythonic way. I didn't want the `--encrypt` command to be too aware of various journal types, but my style still feels a bit C#ish.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have tested this code locally.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
- [x] All tests pass.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
