### PR TITLE
Add and run `isort` on Python files

### DIFF
--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -4,22 +4,22 @@
 import datetime
 import fnmatch
 import os
-from pathlib import Path
 import platform
 import plistlib
 import re
 import socket
 import time
 import uuid
+from pathlib import Path
 from xml.parsers.expat import ExpatError
 
 import pytz
 import tzlocal
 
-from . import Entry
-from . import Journal
-from . import __title__
-from . import __version__
+from jrnl import Entry
+from jrnl import Journal
+from jrnl import __title__
+from jrnl import __version__
 
 
 class DayOne(Journal.Journal):

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -18,15 +18,14 @@ from cryptography.hazmat.primitives.ciphers import algorithms
 from cryptography.hazmat.primitives.ciphers import modes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
-from .Journal import Journal
-from .Journal import LegacyJournal
-from .prompt import create_password
-
 from jrnl.exception import JrnlException
+from jrnl.Journal import Journal
+from jrnl.Journal import LegacyJournal
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
 from jrnl.output import print_msg
+from jrnl.prompt import create_password
 
 
 def make_key(password):

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -6,8 +6,8 @@ import re
 
 import ansiwrap
 
-from .color import colorize
-from .color import highlight_tags_with_background_color
+from jrnl.color import colorize
+from jrnl.color import highlight_tags_with_background_color
 
 
 class Entry:

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -5,8 +5,8 @@ import codecs
 import fnmatch
 import os
 
-from . import Journal
-from . import time
+from jrnl import Journal
+from jrnl import time
 
 
 def get_files(journal_config):

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -6,15 +6,14 @@ import logging
 import os
 import re
 
-from . import Entry
-from . import time
-from .prompt import yesno
-from .path import expand_path
-
-from jrnl.output import print_msg
+from jrnl import Entry
+from jrnl import time
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
+from jrnl.output import print_msg
+from jrnl.path import expand_path
+from jrnl.prompt import yesno
 
 
 class Tag:

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -448,11 +448,11 @@ def open_journal(journal_name, config, legacy=False):
         if config["journal"].strip("/").endswith(".dayone") or "entries" in os.listdir(
             config["journal"]
         ):
-            from . import DayOneJournal
+            from jrnl import DayOneJournal
 
             return DayOneJournal.DayOne(**config).open()
         else:
-            from . import FolderJournal
+            from jrnl import FolderJournal
 
             return FolderJournal.Folder(journal_name, **config).open()
 
@@ -460,12 +460,12 @@ def open_journal(journal_name, config, legacy=False):
         if legacy:
             return LegacyJournal(journal_name, **config).open()
         if config["journal"].endswith(os.sep):
-            from . import FolderJournal
+            from jrnl import FolderJournal
 
             return FolderJournal.Folder(journal_name, **config).open()
         return PlainJournal(journal_name, **config).open()
 
-    from . import EncryptedJournal
+    from jrnl import EncryptedJournal
 
     if legacy:
         return EncryptedJournal.LegacyEncryptedJournal(journal_name, **config).open()

--- a/jrnl/__init__.py
+++ b/jrnl/__init__.py
@@ -2,7 +2,7 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 try:
-    from .__version__ import __version__
+    from jrnl.__version__ import __version__
 except ImportError:
     __version__ = "source"
 __title__ = "jrnl"

--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -3,7 +3,7 @@
 
 import sys
 
-from .cli import cli
+from jrnl.cli import cli
 
 if __name__ == "__main__":
     sys.exit(cli())

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -5,16 +5,16 @@ import argparse
 import re
 import textwrap
 
-from .commands import postconfig_decrypt
-from .commands import postconfig_encrypt
-from .commands import postconfig_import
-from .commands import postconfig_list
-from .commands import preconfig_diagnostic
-from .commands import preconfig_version
-from .output import deprecated_cmd
-from .plugins import EXPORT_FORMATS
-from .plugins import IMPORT_FORMATS
-from .plugins import util
+from jrnl.commands import postconfig_decrypt
+from jrnl.commands import postconfig_encrypt
+from jrnl.commands import postconfig_import
+from jrnl.commands import postconfig_list
+from jrnl.commands import preconfig_diagnostic
+from jrnl.commands import preconfig_version
+from jrnl.output import deprecated_cmd
+from jrnl.plugins import EXPORT_FORMATS
+from jrnl.plugins import IMPORT_FORMATS
+from jrnl.plugins import util
 
 
 class WrappingFormatter(argparse.RawTextHelpFormatter):

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -5,14 +5,13 @@ import logging
 import sys
 import traceback
 
-from .jrnl import run
-from .args import parse_args
-from jrnl.output import print_msg
-
+from jrnl.args import parse_args
 from jrnl.exception import JrnlException
+from jrnl.jrnl import run
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
+from jrnl.output import print_msg
 
 
 def configure_logger(debug=False):

--- a/jrnl/color.py
+++ b/jrnl/color.py
@@ -7,7 +7,7 @@ from string import whitespace
 
 import colorama
 
-from .os_compat import on_windows
+from jrnl.os_compat import on_windows
 
 if on_windows():
     colorama.init()

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -17,11 +17,11 @@ avoid any possible overhead for these standalone commands.
 import platform
 import sys
 
-from jrnl.output import print_msg
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
+from jrnl.output import print_msg
 from jrnl.prompt import create_password
 
 
@@ -70,10 +70,10 @@ def postconfig_encrypt(args, config, original_config, **kwargs):
     """
     Encrypt a journal in place, or optionally to a new file
     """
-    from .EncryptedJournal import EncryptedJournal
-    from .Journal import open_journal
     from .config import update_config
+    from .EncryptedJournal import EncryptedJournal
     from .install import save_config
+    from .Journal import open_journal
 
     # Open the journal
     journal = open_journal(args.journal_name, config)
@@ -118,10 +118,10 @@ def postconfig_encrypt(args, config, original_config, **kwargs):
 
 def postconfig_decrypt(args, config, original_config, **kwargs):
     """Decrypts into new file. If filename is not set, we encrypt the journal file itself."""
-    from .Journal import PlainJournal
-    from .Journal import open_journal
     from .config import update_config
     from .install import save_config
+    from .Journal import PlainJournal
+    from .Journal import open_journal
 
     journal = open_journal(args.journal_name, config)
     journal.config["encrypt"] = False

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -73,7 +73,7 @@ def postconfig_encrypt(args, config, original_config, **kwargs):
     from jrnl.config import update_config
     from jrnl.EncryptedJournal import EncryptedJournal
     from jrnl.install import save_config
-    from jrnl.Journal import jrnlopen_journal
+    from jrnl.Journal import open_journal
 
     # Open the journal
     journal = open_journal(args.journal_name, config)

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -50,14 +50,14 @@ conditions; for details, see: https://www.gnu.org/licenses/gpl-3.0.html"""
 
 
 def postconfig_list(config, **kwargs):
-    from .output import list_journals
+    from jrnl.output import list_journals
 
     print(list_journals(config))
 
 
 def postconfig_import(args, config, **kwargs):
-    from .Journal import open_journal
-    from .plugins import get_importer
+    from jrnl.Journal import open_journal
+    from jrnl.plugins import get_importer
 
     # Requires opening the journal
     journal = open_journal(args.journal_name, config)
@@ -70,10 +70,10 @@ def postconfig_encrypt(args, config, original_config, **kwargs):
     """
     Encrypt a journal in place, or optionally to a new file
     """
-    from .config import update_config
-    from .EncryptedJournal import EncryptedJournal
-    from .install import save_config
-    from .Journal import open_journal
+    from jrnl.config import update_config
+    from jrnl.EncryptedJournal import EncryptedJournal
+    from jrnl.install import save_config
+    from jrnl.Journal import jrnlopen_journal
 
     # Open the journal
     journal = open_journal(args.journal_name, config)
@@ -118,10 +118,10 @@ def postconfig_encrypt(args, config, original_config, **kwargs):
 
 def postconfig_decrypt(args, config, original_config, **kwargs):
     """Decrypts into new file. If filename is not set, we encrypt the journal file itself."""
-    from .config import update_config
-    from .install import save_config
-    from .Journal import PlainJournal
-    from .Journal import open_journal
+    from jrnl.config import update_config
+    from jrnl.install import save_config
+    from jrnl.Journal import PlainJournal
+    from jrnl.Journal import open_journal
 
     journal = open_journal(args.journal_name, config)
     journal.config["encrypt"] = False

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -5,18 +5,17 @@ import logging
 import os
 
 import colorama
-from ruamel.yaml import YAML
 import xdg.BaseDirectory
+from ruamel.yaml import YAML
 
-from . import __version__
-from jrnl.output import list_journals
-from jrnl.output import print_msg
+from jrnl import __version__
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
-
-from .path import home_dir
+from jrnl.messages import MsgText
+from jrnl.output import list_journals
+from jrnl.output import print_msg
+from jrnl.path import home_dir
 
 # Constants
 DEFAULT_CONFIG_NAME = "jrnl.yaml"

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -8,14 +8,13 @@ import sys
 import tempfile
 from pathlib import Path
 
+from jrnl.exception import JrnlException
+from jrnl.messages import Message
+from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
 from jrnl.os_compat import on_windows
 from jrnl.os_compat import split_args
 from jrnl.output import print_msg
-
-from jrnl.exception import JrnlException
-from jrnl.messages import Message
-from jrnl.messages import MsgText
-from jrnl.messages import MsgStyle
 
 
 def get_text_from_editor(config, template=""):

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -6,24 +6,23 @@ import logging
 import os
 import sys
 
-from .path import home_dir
-from .path import absolute_path
-from .path import expand_path
-from .config import DEFAULT_JOURNAL_KEY
-from .config import get_config_path
-from .config import get_default_config
-from .config import get_default_journal_path
-from .config import load_config
-from .config import save_config
-from .config import verify_config_colors
-from .prompt import yesno
-from .upgrade import is_old_version
-
-from jrnl.output import print_msg
+from jrnl.config import DEFAULT_JOURNAL_KEY
+from jrnl.config import get_config_path
+from jrnl.config import get_default_config
+from jrnl.config import get_default_journal_path
+from jrnl.config import load_config
+from jrnl.config import save_config
+from jrnl.config import verify_config_colors
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
+from jrnl.output import print_msg
+from jrnl.path import absolute_path
+from jrnl.path import expand_path
+from jrnl.path import home_dir
+from jrnl.prompt import yesno
+from jrnl.upgrade import is_old_version
 
 
 def upgrade_config(config_data, alt_config_path=None):

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -4,24 +4,23 @@
 import logging
 import sys
 
-from . import install
-from . import plugins
-from .Journal import open_journal
-from .config import get_journal_name
-from .config import scope_config
-from .config import get_config_path
-from .editor import get_text_from_editor
-from .editor import get_text_from_stdin
-from . import time
-from .override import apply_overrides
+from jrnl import install
+from jrnl import plugins
+from jrnl import time
+from jrnl.config import get_config_path
+from jrnl.config import get_journal_name
+from jrnl.config import scope_config
+from jrnl.editor import get_text_from_editor
+from jrnl.editor import get_text_from_stdin
+from jrnl.exception import JrnlException
+from jrnl.Journal import open_journal
+from jrnl.messages import Message
+from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
 from jrnl.output import print_msg
 from jrnl.output import print_msgs
-from .path import expand_path
-
-from jrnl.exception import JrnlException
-from jrnl.messages import Message
-from jrnl.messages import MsgText
-from jrnl.messages import MsgStyle
+from jrnl.override import apply_overrides
+from jrnl.path import expand_path
 
 
 def run(args):

--- a/jrnl/messages/Message.py
+++ b/jrnl/messages/Message.py
@@ -4,8 +4,8 @@
 from typing import Mapping
 from typing import NamedTuple
 
-from .MsgStyle import MsgStyle
-from .MsgText import MsgText
+from jrnl.messages.MsgStyle import MsgStyle
+from jrnl.messages.MsgText import MsgText
 
 
 class Message(NamedTuple):

--- a/jrnl/messages/Message.py
+++ b/jrnl/messages/Message.py
@@ -1,11 +1,11 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from typing import NamedTuple
 from typing import Mapping
+from typing import NamedTuple
 
-from .MsgText import MsgText
 from .MsgStyle import MsgStyle
+from .MsgText import MsgText
 
 
 class Message(NamedTuple):

--- a/jrnl/messages/MsgStyle.py
+++ b/jrnl/messages/MsgStyle.py
@@ -8,7 +8,7 @@ from typing import NamedTuple
 from rich import box
 from rich.panel import Panel
 
-from .MsgText import MsgText
+from jrnl.messages.MsgText import MsgText
 
 
 class MsgStyle(Enum):

--- a/jrnl/messages/MsgStyle.py
+++ b/jrnl/messages/MsgStyle.py
@@ -2,10 +2,11 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from enum import Enum
-from typing import NamedTuple
 from typing import Callable
-from rich.panel import Panel
+from typing import NamedTuple
+
 from rich import box
+from rich.panel import Panel
 
 from .MsgText import MsgText
 

--- a/jrnl/messages/__init__.py
+++ b/jrnl/messages/__init__.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from .Message import Message
-from .MsgStyle import MsgStyle
-from .MsgText import MsgText
+from jrnl.messages.Message import Message
+from jrnl.messages.MsgStyle import MsgStyle
+from jrnl.messages.MsgText import MsgText
 
 Message = Message
 MsgStyle = MsgStyle

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -26,7 +26,7 @@ def deprecated_cmd(old_cmd, new_cmd, callback=None, **kwargs):
 
 
 def list_journals(configuration):
-    from . import config
+    from jrnl import config
 
     """List the journals specified in the configuration file"""
     result = f"Journals defined in config ({config.get_config_path()})\n"

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -2,10 +2,10 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import textwrap
-
 from typing import Union
-from rich.text import Text
+
 from rich.console import Console
+from rich.text import Text
 
 from jrnl.messages import Message
 from jrnl.messages import MsgStyle

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -1,8 +1,11 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from .config import update_config, make_yaml_valid_dict
 from argparse import Namespace
+
+from jrnl.config import make_yaml_valid_dict
+from jrnl.config import update_config
+
 
 # import logging
 def apply_overrides(args: Namespace, base_config: dict) -> dict:

--- a/jrnl/plugins/__init__.py
+++ b/jrnl/plugins/__init__.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from .dates_exporter import DatesExporter
-from .fancy_exporter import FancyExporter
-from .jrnl_importer import JRNLImporter
-from .json_exporter import JSONExporter
-from .markdown_exporter import MarkdownExporter
-from .tag_exporter import TagExporter
-from .text_exporter import TextExporter
-from .xml_exporter import XMLExporter
-from .yaml_exporter import YAMLExporter
+from jrnl.plugins.dates_exporter import DatesExporter
+from jrnl.plugins.fancy_exporter import FancyExporter
+from jrnl.plugins.jrnl_importer import JRNLImporter
+from jrnl.plugins.json_exporter import JSONExporter
+from jrnl.plugins.markdown_exporter import MarkdownExporter
+from jrnl.plugins.tag_exporter import TagExporter
+from jrnl.plugins.text_exporter import TextExporter
+from jrnl.plugins.xml_exporter import XMLExporter
+from jrnl.plugins.yaml_exporter import YAMLExporter
 
 __exporters = [
     JSONExporter,

--- a/jrnl/plugins/__init__.py
+++ b/jrnl/plugins/__init__.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+from .dates_exporter import DatesExporter
 from .fancy_exporter import FancyExporter
 from .jrnl_importer import JRNLImporter
 from .json_exporter import JSONExporter
 from .markdown_exporter import MarkdownExporter
 from .tag_exporter import TagExporter
-from .dates_exporter import DatesExporter
 from .text_exporter import TextExporter
 from .xml_exporter import XMLExporter
 from .yaml_exporter import YAMLExporter

--- a/jrnl/plugins/dates_exporter.py
+++ b/jrnl/plugins/dates_exporter.py
@@ -3,7 +3,7 @@
 
 from collections import Counter
 
-from .text_exporter import TextExporter
+from jrnl.plugins.text_exporter import TextExporter
 
 
 class DatesExporter(TextExporter):

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -1,11 +1,12 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+from textwrap import TextWrapper
+
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
-from textwrap import TextWrapper
+from jrnl.messages import MsgText
 
 from .text_exporter import TextExporter
 

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -7,8 +7,7 @@ from jrnl.exception import JrnlException
 from jrnl.messages import Message
 from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
-
-from .text_exporter import TextExporter
+from jrnl.plugins.text_exporter import TextExporter
 
 
 class FancyExporter(TextExporter):

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -5,8 +5,8 @@ import sys
 
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
 from jrnl.output import print_msg
 
 

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -3,8 +3,8 @@
 
 import json
 
-from .text_exporter import TextExporter
-from .util import get_tags_count
+from jrnl.plugins.text_exporter import TextExporter
+from jrnl.plugins.util import get_tags_count
 
 
 class JSONExporter(TextExporter):

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -8,8 +8,7 @@ from jrnl.messages import Message
 from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
 from jrnl.output import print_msg
-
-from .text_exporter import TextExporter
+from jrnl.plugins.text_exporter import TextExporter
 
 
 class MarkdownExporter(TextExporter):

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -4,12 +4,12 @@
 import os
 import re
 
-from .text_exporter import TextExporter
-
-from jrnl.output import print_msg
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
+from jrnl.output import print_msg
+
+from .text_exporter import TextExporter
 
 
 class MarkdownExporter(TextExporter):

--- a/jrnl/plugins/tag_exporter.py
+++ b/jrnl/plugins/tag_exporter.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from .text_exporter import TextExporter
-from .util import get_tags_count
+from jrnl.plugins.text_exporter import TextExporter
+from jrnl.plugins.util import get_tags_count
 
 
 class TagExporter(TextExporter):

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -5,10 +5,10 @@ import os
 import re
 import unicodedata
 
-from jrnl.output import print_msg
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
+from jrnl.output import print_msg
 
 
 class TextExporter:

--- a/jrnl/plugins/xml_exporter.py
+++ b/jrnl/plugins/xml_exporter.py
@@ -3,8 +3,8 @@
 
 from xml.dom import minidom
 
-from .json_exporter import JSONExporter
-from .util import get_tags_count
+from jrnl.plugins.json_exporter import JSONExporter
+from jrnl.plugins.util import get_tags_count
 
 
 class XMLExporter(JSONExporter):

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -4,13 +4,13 @@
 import os
 import re
 
-from .text_exporter import TextExporter
-
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
 from jrnl.output import print_msg
+
+from .text_exporter import TextExporter
 
 
 class YAMLExporter(TextExporter):

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -9,8 +9,7 @@ from jrnl.messages import Message
 from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
 from jrnl.output import print_msg
-
-from .text_exporter import TextExporter
+from jrnl.plugins.text_exporter import TextExporter
 
 
 class YAMLExporter(TextExporter):

--- a/jrnl/prompt.py
+++ b/jrnl/prompt.py
@@ -2,8 +2,8 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
 from jrnl.output import print_msg
 from jrnl.output import print_msgs
 

--- a/jrnl/prompt.py
+++ b/jrnl/prompt.py
@@ -35,7 +35,7 @@ def create_password(journal_name: str) -> str:
         print_msg(Message(MsgText.PasswordDidNotMatch, MsgStyle.ERROR))
 
     if yesno(Message(MsgText.PasswordStoreInKeychain), default=True):
-        from .EncryptedJournal import set_keychain
+        from jrnl.EncryptedJournal import set_keychain
 
         set_keychain(journal_name, pw)
 

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -3,21 +3,20 @@
 
 import os
 
-from . import Journal
-from . import __version__
-from .EncryptedJournal import EncryptedJournal
-from .config import is_config_json
-from .config import load_config
-from .config import scope_config
-from .prompt import yesno
-from .path import expand_path
-
-from jrnl.output import print_msg
-from jrnl.output import print_msgs
+from jrnl import Journal
+from jrnl import __version__
+from jrnl.config import is_config_json
+from jrnl.config import load_config
+from jrnl.config import scope_config
+from jrnl.EncryptedJournal import EncryptedJournal
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
-from jrnl.messages import MsgText
 from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
+from jrnl.output import print_msg
+from jrnl.output import print_msgs
+from jrnl.path import expand_path
+from jrnl.prompt import yesno
 
 
 def backup(filename, binary=False):

--- a/poetry.lock
+++ b/poetry.lock
@@ -227,7 +227,7 @@ python-versions = "*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.4"
+version = "4.12.0"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -239,7 +239,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "iniconfig"
@@ -296,6 +296,20 @@ parallel = ["ipyparallel"]
 qtconsole = ["qtconsole"]
 test = ["pytest (<7.1)", "pytest-asyncio", "testpath"]
 test_extra = ["pytest (<7.1)", "pytest-asyncio", "testpath", "curio", "matplotlib (!=3.2.0)", "nbformat", "numpy (>=1.19)", "pandas", "trio"]
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "jedi"
@@ -938,7 +952,7 @@ pytz = "*"
 
 [[package]]
 name = "virtualenv"
-version = "20.14.1"
+version = "20.15.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -1010,13 +1024,10 @@ python-versions = ">=3.7"
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
-[extras]
-testing = []
-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9.0, <3.12"
-content-hash = "ceca9186ac31a0b8ec81a6cc134469842080c786971bb8642d9e67d51bd73fca"
+content-hash = "aa6579a24cd86b73dd5a6229a29f2d50b33600c880c528f18ad5beabeed99cea"
 
 [metadata.files]
 ansiwrap = [
@@ -1188,8 +1199,8 @@ glob2 = [
     {file = "glob2-0.7.tar.gz", hash = "sha256:85c3dbd07c8aa26d63d7aacee34fa86e9a91a3873bc30bf62ec46e531f92ab8c"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.4-py3-none-any.whl", hash = "sha256:c58c8eb8a762858f49e18436ff552e83914778e50e9d2f1660535ffb364552ec"},
-    {file = "importlib_metadata-4.11.4.tar.gz", hash = "sha256:5d26852efe48c0a32b0509ffbc583fda1a2266545a78d104a6f4aff3db17d700"},
+    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
+    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1201,6 +1212,10 @@ ipdb = [
 ipython = [
     {file = "ipython-8.4.0-py3-none-any.whl", hash = "sha256:7ca74052a38fa25fe9bedf52da0be7d3fdd2fb027c3b778ea78dfe8c212937d1"},
     {file = "ipython-8.4.0.tar.gz", hash = "sha256:f2db3a10254241d9b447232cec8b424847f338d9d36f9a577a6192c332a46abd"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 jedi = [
     {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
@@ -1521,8 +1536,8 @@ tzlocal = [
     {file = "tzlocal-2.1.tar.gz", hash = "sha256:643c97c5294aedc737780a49d9df30889321cbe1204eac2c2ec6134035a92e44"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
-    {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
+    {file = "virtualenv-20.15.0-py2.py3-none-any.whl", hash = "sha256:804cce4de5b8a322f099897e308eecc8f6e2951f1a8e7e2b3598dff865f01336"},
+    {file = "virtualenv-20.15.0.tar.gz", hash = "sha256:4c44b1d77ca81f8368e2d7414f9b20c428ad16b343ac6d226206c5b84e2b4fcc"},
 ]
 watchdog = [
     {file = "watchdog-2.1.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a735a990a1095f75ca4f36ea2ef2752c99e6ee997c46b0de507ba40a09bf7330"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ test = [
 [tool.isort]
 profile = "black"
 force_single_line = true
-known_first_party = ["jrnl"]
+known_first_party = ["jrnl", "tests"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ tzlocal = ">2.0, <3.0"   # https://github.com/regebro/tzlocal/blob/master/CHANGE
 [tool.poetry.dev-dependencies]
 black = { version = ">=21.5b2", allow-prereleases = true }
 ipdb = "*"
+isort = ">=5.10"
 mkdocs = ">=1.0,<1.3"
 poethepoet = "*"
 pyproject-flake8 = "*"
@@ -71,6 +72,13 @@ style-check = [
   {cmd = "pflake8 --version"},
   {cmd = "pflake8 jrnl tests"},
 ]
+sort-run = [
+  {cmd = "isort ."},
+]
+sort-check = [
+  {cmd = "isort --version"},
+  {cmd = "isort --check ."},
+]
 # docs-check = ?
 docs-run = [
   {cmd = "mkdocs serve"},
@@ -85,23 +93,25 @@ installer-check = [
 ]
 
 # Groups of tasks
+format = [
+  "format-run",
+  "sort-run",
+]
 lint = [
   "installer-check",
   "style-check",
+  "sort-check",
   "format-check",
 ]
-
 test = [
   "lint",
   "test-run",
 ]
 
 [tool.isort]
-multi_line_output = 7
+profile = "black"
 force_single_line = true
-line_length = 88
 known_first_party = ["jrnl"]
-force_sort_within_sections = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,8 @@
 from pytest import mark
 from pytest import skip
 
-from jrnl.os_compat import on_windows
 from jrnl.os_compat import on_posix
-
+from jrnl.os_compat import on_windows
 
 pytest_plugins = [
     "tests.lib.fixtures",

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -1,23 +1,23 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from collections import defaultdict
 import os
-from pathlib import Path
 import tempfile
-
+from collections import defaultdict
 from collections.abc import Iterable
+from pathlib import Path
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import toml
 from keyring import backend
 from keyring import errors
 from pytest import fixture
-from unittest.mock import patch
-from unittest.mock import Mock
-from .helpers import get_fixture
-import toml
 from rich.console import Console
 
 from jrnl.config import load_config
 from jrnl.os_compat import split_args
+from tests.lib.helpers import get_fixture
 
 
 # --- Keyring --- #

--- a/tests/lib/given_steps.py
+++ b/tests/lib/given_steps.py
@@ -1,12 +1,12 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from datetime import datetime
 import json
 import os
 import random
 import shutil
 import string
+from datetime import datetime
 from unittest.mock import MagicMock
 from unittest.mock import patch
 from xml.etree import ElementTree
@@ -16,10 +16,9 @@ from pytest_bdd.parsers import parse
 
 from jrnl import __version__
 from jrnl.time import __get_pdt_calendar
-
-from .fixtures import FailedKeyring
-from .fixtures import TestKeyring
-from .helpers import get_fixture
+from tests.lib.fixtures import FailedKeyring
+from tests.lib.fixtures import TestKeyring
+from tests.lib.helpers import get_fixture
 
 
 @given(parse("we {editor_method} to the editor if opened\n{editor_input}"))

--- a/tests/lib/then_steps.py
+++ b/tests/lib/then_steps.py
@@ -11,11 +11,10 @@ from pytest_bdd.parsers import parse
 from ruamel.yaml import YAML
 
 from jrnl.config import scope_config
-
-from .helpers import assert_equal_tags_ignoring_order
-from .helpers import does_directory_contain_files
-from .helpers import get_nested_val
-from .helpers import parse_should_or_should_not
+from tests.lib.helpers import assert_equal_tags_ignoring_order
+from tests.lib.helpers import does_directory_contain_files
+from tests.lib.helpers import get_nested_val
+from tests.lib.helpers import parse_should_or_should_not
 
 
 @then("we should get no error")

--- a/tests/lib/then_steps.py
+++ b/tests/lib/then_steps.py
@@ -14,8 +14,8 @@ from jrnl.config import scope_config
 
 from .helpers import assert_equal_tags_ignoring_order
 from .helpers import does_directory_contain_files
-from .helpers import parse_should_or_should_not
 from .helpers import get_nested_val
+from .helpers import parse_should_or_should_not
 
 
 @then("we should get no error")

--- a/tests/lib/when_steps.py
+++ b/tests/lib/when_steps.py
@@ -1,8 +1,8 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from contextlib import ExitStack
 import os
+from contextlib import ExitStack
 
 from pytest_bdd import when
 from pytest_bdd.parsers import parse

--- a/tests/unit/test_color.py
+++ b/tests/unit/test_color.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import pytest
 from colorama import Fore
 from colorama import Style
-import pytest
 
 from jrnl.color import colorize
 

--- a/tests/unit/test_config_file.py
+++ b/tests/unit/test_config_file.py
@@ -1,11 +1,12 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-import pytest
 import os
 
-from jrnl.install import find_alt_config
+import pytest
+
 from jrnl.exception import JrnlException
+from jrnl.install import find_alt_config
 
 
 def test_find_alt_config(request):

--- a/tests/unit/test_jrnl.py
+++ b/tests/unit/test_jrnl.py
@@ -1,15 +1,15 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import random
+import string
 from unittest import mock
 
 import pytest
 
-import random
-import string
 import jrnl
-from jrnl.jrnl import _display_search_results
 from jrnl.args import parse_args
+from jrnl.jrnl import _display_search_results
 
 
 @pytest.fixture

--- a/tests/unit/test_override.py
+++ b/tests/unit/test_override.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+from argparse import Namespace
+
 import pytest
 
 from jrnl.override import _convert_dots_to_list
@@ -8,8 +10,6 @@ from jrnl.override import _get_config_node
 from jrnl.override import _get_key_and_value_from_pair
 from jrnl.override import _recursively_apply
 from jrnl.override import apply_overrides
-
-from argparse import Namespace
 
 
 @pytest.fixture()

--- a/tests/unit/test_path.py
+++ b/tests/unit/test_path.py
@@ -1,16 +1,16 @@
 # Copyright (C) 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-import pytest
 import random
 import string
-
 from os import getenv
 from unittest.mock import patch
 
-from jrnl.path import home_dir
-from jrnl.path import expand_path
+import pytest
+
 from jrnl.path import absolute_path
+from jrnl.path import expand_path
+from jrnl.path import home_dir
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR:
- Add `isort` to our linting tools
- Runs `isort` automatically with existing `poe format` task
- Runs `isort --check` when running tests
- Updates imports across codebase to have a clean state for testing

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
