### PR TITLE
Take out redundant lines from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,11 +14,9 @@ Here are some key points to include in your description:
 
 - [ ] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
 - [ ] I have included a link to the relevant issue number.
-- [ ] I have tested this code locally.
 - [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
   for the same issue.
 - [ ] I have written new tests for these changes, as needed.
-- [ ] All tests pass.
 <!--
 NOTE: Your PR may not be reviewed if there are any failing tests. You can run
 tests locally with `make test` (see the contributing doc if you need help with


### PR DESCRIPTION
We had check marks asking whether the code was tested and if the tests pass. Our test
pipeline tells us this information, so there's no need for anyone to check those boxes.

This PR removes those lines from the PR template.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->