### PR TITLE
`-not` search parameter no longer opens editor

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -81,6 +81,7 @@ def _is_write_mode(args, config, **kwargs):
             args.delete,
             args.edit,
             args.change_time,
+            args.excluded,
             args.export,
             args.end_date,
             args.today_in_history,

--- a/tests/bdd/features/search.feature
+++ b/tests/bdd/features/search.feature
@@ -183,6 +183,19 @@ Feature: Searching in a journal
         | basic_folder.yaml  |
         | basic_dayone.yaml  |
 
+    Scenario Outline:  Using -not should exclude all entries with that tag
+        # https://github.com/jrnl-org/jrnl/issues/1472
+        Given we use the config "<config_file>"
+        When we run "jrnl -not @tagtwo"
+        Then the output should not contain "@tagtwo"
+        And the editor should not have been called
+
+        Examples: configs
+        | config_file   |
+        | basic_onefile.yaml |
+        | basic_folder.yaml  |
+        | basic_dayone.yaml  |
+
     Scenario: DayOne tag searching should work with tags containing a mixture of upper and lower case.
         # https://github.com/jrnl-org/jrnl/issues/354
         Given we use the config "dayone.yaml"


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->

Okay, well this time I hope I've got this right. It should not open the editor when `-not` is used without other search parameters. For example, `jrnl -not @tag` would open the editor before and now it just excludes entries that have the tag `@tag`.

Fixes #1472.