### PR TITLE
Give a proper message when trying to use an empty config file

### DIFF
--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -75,6 +75,12 @@ def load_or_install_jrnl(alt_config_path):
         logging.debug("Reading configuration from file %s", config_path)
         config = load_config(config_path)
 
+        if config is None:
+            print(
+                f"Configuration file {config_path} is empty, now using default config"
+            )
+            config = get_default_config()
+
         if is_old_version(config_path):
             from jrnl import upgrade
 

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -76,10 +76,8 @@ def load_or_install_jrnl(alt_config_path):
         config = load_config(config_path)
 
         if config is None:
-            print(
-                f"Configuration file {config_path} is empty, now using default config"
-            )
-            config = get_default_config()
+            print("Unable to parse config file", file=sys.stderr)
+            sys.exit()
 
         if is_old_version(config_path):
             from jrnl import upgrade

--- a/tests/bdd/features/config_file.feature
+++ b/tests/bdd/features/config_file.feature
@@ -85,7 +85,6 @@ Feature: Multiple journals
         Then the output should contain "Journal encrypted to features/journals/basic_onefile.journal"
         And the config should contain "encrypt: false"
 
-
     Scenario: Don't overwrite main config when decrypting a journal in an alternate config
         Given the config "editor_encrypted.yaml" exists
         And we use the password "bad doggie no biscuit" if prompted
@@ -93,3 +92,8 @@ Feature: Multiple journals
         When we run "jrnl --cf editor_encrypted.yaml --decrypt"
         Then the config should contain "encrypt: true"
         And the output should not contain "Wrong password"
+
+    Scenario: Use default config when configuration file is empty or corrupt
+        Given the config "empty_file.yaml" exists
+        When we run "jrnl --cf empty_file.yaml"
+        Then the output should contain "empty, now using default config"

--- a/tests/bdd/features/config_file.feature
+++ b/tests/bdd/features/config_file.feature
@@ -93,7 +93,13 @@ Feature: Multiple journals
         Then the config should contain "encrypt: true"
         And the output should not contain "Wrong password"
 
-    Scenario: Use default config when configuration file is empty or corrupt
+    Scenario: Show an error message when the config file is empty
+        Given we use the config "empty_file.yaml"
+        When we run "jrnl -1"
+        Then the error output should contain "Unable to parse config file"
+
+    Scenario: Show an error message when using --config-file with empty file
         Given the config "empty_file.yaml" exists
+        And we use the config "basic_onefile.yaml"
         When we run "jrnl --cf empty_file.yaml"
-        Then the output should contain "empty, now using default config"
+        Then the error output should contain "Unable to parse config file"

--- a/tests/lib/given_steps.py
+++ b/tests/lib/given_steps.py
@@ -101,7 +101,11 @@ def we_use_the_config(request, temp_dir, working_dir):
 
     # @todo get rid of this by using default config values
     # merge in version number
-    if config_file.endswith("yaml") and os.path.exists(config_dest):
+    if (
+        config_file.endswith("yaml")
+        and os.path.exists(config_dest)
+        and os.path.getsize(config_dest) > 0
+    ):
         # Add jrnl version to file for 2.x journals
         with open(config_dest, "a") as cf:
             cf.write("version: {}".format(__version__))


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

Hi, I'm new to making commits so all feedback is welcome. Of course I put in my best effort.

This code adds a check for an empty config file, as specified by the issue #1420 . If an empty file is found, the programs prints a message and uses the default config, so the user won't be hindered in doing what he tried to do.

I added a bdd test, but couldn't get it to work properly. The test can't seem to find the new 'empty_file.yaml' config I created. Hopefully someone can help me out here.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
