### PR TITLE
Pin jinja2 in docs requirements to keep readthedocs builds from failing

### DIFF
--- a/docs_theme/requirements.txt
+++ b/docs_theme/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.2.3
-jinja==3.0.3 # https://github.com/readthedocs/readthedocs.org/issues/9037
+jinja2==3.0.3 # https://github.com/readthedocs/readthedocs.org/issues/9037

--- a/docs_theme/requirements.txt
+++ b/docs_theme/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.2.3
-
+jinja==3.0.3 # https://github.com/readthedocs/readthedocs.org/issues/9037

--- a/docs_theme/requirements.txt
+++ b/docs_theme/requirements.txt
@@ -1,2 +1,2 @@
 mkdocs==1.2.3
-jinja<3.1.0 # https://github.com/readthedocs/readthedocs.org/issues/9037
+

--- a/docs_theme/requirements.txt
+++ b/docs_theme/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs==1.2.3
+jinja<3.1.0 # https://github.com/readthedocs/readthedocs.org/issues/9037

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -17,6 +17,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.10
   install:
     - requirements: docs_theme/requirements.txt

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -17,6 +17,5 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.10
   install:
     - requirements: docs_theme/requirements.txt


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

Our documentation build is suddenly failing due to something wrong with a dependency in the read the docs build process. I'm not sure if this will work - let's see.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
