### PR TITLE
Yaml export errors now don't show stack trace

### DIFF
--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -35,6 +35,9 @@ class TextExporter:
                 return f"[Journal exported to {path}]"
         except IOError as e:
             return f"[{ERROR_COLOR}ERROR{RESET_COLOR}: {e.filename} {e.strerror}]"
+        except RuntimeError as e:
+            os.remove(path)
+            return e
 
     @classmethod
     def make_filename(cls, entry):
@@ -54,6 +57,9 @@ class TextExporter:
                 return "[{2}ERROR{3}: {0} {1}]".format(
                     e.filename, e.strerror, ERROR_COLOR, RESET_COLOR
                 )
+            except RuntimeError as e:
+                os.remove(full_path)
+                return e
         return "[Journal exported to {}]".format(path)
 
     def _slugify(string):

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -36,7 +36,6 @@ class TextExporter:
         except IOError as e:
             return f"[{ERROR_COLOR}ERROR{RESET_COLOR}: {e.filename} {e.strerror}]"
         except RuntimeError as e:
-            os.remove(path)
             return e
 
     @classmethod
@@ -58,7 +57,6 @@ class TextExporter:
                     e.filename, e.strerror, ERROR_COLOR, RESET_COLOR
                 )
             except RuntimeError as e:
-                os.remove(full_path)
                 return e
         return "[Journal exported to {}]".format(path)
 

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -23,12 +23,10 @@ class YAMLExporter(TextExporter):
     def export_entry(cls, entry, to_multifile=True):
         """Returns a markdown representation of a single entry, with YAML front matter."""
         if to_multifile is False:
-            print(
+            raise RuntimeError(
                 f"{ERROR_COLOR}ERROR{RESET_COLOR}: YAML export must be to individual files. Please \
-                specify a directory to export to.",
-                file=sys.stderr,
+                specify a directory to export to."
             )
-            return
 
         date_str = entry.date.strftime(entry.journal.config["timeformat"])
         body_wrapper = "\n" if entry.body else ""
@@ -131,10 +129,8 @@ class YAMLExporter(TextExporter):
     @classmethod
     def export_journal(cls, journal):
         """Returns an error, as YAML export requires a directory as a target."""
-        print(
+        raise RuntimeError(
             "{}ERROR{}: YAML export must be to individual files. Please specify a directory to export to.".format(
                 ERROR_COLOR, RESET_COLOR
-            ),
-            file=sys.stderr,
+            )
         )
-        return

--- a/tests/bdd/features/format.feature
+++ b/tests/bdd/features/format.feature
@@ -425,6 +425,20 @@ Feature: Custom formats
         | basic_folder.yaml    |
         # | basic_dayone.yaml    |
 
+    Scenario Outline: Exporting YAML to nonexistent directory leads to user-friendly error with no traceback
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        When we run "jrnl --export yaml --file nonexistent_dir"
+        Then the output should contain "YAML export must be to individual files"
+        And the output should not contain "Traceback"
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        # | basic_dayone.yaml    | @todo
+
     @skip_win # @todo YAML exporter does not correctly export emoji on Windows
     Scenario Outline: Add a blank line to YAML export if there isn't one already
         # https://github.com/jrnl-org/jrnl/issues/768

--- a/tests/bdd/features/format.feature
+++ b/tests/bdd/features/format.feature
@@ -437,7 +437,7 @@ Feature: Custom formats
         | basic_onefile.yaml   |
         | basic_encrypted.yaml |
         | basic_folder.yaml    |
-        # | basic_dayone.yaml    | @todo
+        | basic_dayone.yaml    |
 
     @skip_win # @todo YAML exporter does not correctly export emoji on Windows
     Scenario Outline: Add a blank line to YAML export if there isn't one already


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->

This is a fix for the bug mentioned in #1227 related to failed YAML exports showing the stack trace along with an error message. Now it just shows the error message.

Instead of printing an error message and returning `none`, I changed it to throw a `RuntimeError`. The advantage of this is that the calling function doesn't throw a `TypeError` when it gets back a `none` value instead of a `string`. It also gives us the opportunity to clean up the file that was open.

Closes #1227.