### PR TITLE
Use locale from config if specified, otherwise use user's environment locale

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2012-2021 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import locale
 import logging
 import sys
 
@@ -47,6 +48,9 @@ def run(args):
     except UserAbort as err:
         print(f"\n{err}", file=sys.stderr)
         sys.exit(1)
+
+    # From here on, dates and numbers will use the locale supplied by the user
+    _init_locale(config)
 
     # Run post-config command now that config is ready
     if callable(args.postconfig_cmd):
@@ -343,3 +347,12 @@ def _display_search_results(args, journal, **kwargs):
         print(exporter.export(journal, args.filename))
     else:
         print(journal.pprint())
+
+
+def _init_locale(config):
+    """
+    Initializes the locale from the environment variables, or the config
+    if specified in the config.
+    """
+    user_locale = config["locale"] if "locale" in config else ""
+    locale.setlocale(locale.LC_ALL, user_locale)

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -175,7 +175,7 @@ Feature: Reading and writing to journal with custom date formats
 
     Scenario Outline: Dates should be displayed using the specified locale
         Given we use the config "basic_onefile.yaml"
-        When we run "jrnl --config-override locale <locale> --config-override timeformat \%c -1"
+        When we run "jrnl --config-override locale <locale> --config-override timeformat '\%c' -1"
         Then the output should contain "<expected_date>"
         
         Examples: configs

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -175,14 +175,14 @@ Feature: Reading and writing to journal with custom date formats
 
     Scenario Outline: Dates should be displayed using the specified locale
         Given we use the config "basic_onefile.yaml"
-        When we run "jrnl --config-override locale <locale> --config-override timeformat '\%c' -1"
+        When we run "jrnl --config-override locale <locale> --config-override timeformat '%A %d %B %Y' -1 --short"
         Then the output should contain "<expected_date>"
         
         Examples: configs
-        | locale       | expected_date        |
-        | en_US.UTF-8  | 9/24/2020 9:14:00 AM |
-        | zh_CN.UTF-8  | 2020/9/24 9:14:00    |
-        | ru_RU.UTF-8  | 24.09.2020 9:14:00   |
-        | fr_FR.UTF-8  | 24/09/2020 09:14:00  |
-        | es_ES.UTF-8  | 24/09/2020 9:14:00   |
-        | de_DE.UTF-8  | 24.09.2020 09:14:00  |
+        | locale       | expected_date                |
+        | en_US.UTF-8  | Thursday 24 September 2020   |
+        | zh_CN.UTF-8  | 星期四 24 九月 2020           |
+        | ru_RU.UTF-8  | четверг 24 Сентябрь 2020     |
+        | fr_FR.UTF-8  | jeudi 24 septembre 2020      |
+        | es_ES.UTF-8  | jueves 24 septiembre 2020    |
+        | de_DE.UTF-8  | Donnerstag 24 September 2020 |

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -172,3 +172,17 @@ Feature: Reading and writing to journal with custom date formats
         Then we should get no error
         And the output should be
             2013-10-27 03:27 Some text.
+
+    Scenario Outline: Dates should be displayed using the specified locale
+        Given we use the config "basic_onefile.yaml"
+        When we run "jrnl --config-override locale <locale> --config-override timeformat \%c -1"
+        Then the output should contain "<expected_date>"
+        
+        Examples: configs
+        | locale | expected_date        |
+        | en_US  | 9/24/2020 9:14:00 AM |
+        | zh_CN  | 2020/9/24 9:14:00    |
+        | ru_RU  | 24.09.2020 9:14:00   |
+        | fr_FR  | 24/09/2020 09:14:00  |
+        | es_ES  | 24/09/2020 9:14:00   |
+        | de_DE  | 24.09.2020 09:14:00  |

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -179,10 +179,10 @@ Feature: Reading and writing to journal with custom date formats
         Then the output should contain "<expected_date>"
         
         Examples: configs
-        | locale | expected_date        |
-        | en_US  | 9/24/2020 9:14:00 AM |
-        | zh_CN  | 2020/9/24 9:14:00    |
-        | ru_RU  | 24.09.2020 9:14:00   |
-        | fr_FR  | 24/09/2020 09:14:00  |
-        | es_ES  | 24/09/2020 9:14:00   |
-        | de_DE  | 24.09.2020 09:14:00  |
+        | locale       | expected_date        |
+        | en_US.UTF-8  | 9/24/2020 9:14:00 AM |
+        | zh_CN.UTF-8  | 2020/9/24 9:14:00    |
+        | ru_RU.UTF-8  | 24.09.2020 9:14:00   |
+        | fr_FR.UTF-8  | 24/09/2020 09:14:00  |
+        | es_ES.UTF-8  | 24/09/2020 9:14:00   |
+        | de_DE.UTF-8  | 24.09.2020 09:14:00  |

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -182,7 +182,5 @@ Feature: Reading and writing to journal with custom date formats
         | locale       | expected_date                |
         | en_US.UTF-8  | Thursday 24 September 2020   |
         | zh_CN.UTF-8  | 星期四 24 九月 2020           |
-        | ru_RU.UTF-8  | четверг 24 Сентябрь 2020     |
-        | fr_FR.UTF-8  | jeudi 24 septembre 2020      |
         | es_ES.UTF-8  | jueves 24 septiembre 2020    |
         | de_DE.UTF-8  | Donnerstag 24 September 2020 |

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -175,7 +175,7 @@ Feature: Reading and writing to journal with custom date formats
 
     Scenario Outline: Dates should be displayed using the specified locale
         Given we use the config "basic_onefile.yaml"
-        When we run "jrnl --config-override locale <locale> --config-override timeformat '%A %d %B %Y' -1 --short"
+        When we run "jrnl --config-override locale <locale> --config-override timeformat \'%A %d %B %Y\' -1 --short"
         Then the output should contain "<expected_date>"
         
         Examples: configs

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -175,7 +175,7 @@ Feature: Reading and writing to journal with custom date formats
 
     Scenario Outline: Dates should be displayed using the specified locale
         Given we use the config "basic_onefile.yaml"
-        When we run "jrnl --config-override locale <locale> --config-override timeformat \'%A %d %B %Y\' -1 --short"
+        When we run "jrnl --config-override locale <locale> --config-override timeformat "'%A %d %B %Y'" -1 --short"
         Then the output should contain "<expected_date>"
         
         Examples: configs


### PR DESCRIPTION
Fixes #1353 by checking the config file for a `locale` setting. If there's no locale setting, then it uses the environment's locale instead.

🚨 Affects both the presentation _and_ storage of dates! 🚨

I'm also going to keep this as a draft until I:

- [ ] add documentation about this feature
  - [ ] include some "gotchas" around Windows vs other environments - from my testing, it seems like Windows only uses the Control Panel's language setting, instead of any environment variables
- [ ] address concerns around automatically fetching the locale and possibly messing with the dates on existing journals (maybe only an issue for people that use %c in their timeformat?) - I don't want every entry between the 1st and 12th day of the month to suddenly get its date mangled because someone is switching their environment between en_US and en_GB, for instance
- [ ] add additional tests?
- [ ] possibly force locale in test code with mocks so that "make test" works right out of the box regardless of the developer's locale
- [ ] gracefully deal with unsupported locales instead of spewing a stack trace

If anyone else would like to work any of the above, feel free to contribute. I'll mainly be working on this on Saturdays, Pacific time.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
