### PR TITLE
Add CACHE_STRING secret to bust GitHub Actions python cache

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: .venv
-        key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}-v2-${{ secrets.CACHE_STRING }}
+        key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}-${{ secrets.CACHE_STRING }}
 
     - name: Install dependencies
       if: ${{ matrix.python-version != '3.10-dev' }}

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -45,11 +45,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: poetry cache
+    - name: poetry cache # Change CACHE_STRING secret to bust the cache. Useful with minor Python version changes.
       uses: actions/cache@v2
       with:
         path: .venv
-        key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}-v2
+        key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}-v2-${{ secrets.CACHE_STRING }}
 
     - name: Install dependencies
       if: ${{ matrix.python-version != '3.10-dev' }}


### PR DESCRIPTION
Sometimes the cache gets out of date and a PR starts failing, especially if it has been open for a while. Looks like one cause for this is if a Python version is updated by GitHub actions after the PR was submitted.

This change here gives us a GitHub secret we can use to reset the cache.

This solution isn't ideal because it doesn't solve the root cause, but it does give us a quick fix for the problem when it occurs.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [ ] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
