### PR TITLE
Fix recipe 'Launch a terminal for rapid logging'

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -159,7 +159,7 @@ jrnl -on "$(jrnl --short | shuf -n 1 | cut -d' ' -f1,2)"
 You can use this to launch a terminal that is the `jrnl` stdin prompt so you can start typing away immediately. 
 
 ```bash
-jrnl now --config-override editor:""
+jrnl --config-override editor ""
 ```
 
 Bind this to a keyboard shortcut. 
@@ -171,13 +171,13 @@ In your `.xbindkeysrc`
 
 ```ini
 Mod4+Mod1+j
- alacritty -t floating-jrnl -e jrnl now --config-override editor:"",
+ alacritty -t floating-jrnl -e jrnl --config-override editor "",
 ```
 
 - **I3 WM** Launch a floating terminal with the `jrnl` prompt
 
 ```ini
-bindsym Mod4+Mod1+j exec --no-startup-id alacritty -t floating-jrnl -e jrnl --config-override editor:""
+bindsym Mod4+Mod1+j exec --no-startup-id alacritty -t floating-jrnl -e jrnl --config-override editor ""
 for_window[title="floating *"] floating enable
 ```
 


### PR DESCRIPTION
Fix the recipe 'Launch a terminal for rapid logging' 

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.

There are no open issues related to this PR.
