### PR TITLE
The `-not` option with no arguments now outputs error instead of stack trace

### DIFF
--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -243,10 +243,10 @@ def parse_args(args=[]):
     reading.add_argument(
         "-not",
         dest="excluded",
-        nargs="?",
+        nargs=1,
         default=[],
         metavar="TAG",
-        action="append",
+        action="extend",
         help="Exclude entries with this tag",
     )
 

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -88,6 +88,12 @@ def test_end_date_alone():
     assert expected == cli_as_dict("-to 2020-01-01")
 
 
+def test_not_empty():
+    with pytest.raises(SystemExit) as wrapped_e:
+        cli_as_dict("-not")
+    assert wrapped_e.value.code == 2
+
+
 def test_not_alone():
     assert cli_as_dict("-not test") == expected_args(excluded=["test"])
 


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
This is related to the bug discussed in #1350. By setting `nargs=1` argparse now automatically checks to see if that you've entered the right number of arguments and that prevents `[None]` from being passed to interior methods. As a result, the user gets an argument error when trying to pass too few arguments.

```
usage: jrnl [--debug] [--help] [--version] [--list] [--encrypt] [--decrypt] [--import] [-on DATE] [-today-in-history] [-month DATE] [-day DATE] [-year DATE]
            [-from DATE] [-to DATE] [-contains TEXT] [-and] [-starred] [-n [NUMBER]] [-not TAG] [--edit] [--delete] [--format TYPE] [--tags] [--short]
            [--config-override CONFIG_KV_PAIR CONFIG_KV_PAIR] [--config-file CONFIG_FILE_PATH]
            [...]
jrnl: error: argument -not: expected 1 argument
```

Fixes #1350.