### PR TITLE
Update maintainer emails to actually use jrnl.sh domain

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by [emailing the maintainers](mailto:jrnl-sh@googlegroups.com).
+reported by [emailing the maintainers](mailto:maintainers@jrnl.sh).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security
 
-If you've discovered a potential security issue in jrnl, please contact the maintainers at [jrnl-sh@googlegroups.com](mailto:jrnl-sh@googlegroups.com).
+If you've discovered a potential security issue in jrnl, please contact the maintainers at [maintainers@jrnl.sh](mailto:maintainers@jrnl.sh).
 
 You can also feel free to [open an issue](https://github.com/jrnl-org/jrnl/issues/new/choose) (but please don't disclose the vulnerability) in case the email goes to spam.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,13 @@ name = "jrnl"
 version = "v3.0-beta"
 description = "Collect your thoughts and notes without leaving the command line."
 authors = [
-    "jrnl contributors <jrnl-sh@googlegroups.com>",
+    "jrnl contributors <maintainers@jrnl.sh>",
     "Manuel Ebert <manuel@1450.me>",
     "Jonathan Wren <jonathan@nowandwren.com>",
     "Micah Ellison <micahellison@gmail.com>"
 ]
 maintainers = [
-    "Jonathan Wren and Micah Ellison <jrnl-sh@googlegroups.com>",
+    "Jonathan Wren and Micah Ellison <maintainers@jrnl.sh>",
 ]
 license = "GPL-3.0-only"
 readme = "README.md"


### PR DESCRIPTION
Update the email in various spots to use the new jrnl.sh address we set up (so fancy!).

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
