### PR TITLE
Fix tests for daylight savings

### DIFF
--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -176,7 +176,7 @@ Feature: Reading and writing to journal with custom date formats
 
 
     @skip #1422
-    Scenario Outline: Using times near daylight savings windows works as expected
+    Scenario Outline: Using "tomorrow" near daylight savings works in Dayone journals
         Given we use the config "dayone.yaml"
         And now is "<date>"
         When we run "jrnl yesterday: This thing happened yesterday"

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -190,7 +190,7 @@ Feature: Reading and writing to journal with custom date formats
         And the output should contain "Adding an entry right now."
         And the output should not contain "A future entry."
 
-        Examples: configs
+        Examples: Dates
         | date                   |
         | 2022-02-10 01:00:00 PM |
         | 2021-03-13 01:00:00 PM |

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -83,6 +83,7 @@ Feature: Reading and writing to journal with custom date formats
         Then the output should not contain "Life is good"
         And the output should not contain "But I'm better."
 
+
     Scenario Outline: Create entry using day of the week as entry date one.
         Given we use the config "simple.yaml"
         And now is "2019-03-12 01:30:32 PM"

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -172,3 +172,28 @@ Feature: Reading and writing to journal with custom date formats
         Then we should get no error
         And the output should be
             2013-10-27 03:27 Some text.
+
+
+    @skip #1422
+    Scenario Outline: Using times near daylight savings windows works as expected
+        Given we use the config "dayone.yaml"
+        And now is "<date>"
+        When we run "jrnl yesterday: This thing happened yesterday"
+        Then the output should contain "Entry added"
+        When we run "jrnl today at 11:59pm: Adding an entry right now."
+        Then the output should contain "Entry added"
+        When we run "jrnl tomorrow: A future entry."
+        Then the output should contain "Entry added"
+        When we run "jrnl -from yesterday -to today"
+        Then the output should contain "This thing happened yesterday"
+        And the output should contain "Adding an entry right now."
+        And the output should not contain "A future entry."
+
+        Examples: configs
+        | date                   |
+        | 2022-02-10 01:00:00 PM |
+        | 2021-03-13 01:00:00 PM |
+        | 2021-11-06 01:00:00 PM |
+        | 2022-03-12 01:00:00 PM |
+        | 2022-11-05 01:00:00 PM |
+

--- a/tests/bdd/features/search.feature
+++ b/tests/bdd/features/search.feature
@@ -36,6 +36,7 @@ Feature: Searching in a journal
 
     Scenario Outline: Displaying entries using -from and -to day should display correct entries
         Given we use the config "<config_file>"
+        And now is "2022-03-10 02:32:00 PM"
         When we run "jrnl yesterday: This thing happened yesterday"
         Then the output should contain "Entry added"
         When we run "jrnl today at 11:59pm: Adding an entry right now."


### PR DESCRIPTION
This PR:
- Fixes current test that was failing on the day before daylight savings
- Adds new set of tests to catch this issue in the future
- Skips the new test for now, because the issue still exists (#1422)

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
