### PR TITLE
Display "No entry to save, because no text was received" after empty entry on cmdline

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -134,11 +134,9 @@ def write_mode(args, config, journal, **kwargs):
     else:
         raw = _write_in_editor(config)
 
-    if not raw:
-        logging.error("Write mode: couldn't get raw text")
-        raise JrnlException(
-            Message(MsgText.JrnlExceptionMessage.NoTextReceived, MsgType.ERROR)
-        )
+    if not raw or raw.isspace():
+        logging.error("Write mode: couldn't get raw text or entry was empty")
+        raise JrnlException(Message(MsgText.NoTextReceived, MsgType.ERROR))
 
     logging.debug(
         'Write mode: appending raw text to journal "%s": %s', args.journal_name, raw

--- a/jrnl/messages.py
+++ b/jrnl/messages.py
@@ -98,7 +98,7 @@ class MsgText(Enum):
         """
 
     NoTextReceived = """
-        Nothing saved to file
+        Entry not saved
         """
 
     # --- Upgrade --- #

--- a/jrnl/messages.py
+++ b/jrnl/messages.py
@@ -98,7 +98,7 @@ class MsgText(Enum):
         """
 
     NoTextReceived = """
-        Entry not saved
+        No entry to save, because no text was received
         """
 
     # --- Upgrade --- #

--- a/tests/bdd/features/write.feature
+++ b/tests/bdd/features/write.feature
@@ -73,12 +73,12 @@ Feature: Writing new entries.
         | basic_dayone.yaml    |
         | basic_folder.yaml    |
 
-    Scenario Outline: Writing an empty entry from the editor should yield "Nothing saved to file" message
+    Scenario Outline: Writing an empty entry from the editor should yield "Entry not saved" message
         Given we use the config "<config_file>"
         And we write nothing to the editor if opened
         And we use the password "test" if prompted
         When we run "jrnl --edit"
-        Then the error output should contain "Nothing saved to file"
+        Then the error output should contain "Entry not saved"
         And the editor should have been called
 
         Examples: configs
@@ -89,6 +89,20 @@ Feature: Writing new entries.
         | basic_encrypted.yaml     |
         | basic_onefile.yaml       |
 
+    Scenario Outline: Writing an empty entry from the command line should yield "Entry not saved" message
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        When we run "jrnl" and enter "\x04"
+        Then the error output should contain "Entry not saved"
+        When we run "jrnl" and enter " \t \n \x04"
+        Then the error output should contain "Entry not saved"
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        | basic_dayone.yaml    |
 
     Scenario Outline: Writing an empty entry from the command line with no editor should yield nothing
         Given we use the config "<config_file>"

--- a/tests/bdd/features/write.feature
+++ b/tests/bdd/features/write.feature
@@ -73,12 +73,12 @@ Feature: Writing new entries.
         | basic_dayone.yaml    |
         | basic_folder.yaml    |
 
-    Scenario Outline: Writing an empty entry from the editor should yield "Entry not saved" message
+    Scenario Outline: Writing an empty entry from the editor should yield "No entry to save" message
         Given we use the config "<config_file>"
         And we write nothing to the editor if opened
         And we use the password "test" if prompted
         When we run "jrnl --edit"
-        Then the error output should contain "Entry not saved"
+        Then the error output should contain "No entry to save, because no text was received"
         And the editor should have been called
 
         Examples: configs
@@ -89,13 +89,13 @@ Feature: Writing new entries.
         | basic_encrypted.yaml     |
         | basic_onefile.yaml       |
 
-    Scenario Outline: Writing an empty entry from the command line should yield "Entry not saved" message
+    Scenario Outline: Writing an empty entry from the command line should yield "No entry to save" message
         Given we use the config "<config_file>"
         And we use the password "test" if prompted
         When we run "jrnl" and enter "\x04"
-        Then the error output should contain "Entry not saved"
+        Then the error output should contain "No entry to save, because no text was received"
         When we run "jrnl" and enter " \t \n \x04"
-        Then the error output should contain "Entry not saved"
+        Then the error output should contain "No entry to save, because no text was received"
 
         Examples: configs
         | config_file          |


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->

This PR fixes the bug mentioned in #1419. Now when the user enters an empty journal entry they get the message `[Entry not saved]` back whether they entered it at the command line or using an editor.

Closes #1419.
