### PR TITLE
Fixed index out of range error in fancy exporter

### DIFF
--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -50,7 +50,7 @@ class FancyExporter(TextExporter):
             subsequent_indent=cls.border_g + " ",
         )
 
-        title_lines = w.wrap(entry.title)
+        title_lines = w.wrap(entry.title) or [""]
         card.append(
             title_lines[0].ljust(initial_linewrap + 1)
             + cls.border_d


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->

This is just a small bug that shows up when trying to print entries using the fancy exporter that lack titles. This error doesn't show up with any of the other `--format` methods as far as I can tell.

#### Steps to reproduce
1. Use `jrnl edit` to add a post without a title.
3. Enter `jrnl -1`.

This change just makes sure that the `title_lines` list always includes at least one empty string.