### PR TITLE
Display message when no edits take place

### DIFF
--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -43,7 +43,7 @@ def get_text_from_editor(config, template=""):
     os.remove(tmpfile)
 
     if not raw:
-        raise JrnlException(Message(MsgText.NoTextReceived, MsgStyle.ERROR))
+        raise JrnlException(Message(MsgText.NoTextReceived, MsgStyle.NORMAL))
 
     return raw
 

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -141,7 +141,7 @@ def write_mode(args, config, journal, **kwargs):
 
     if not raw or raw.isspace():
         logging.error("Write mode: couldn't get raw text or entry was empty")
-        raise JrnlException(Message(MsgText.NoTextReceived, MsgStyle.ERROR))
+        raise JrnlException(Message(MsgText.NoTextReceived, MsgStyle.NORMAL))
 
     logging.debug(
         'Write mode: appending raw text to journal "%s": %s', args.journal_name, raw
@@ -341,6 +341,9 @@ def _print_edited_summary(journal, old_stats, **kwargs):
             else MsgText.JournalCountModifiedPlural
         )
         msgs.append(Message(my_msg, MsgStyle.NORMAL, {"num": stats["modified"]}))
+
+    if not msgs:
+        msgs.append(Message(MsgText.NoEditsReceived, MsgStyle.NORMAL))
 
     print_msgs(msgs)
 

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -146,6 +146,8 @@ class MsgText(Enum):
             https://jrnl.sh/en/stable/external-editors/
         """
 
+    NoEditsReceived = "No edits to save, because nothing was changed"
+
     NoTextReceived = """
         No entry to save, because no text was received
         """


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `make test` (see the contributing doc if you need help with
`make`), or use our automated tests after you submit your PR.
-->

This displays an error message when no edits take place after launching the editor with the `jrnl --edit` command. 
![Screen Shot 2022-06-13 at 11 36 46 AM](https://user-images.githubusercontent.com/42982186/173421780-a9763d02-64bf-443d-b667-3df63391b739.png)
I tried to model the message after `MsgText.NoTextReceived`.

Fixes #1501