### PR TITLE
Add hash as a default tag symbol for new jrnl config file

### DIFF
--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -89,7 +89,7 @@ def get_default_config():
         "default_hour": 9,
         "default_minute": 0,
         "timeformat": "%Y-%m-%d %H:%M",
-        "tagsymbols": "@",
+        "tagsymbols": "#@",
         "highlight": True,
         "linewrap": 79,
         "indent_character": "|",


### PR DESCRIPTION
This PR adds the # symbol as a default tag symbol for new jrnl installations. @ is still preserved so either can be used.

Tested locally to confirm that it is included in the config when running jrnl for the first time.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] ~I have included a link to the relevant issue number.~
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] ~I have written new tests for these changes, as needed.~
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
