### PR TITLE
Fix TypeError when using debug flag

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -146,7 +146,7 @@ def write_mode(args, config, journal, **kwargs):
     journal.new_entry(raw)
     print(f"[Entry added to {args.journal_name} journal]", file=sys.stderr)
     journal.write()
-    logging.debug("Write mode: completed journal.write()", args.journal_name, raw)
+    logging.debug("Write mode: completed journal.write()")
 
 
 def search_mode(args, journal, **kwargs):


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
Fixed a "TypeError: not all arguments converted during string formatting" by removing the arguments when outputting debug text 'Write mode: completed'. The arguments were already sent to the debug output 5 lines above.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
