### PR TITLE
Update copyright year

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 name: Changelog
 
 on:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 name: Docs
 
 on:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 name: Release
 on:
   workflow_dispatch:

--- a/.github/workflows/testing_prs.yaml
+++ b/.github/workflows/testing_prs.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 name: Testing
 
 on:

--- a/.github/workflows/testing_schedule.yaml
+++ b/.github/workflows/testing_schedule.yaml
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 name: Testing
 
 on:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Contributing
 
 See "[Contributing](docs/contributing.md)" in the `docs` directory.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 <p align="center">
 <a href="https://jrnl.sh">
 <img align="center" src="https://raw.githubusercontent.com/jrnl-org/jrnl/develop/docs_theme/assets/readme-header.png"/>

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,5 +1,7 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
 
 # Advanced Usage
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Contributing to jrnl
 
 We welcome contributions to jrnl, whether it's through reporting bugs, improving the documentation, testing releases, engaging in discussion on features and bugs, or writing code.

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Encryption
 
 ## A Note on Security

--- a/docs/external-editors.md
+++ b/docs/external-editors.md
@@ -1,3 +1,8 @@
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # External editors
 
 Configure your preferred external editor by updating the `editor` option

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Formats
 
 `jrnl` supports a variety of alternate formats. These can be used to display your

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Getting started
 
 ## Installation

--- a/docs/journal-types.md
+++ b/docs/journal-types.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Journal Types
 `jrnl` can store your journal in a few different ways:
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Overview
 
 `jrnl` is a simple journal application for the command line.

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Privacy and Security
 
 `jrnl` is designed with privacy and security in mind, but like any other

--- a/docs/reference-command-line.md
+++ b/docs/reference-command-line.md
@@ -1,3 +1,8 @@
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Command Line Reference
 
 ## Synopsis

--- a/docs/reference-config-file.md
+++ b/docs/reference-config-file.md
@@ -1,3 +1,8 @@
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Configuration File Reference
 
 `jrnl` stores its information in a YAML configuration file.

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Tips and Tricks
 
 This page contains tips and tricks for using `jrnl`, often in conjunction

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 # Basic Usage #
 
 `jrnl` has two modes: **composing** and **viewing**. Whenever you don't enter

--- a/docs_theme/assets/colors.css
+++ b/docs_theme/assets/colors.css
@@ -1,5 +1,7 @@
-/* Copyright (C) 2012-2021 jrnl contributors
-   License: https://www.gnu.org/licenses/gpl-3.0.html */
+/*
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+*/
 
 :root {
   /* For dark bg */

--- a/docs_theme/assets/highlight.css
+++ b/docs_theme/assets/highlight.css
@@ -1,4 +1,7 @@
 /*
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Atom One Dark With support for ReasonML by Gidi Morris, based off work by
 Daniel Gamage
 

--- a/docs_theme/assets/index.css
+++ b/docs_theme/assets/index.css
@@ -1,5 +1,8 @@
-/* Copyright (C) 2012-2021 jrnl contributors
-   License: https://www.gnu.org/licenses/gpl-3.0.html */
+/*
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+*/
+
 /* reset */article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}audio,canvas,video{display:inline-block}audio:not([controls]){display:none;height:0}[hidden]{display:none}html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}a:focus{outline:thin dotted}a:active,a:hover{outline:0}h1{font-size:2em;margin:.67em 0}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:bold}dfn{font-style:italic}hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}mark{background:#ff0;color:#000}code,kbd,pre,samp{font-family:monospace,serif;font-size:1em}pre{white-space:pre-wrap}q{quotes:"\201C" "\201D" "\2018" "\2019"}small{font-size:80%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}img{border:0}svg:not(:root){overflow:hidden}figure{margin:0}fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}legend{border:0;padding:0}button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}button,input{line-height:normal}button,select{text-transform:none}button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}button[disabled],html input[disabled]{cursor:default}input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}textarea{overflow:auto;vertical-align:top}table{border-collapse:collapse;border-spacing:0}
 
 body {

--- a/docs_theme/assets/theme.css
+++ b/docs_theme/assets/theme.css
@@ -1,5 +1,7 @@
-/* Copyright (C) 2012-2021 jrnl contributors
-   License: https://www.gnu.org/licenses/gpl-3.0.html */
+/*
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+*/
 
 /* ------------------------------------------------------------ */
 /* Overrides for jrnl theme                                     */

--- a/docs_theme/index.html
+++ b/docs_theme/index.html
@@ -1,5 +1,8 @@
-<!-- Copyright (C) 2012-2021 jrnl contributors
-     License: https://www.gnu.org/licenses/gpl-3.0.html -->
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 

--- a/docs_theme/main.html
+++ b/docs_theme/main.html
@@ -1,3 +1,8 @@
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 {% extends "base.html" %}
 
 {%- block search_button %}

--- a/docs_theme/search.html
+++ b/docs_theme/search.html
@@ -1,3 +1,8 @@
+<!--
+Copyright (C) 2012-2022 jrnl contributors
+License: https://www.gnu.org/licenses/gpl-3.0.html
+-->
+
 {% extends "main.html" %}
 
 {% block content %}

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import datetime
 import fnmatch
 import os

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import base64
 import hashlib
 import logging

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -1,6 +1,5 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
-
 
 import datetime
 import re

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -1,7 +1,5 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
-
 
 import codecs
 import fnmatch

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -1,6 +1,5 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
-
 
 import datetime
 import logging

--- a/jrnl/__init__.py
+++ b/jrnl/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 try:

--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import sys

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import argparse

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import logging

--- a/jrnl/color.py
+++ b/jrnl/color.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import re
 from string import punctuation
 from string import whitespace

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 """
 Functions in this file are standalone commands. All standalone commands are split into
 two categories depending on whether they require the config to be loaded to be able to
@@ -38,7 +41,7 @@ def preconfig_version(_):
 
     version_str = f"""{__title__} version {__version__}
 
-Copyright (C) 2012-2021 jrnl contributors
+Copyright (C) 2012-2022 jrnl contributors
 
 This is free software, and you are welcome to redistribute it under certain
 conditions; for details, see: https://www.gnu.org/licenses/gpl-3.0.html"""

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import logging
 import os
 

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import logging
 import os
 import subprocess

--- a/jrnl/exception.py
+++ b/jrnl/exception.py
@@ -1,5 +1,6 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from jrnl.messages import Message
 from jrnl.output import print_msg
 

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -1,6 +1,5 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
-
 
 import glob
 import logging

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import logging

--- a/jrnl/messages/Message.py
+++ b/jrnl/messages/Message.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from typing import NamedTuple
 from typing import Mapping
 

--- a/jrnl/messages/MsgStyle.py
+++ b/jrnl/messages/MsgStyle.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from enum import Enum
 from typing import NamedTuple
 from typing import Callable

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from enum import Enum
 
 

--- a/jrnl/messages/__init__.py
+++ b/jrnl/messages/__init__.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from .Message import Message
 from .MsgStyle import MsgStyle
 from .MsgText import MsgText

--- a/jrnl/os_compat.py
+++ b/jrnl/os_compat.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import shlex

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -1,5 +1,6 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import textwrap
 
 from typing import Union

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from .config import update_config, make_yaml_valid_dict
 from argparse import Namespace
 

--- a/jrnl/path.py
+++ b/jrnl/path.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import os.path
 
 

--- a/jrnl/plugins/__init__.py
+++ b/jrnl/plugins/__init__.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from .fancy_exporter import FancyExporter

--- a/jrnl/plugins/dates_exporter.py
+++ b/jrnl/plugins/dates_exporter.py
@@ -1,6 +1,6 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from collections import Counter
 
 from .text_exporter import TextExporter

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from jrnl.exception import JrnlException

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import sys

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import json

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/jrnl/plugins/tag_exporter.py
+++ b/jrnl/plugins/tag_exporter.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from .text_exporter import TextExporter

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/jrnl/plugins/util.py
+++ b/jrnl/plugins/util.py
@@ -1,7 +1,5 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
-
 
 def get_tags_count(journal):
     """Returns a set of tuples (count, tag) for all tags present in the journal."""

--- a/jrnl/plugins/util.py
+++ b/jrnl/plugins/util.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+
 def get_tags_count(journal):
     """Returns a set of tuples (count, tag) for all tags present in the journal."""
     # Astute reader: should the following line leave you as puzzled as me the first time

--- a/jrnl/plugins/xml_exporter.py
+++ b/jrnl/plugins/xml_exporter.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from xml.dom import minidom

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -1,5 +1,4 @@
-# encoding: utf-8
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/jrnl/prompt.py
+++ b/jrnl/prompt.py
@@ -1,5 +1,6 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from jrnl.messages import Message
 from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import datetime

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/tests/bdd/features/build.feature
+++ b/tests/bdd/features/build.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Build process
 
     Scenario: Version numbers should stay in sync

--- a/tests/bdd/features/change_time.feature
+++ b/tests/bdd/features/change_time.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Change entry times in journal
     Scenario Outline: Change time flag changes single entry timestamp
         Given we use the config "<config_file>"

--- a/tests/bdd/features/config_file.feature
+++ b/tests/bdd/features/config_file.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Multiple journals
 
     Scenario: Read a journal from an alternate config

--- a/tests/bdd/features/core.feature
+++ b/tests/bdd/features/core.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Functionality of jrnl outside of actually handling journals
 
     Scenario: Displaying the version number

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Reading and writing to journal with custom date formats
 
     Scenario: Dates can include a time

--- a/tests/bdd/features/delete.feature
+++ b/tests/bdd/features/delete.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Delete entries from journal
     Scenario Outline: Delete flag allows deletion of single entry
         Given we use the config "<config_file>"

--- a/tests/bdd/features/encrypt.feature
+++ b/tests/bdd/features/encrypt.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Encrypting and decrypting journals
 
     Scenario: Decrypting a journal

--- a/tests/bdd/features/file_storage.feature
+++ b/tests/bdd/features/file_storage.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Journals iteracting with the file system in a way that users can see
 
     Scenario: Adding entries to a Folder journal should generate date files

--- a/tests/bdd/features/format.feature
+++ b/tests/bdd/features/format.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Custom formats
 
     Scenario Outline: Short printing via --format flag

--- a/tests/bdd/features/import.feature
+++ b/tests/bdd/features/import.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Importing data
 
     Scenario Outline: --import allows new entry from stdin

--- a/tests/bdd/features/multiple_journals.feature
+++ b/tests/bdd/features/multiple_journals.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Multiple journals
 
     Scenario: Loading a config with two journals

--- a/tests/bdd/features/override.feature
+++ b/tests/bdd/features/override.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Implementing Runtime Overrides for Select Configuration Keys
 
         Scenario: Override configured editor with built-in input === editor:''

--- a/tests/bdd/features/password.feature
+++ b/tests/bdd/features/password.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Using the installed keyring
 
     Scenario: Storing a password in keyring

--- a/tests/bdd/features/search.feature
+++ b/tests/bdd/features/search.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Searching in a journal
 
     Scenario Outline: Displaying entries using -on today should display entries created today

--- a/tests/bdd/features/star.feature
+++ b/tests/bdd/features/star.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Starring entries
 
     Scenario Outline: Starring an entry will mark it in the journal file

--- a/tests/bdd/features/tag.feature
+++ b/tests/bdd/features/tag.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Tagging
 # See search.feature for tag-related searches
 # And format.feature for tag-related output

--- a/tests/bdd/features/upgrade.feature
+++ b/tests/bdd/features/upgrade.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Upgrading Journals from 1.x.x to 2.x.x
 
     Scenario: Upgrade and parse journals with square brackets

--- a/tests/bdd/features/write.feature
+++ b/tests/bdd/features/write.feature
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 Feature: Writing new entries.
 
     Scenario Outline: Multiline entry with punctuation should keep title punctuation

--- a/tests/bdd/test_features.py
+++ b/tests/bdd/test_features.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from pytest_bdd import scenarios
 
 scenarios("features/build.feature")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from pytest import mark

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from collections import defaultdict

--- a/tests/lib/given_steps.py
+++ b/tests/lib/given_steps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from datetime import datetime

--- a/tests/lib/helpers.py
+++ b/tests/lib/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import functools

--- a/tests/lib/then_steps.py
+++ b/tests/lib/then_steps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import json

--- a/tests/lib/when_steps.py
+++ b/tests/lib/when_steps.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from contextlib import ExitStack

--- a/tests/unit/test_color.py
+++ b/tests/unit/test_color.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from colorama import Fore
 from colorama import Style
 import pytest

--- a/tests/unit/test_config_file.py
+++ b/tests/unit/test_config_file.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import pytest
 import os
 

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import pytest
 
 from jrnl.exception import JrnlException

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import sys
 from unittest import mock
 

--- a/tests/unit/test_jrnl.py
+++ b/tests/unit/test_jrnl.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/test_os_compat.py
+++ b/tests/unit/test_os_compat.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from unittest import mock
 
 import pytest

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,5 +1,6 @@
-# Copyright (C) 2012-2021 jrnl contributors
+# Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from unittest.mock import Mock
 from unittest.mock import patch
 

--- a/tests/unit/test_override.py
+++ b/tests/unit/test_override.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import pytest
 
 from jrnl.override import _convert_dots_to_list

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import shlex
 
 import pytest

--- a/tests/unit/test_path.py
+++ b/tests/unit/test_path.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import pytest
 import random
 import string

--- a/tests/unit/test_time.py
+++ b/tests/unit/test_time.py
@@ -1,3 +1,6 @@
+# Copyright (C) 2012-2022 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import datetime
 
 from jrnl import time


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
It's already June, and we haven't updated the copyright year for 2022.

This PR:
- Updates copyright displayed to users (e.g. `jrnl --version`)
- Updates copyright year in each file (required by GPLv3)
- Adds missing copyright notices in some files
- Standardizes formatting for copyright notices throughout all files
### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
