### PR TITLE
Fix Poetry caching for accessibility tests

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,11 +39,14 @@ jobs:
     - name: Setup Node.js environment
       uses: actions/setup-node@main
 
+    - name: Capture full Python version in env
+      run: echo "PYTHON_FULL_VERSION=$(python --version)" >> $GITHUB_ENV
+
     - name: poetry cache
       uses: actions/cache@v2
       with:
         path: .venv
-        key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ matrix.python-version }}
+        key: ${{ runner.os }}-${{ hashFiles('poetry.lock') }}-${{ env.PYTHON_FULL_VERSION }}-${{ secrets.CACHE_STRING }}
 
     - name: npm cache
       uses: actions/cache@v2


### PR DESCRIPTION
The cache key was changed a while back, and we left out the accessibility tests. The tests still ran, but no longer cached the installed packages through poetry, resulting in slower tests. This PR fixes it, and should speed up the accessibility tests.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
