### PR TITLE
Add added option to _print_edited_summary

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -275,13 +275,18 @@ def _edit_search_results(config, journal, old_entries, **kwargs):
 
 def _print_edited_summary(journal, old_stats, **kwargs):
     stats = {
+        "added": len(journal) - old_stats["count"],
         "deleted": old_stats["count"] - len(journal),
         "modified": len([e for e in journal.entries if e.modified]),
     }
 
     prompts = []
 
-    if stats["deleted"]:
+    if stats["added"] > 0:
+        prompts.append(f"{stats['added']} {_pluralize_entry(stats['added'])} added")
+        stats["modified"] -= stats["added"]
+
+    if stats["deleted"] > 0:
         prompts.append(
             f"{stats['deleted']} {_pluralize_entry(stats['deleted'])} deleted"
         )

--- a/tests/bdd/features/write.feature
+++ b/tests/bdd/features/write.feature
@@ -211,3 +211,74 @@ Feature: Writing new entries.
         Then we should see the message "Entry added"
         When we run "jrnl -1"
         Then the output should be "2013-07-23 09:00 Testing folder journal."
+
+    Scenario Outline: Correctly count when adding a single entry via --edit
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        And we append to the editor if opened
+            [2021-11-13] worked on jrnl tests
+        When we run "jrnl --edit"
+        Then the output should contain
+            [1 entry added]
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        #| basic_dayone.yaml    | @todo
+
+
+    Scenario Outline: Correctly count when adding multiple entries via --edit
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        And we append to the editor if opened
+            [2021-11-11] worked on jrnl tests
+            [2021-11-12] worked on jrnl tests again
+            [2021-11-13] worked on jrnl tests a little bit more
+        When we run "jrnl --edit"
+        Then the output should contain
+            [3 entries added]
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        #| basic_dayone.yaml    | @todo
+
+
+    Scenario Outline: Correctly count when removing entries via --edit
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        And we write to the editor if opened
+            [2021-11-13] I am replacing my whole journal with this entry
+        When we run "jrnl --edit"
+        Then the output should contain
+            [2 entries deleted, 1 entry modified]
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        #| basic_dayone.yaml    | @todo
+
+
+    Scenario Outline: Correctly count modification when running --edit on a single entry
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        And we write to the editor if opened
+            [2021-11-13] I am replacing the last entry with this entry
+        When we run "jrnl --edit -1"
+        Then the output should contain
+            [1 entry modified]
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        #| basic_dayone.yaml    | @todo
+
+

--- a/tests/bdd/features/write.feature
+++ b/tests/bdd/features/write.feature
@@ -265,7 +265,7 @@ Feature: Writing new entries.
         #| basic_dayone.yaml    | @todo
 
 
-    Scenario Outline: Correctly count modification when running --edit on a single entry
+    Scenario Outline: Correctly count modification when running --edit to replace a single entry
         Given we use the config "<config_file>"
         And we use the password "test" if prompted
         And we write to the editor if opened
@@ -282,3 +282,18 @@ Feature: Writing new entries.
         #| basic_dayone.yaml    | @todo
 
 
+    Scenario Outline: Correctly count modification when running --edit on whole journal and adding to last entry
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        And we append to the editor if opened
+            This is a small addendum to my latest entry.
+        When we run "jrnl --edit"
+        Then the output should contain
+            [1 entry modified]
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        #| basic_dayone.yaml    | @todo


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

Fixes #1198. The summary used to show negative numbers when entries were added. There was also no option to show the added entries. 

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
