### PR TITLE
Editor no longer opens when -not is used without search flags

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -109,6 +109,19 @@ def _is_write_mode(args, config, **kwargs):
     ):
         write_mode = False
 
+    # If -not is set but we are not searching, throw an error
+    if write_mode and args.excluded:
+        raise JrnlException(
+            Message(
+                MsgText.InvalidArgumentUsage,
+                MsgType.NORMAL,
+                {
+                    "arg": "-not",
+                    "msg": "expected another search parameter like -on, -contains, etc.",
+                },
+            )
+        )
+
     return write_mode
 
 

--- a/jrnl/messages.py
+++ b/jrnl/messages.py
@@ -134,6 +134,9 @@ class MsgText(Enum):
         No entries to modify, because the search returned no results
         """
 
+    # --- Usage --- #
+    InvalidArgumentUsage = "Invalid usage of {arg}: {msg}"
+
 
 class Message(NamedTuple):
     text: MsgText

--- a/tests/bdd/features/search.feature
+++ b/tests/bdd/features/search.feature
@@ -292,3 +292,11 @@ Feature: Searching in a journal
             2013-06-17 20:38 This entry has a location.
 
             2013-07-17 11:38 This entry is starred!
+    
+    Scenario: Using -not without other search parameters should not open editor
+        Given we use the config "editor.yaml"
+        And we write nothing to the editor if opened
+        And we use the password "test" if prompted
+        When we run "jrnl -not @tag"
+        Then the error output should contain "Invalid usage of -not"
+        And the editor should not have been called


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
This is fixes #1472. Essentially the problem was that `-not` gets ignored when it is not accompanied with search flags like `-on`, `-contains`, etc. That means that you could accidentally create a new entry by typing something like `jrnl -not @tag`.

I added a check to the `_is_write_mode` that throws an error if `-not` exists and we're not searching for anything. Ideally this would be able to be handled inside the parser but there are essentially two reasons why that's not possible.
1. `argparse` doesn't natively support dependent arguments.
2. We still have to account for the edge case where a string of tag arguments is interpreted as a search query.