### PR TITLE
Create folder if config ends with (back)slash

### DIFF
--- a/docs/journal-types.md
+++ b/docs/journal-types.md
@@ -31,7 +31,7 @@ be located in: `~/folderjournal/2021/05/05.txt`
 Creating a new folder journal can be done in two ways:
 
 * Create a folder with the name of the journal before running `jrnl`. Otherwise, when you run `jrnl` for the first time, it will assume that you are creating a single file journal instead, and it will create a file at that path.
-* Create a new journal in your [config_file](advanced.md) and end the path with a ``/`` (on a POSIX system like Linux or MacOSX) or a ``\`` (on a Windows system).
+* Create a new journal in your [config_file](advanced.md) and end the path with a ``/`` (on a POSIX system like Linux or MacOSX) or a ``\`` (on a Windows system). The folder will be created automatically if it doesn't exist.
 
 !!! note
 Folder journals can't be encrypted.

--- a/docs/journal-types.md
+++ b/docs/journal-types.md
@@ -28,9 +28,10 @@ you have an entry on May 5th, 2021 in a folder journal at `~/folderjournal`, it 
 be located in: `~/folderjournal/2021/05/05.txt`
 
 !!! note
-When creating a new folder journal, you will need to create the folder before running
-`jrnl`. Otherwise, when you run `jrnl` for the first time, it will assume that you
-are creating a single file journal instead, and it will create a file at that path.
+Creating a new folder journal can be done in two ways:
+
+* Create a folder with the name of the journal before running `jrnl`. Otherwise, when you run `jrnl` for the first time, it will assume that you are creating a single file journal instead, and it will create a file at that path.
+* Create a new journal in your [config_file](advanced.md) and end the path with a ``/`` (on a POSIX system like Linux or MacOSX) or a ``\`` (on a Windows system).
 
 !!! note
 Folder journals can't be encrypted.

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -436,6 +436,7 @@ def open_journal(journal_name, config, legacy=False):
             return LegacyJournal(journal_name, **config).open()
         if config["journal"].endswith("/") or config["journal"].endswith("\\"):
             from . import FolderJournal
+
             return FolderJournal.Folder(journal_name, **config).open()
         return PlainJournal(journal_name, **config).open()
 

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -434,6 +434,9 @@ def open_journal(journal_name, config, legacy=False):
     if not config["encrypt"]:
         if legacy:
             return LegacyJournal(journal_name, **config).open()
+        if config["journal"].endswith("/") or config["journal"].endswith("\\"):
+            from . import FolderJournal
+            return FolderJournal.Folder(journal_name, **config).open()
         return PlainJournal(journal_name, **config).open()
 
     from . import EncryptedJournal

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -434,7 +434,7 @@ def open_journal(journal_name, config, legacy=False):
     if not config["encrypt"]:
         if legacy:
             return LegacyJournal(journal_name, **config).open()
-        if config["journal"].endswith("/") or config["journal"].endswith("\\"):
+        if config["journal"].endswith(os.sep):
             from . import FolderJournal
 
             return FolderJournal.Folder(journal_name, **config).open()

--- a/tests/bdd/features/file_storage.feature
+++ b/tests/bdd/features/file_storage.feature
@@ -31,12 +31,22 @@ Feature: Journals iteracting with the file system in a way that users can see
         When we run "jrnl -99 --short"
         Then the output should contain "This is a new entry in my journal"
     
-    Scenario: If the directory for a Folder journal ending in a slash ('/' or '\') doesn't exist, then it should be created
+    @on_posix
+    Scenario: If the directory for a Folder journal ending in a slash ('/') doesn't exist, then it should be created
         Given we use the config "missing_directory.yaml"
         Then the journal "endslash" directory should not exist
         When we run "jrnl endslash This is a new entry in my journal"
         Then the journal "endslash" directory should exist
         When we run "jrnl endslash -1"
+        Then the output should contain "This is a new entry in my journal"
+
+    @on_win
+    Scenario: If the directory for a Folder journal ending in a backslash ('\') doesn't exist, then it should be created
+        Given we use the config "missing_directory.yaml"
+        Then the journal "endbackslash" directory should not exist
+        When we run "jrnl endbackslash This is a new entry in my journal"
+        Then the journal "endbackslash" directory should exist
+        When we run "jrnl endbackslash -1"
         Then the output should contain "This is a new entry in my journal"
 
     Scenario: Creating journal with relative path should update to absolute path

--- a/tests/bdd/features/file_storage.feature
+++ b/tests/bdd/features/file_storage.feature
@@ -30,6 +30,14 @@ Feature: Journals iteracting with the file system in a way that users can see
         Then the journal should exist
         When we run "jrnl -99 --short"
         Then the output should contain "This is a new entry in my journal"
+    
+    Scenario: If the directory for a Folder journal ending in a slash ('/' or '\') doesn't exist, then it should be created
+        Given we use the config "missing_directory.yaml"
+        Then the journal "endslash" directory should not exist
+        When we run "jrnl endslash This is a new entry in my journal"
+        Then the journal "endslash" directory should exist
+        When we run "jrnl endslash -1"
+        Then the output should contain "This is a new entry in my journal"
 
     Scenario: Creating journal with relative path should update to absolute path
         Given we use no config

--- a/tests/data/configs/missing_directory.yaml
+++ b/tests/data/configs/missing_directory.yaml
@@ -6,6 +6,7 @@ highlight: true
 journals:
   default: features/journals/missing_directory/simple.journal
   endslash: features/journals/missing_folder/
+  endbackslash: features\journals\missing_folder\
 linewrap: 80
 tagsymbols: "@"
 template: false

--- a/tests/data/configs/missing_directory.yaml
+++ b/tests/data/configs/missing_directory.yaml
@@ -5,6 +5,7 @@ encrypt: false
 highlight: true
 journals:
   default: features/journals/missing_directory/simple.journal
+  endslash: features/journals/missing_folder/
 linewrap: 80
 tagsymbols: "@"
 template: false

--- a/tests/lib/then_steps.py
+++ b/tests/lib/then_steps.py
@@ -214,16 +214,10 @@ def journal_should_not_exist(config_on_disk, should_or_should_not):
 def directory_should_not_exist(config_on_disk, should_or_should_not, journal_name):
     scoped_config = scope_config(config_on_disk, journal_name)
     expected_path = scoped_config["journal"]
-
+    we_should = parse_should_or_should_not(should_or_should_not)
     dir_exists = os.path.isdir(expected_path)
-    if should_or_should_not == "should":
-        assert dir_exists
-    elif should_or_should_not == "should not":
-        assert not dir_exists
-    else:
-        raise Exception(
-            "should_or_should_not valid values are 'should' or 'should not'"
-        )
+
+    assert dir_exists == we_should
 
 
 @then(parse('the content of file "{file_path}" in the cache should be\n{file_content}'))

--- a/tests/lib/then_steps.py
+++ b/tests/lib/then_steps.py
@@ -210,6 +210,22 @@ def journal_should_not_exist(config_on_disk, should_or_should_not):
         )
 
 
+@then(parse('the journal "{journal_name}" directory {should_or_should_not} exist'))
+def directory_should_not_exist(config_on_disk, should_or_should_not, journal_name):
+    scoped_config = scope_config(config_on_disk, journal_name)
+    expected_path = scoped_config["journal"]
+
+    dir_exists = os.path.isdir(expected_path)
+    if should_or_should_not == "should":
+        assert dir_exists
+    elif should_or_should_not == "should not":
+        assert not dir_exists
+    else:
+        raise Exception(
+            "should_or_should_not valid values are 'should' or 'should not'"
+        )
+
+
 @then(parse('the content of file "{file_path}" in the cache should be\n{file_content}'))
 def content_of_file_should_be(file_path, file_content, cache_dir):
     assert cache_dir["exists"]


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
(Accidentally closed the previous pull request #1482, so here it is again.)
This PR fixes the issue #1293 When reading the config file, the code now checks if the path ends with a (back)slash and if so, calls the FolderJournal instead of the PlainJournal.

I also added a BDD test for this specific check. There was already a check for a non-existent directory, but didn't check if the path ended with a (back)slash.
### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
