### PR TITLE
Use full Python version for GitHub Actions cache key

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -45,11 +45,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: poetry cache # Change CACHE_STRING secret to bust the cache. Useful with minor Python version changes.
+    - name: Capture full Python version in env
+      run: echo "PYTHON_FULL_VERSION=$(python --version)" >> $GITHUB_ENV
+
+    - name: poetry cache # Change CACHE_STRING secret to bust the cache
       uses: actions/cache@v2
       with:
         path: .venv
-        key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}-${{ secrets.CACHE_STRING }}
+        key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ env.PYTHON_FULL_VERSION }}-${{ secrets.CACHE_STRING }}
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

We keep running into stale cache issues when this happens:
* Someone opens a PR
* Python releases a new patch version (like from 3.9.7 to 3.9.8)
* The next time tests run on that PR, they crash because they're have references to the older patch version

This should fix the issue by grabbing the full `python --version`  output such as "Python 3.9.8" and using that as part of the cache key.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
