### PR TITLE
Stop hardcoding bot info in changelog pipeline

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -141,8 +141,8 @@ jobs:
       - name: Commit
         if: env.SOMETHING_CHANGED == 'true'
         run: |
-          git config user.email "jrnl.bot@gmail.com"
-          git config user.name "Jrnl Bot"
+          git config --global user.name "${{ secrets.JRNL_BOT_NAME }}"
+          git config --global user.email "${{ secrets.JRNL_BOT_EMAIL }}"
           git add "$FILENAME"
           git commit -m "Update changelog [ci skip]"
           git push origin $BRANCH


### PR DESCRIPTION
This PR uses the already established environment variables to update the changelog pipeline (which had previously hardcoded the values).

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->
