### PR TITLE
Add message showing the number of search results

### DIFF
--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -224,6 +224,10 @@ class MsgText(Enum):
         No entries to modify, because the search returned no results
         """
 
+    NoEntriesFound = "no entries found"
+    EntryFoundCountSingular = "{num} entry found"
+    EntryFoundCountPlural = "{num} entries found"
+
     # --- Formats --- #
     HeadingsPastH6 = """
         Headings increased past H6 on export - {date} {title}

--- a/tests/bdd/features/search.feature
+++ b/tests/bdd/features/search.feature
@@ -27,7 +27,8 @@ Feature: Searching in a journal
         When we run "jrnl tomorrow: A future entry."
         Then the output should contain "Entry added"
         When we run "jrnl -from today"
-        Then the output should contain "Adding an entry right now."
+        Then the output should contain "2 entries found" 
+        And the output should contain "Adding an entry right now."
         And the output should contain "A future entry."
         And the output should not contain "This thing happened yesterday"
 
@@ -47,7 +48,8 @@ Feature: Searching in a journal
         When we run "jrnl tomorrow: A future entry."
         Then the output should contain "Entry added"
         When we run "jrnl -from yesterday -to today"
-        Then the output should contain "This thing happened yesterday"
+        Then the output should contain "2 entries found"
+        And the output should contain "This thing happened yesterday"
         And the output should contain "Adding an entry right now."
         And the output should not contain "A future entry."
 
@@ -61,11 +63,25 @@ Feature: Searching in a journal
         Given we use the config "<config_file>"
         When we run "jrnl -contains first --short"
         Then we should get no error
+        And the output should contain "1 entry found"
         And the output should be
             2020-08-29 11:11 Entry the first.
 
         Examples: configs
         | config_file   |
+        | basic_onefile.yaml |
+        | basic_folder.yaml  |
+        | basic_dayone.yaml  |
+
+    Scenario Outline: Searching for an unknown string
+        Given we use the config "<config_file>"
+        When we run "jrnl -contains slkdfsdkfjsd"
+        Then we should get no error
+        And the output should contain "no entries found"
+        And the output should not contain "slkdfsdkfjsd"
+
+        Examples: configs
+        | config_file        |
         | basic_onefile.yaml |
         | basic_folder.yaml  |
         | basic_dayone.yaml  |
@@ -86,6 +102,7 @@ Feature: Searching in a journal
         Given we use the config "<config_file>"
         When we run "jrnl -and @tagone @tagtwo -contains maybe"
         Then we should get no error
+        And the output should contain "1 entry found"
         And the output should contain "maybe"
 
         Examples: configs
@@ -98,6 +115,7 @@ Feature: Searching in a journal
         Given we use the config "<config_file>"
         When we run "jrnl -not @tagone -contains lonesome"
         Then we should get no error
+        And the output should contain "1 entry found"
         And the output should contain "lonesome"
 
         Examples: configs
@@ -287,7 +305,8 @@ Feature: Searching in a journal
         And now is "2020-08-31 02:32:00 PM"
         When we run "jrnl 2019-08-31 01:01: Hi, from last year."
         And we run "jrnl -today-in-history --short"
-        Then the output should be
+        Then the output should contain "2 entries found"
+        And the output should be
             2019-08-31 01:01 Hi, from last year.
             2020-08-31 14:32 A second entry in what I hope to be a long series.
 
@@ -302,6 +321,7 @@ Feature: Searching in a journal
         Given we use the config "dayone.yaml"
         When we run "jrnl -from 'feb 2013'"
         Then we should get no error
+        And the output should contain "3 entries found"
         And the output should be
             2013-05-17 11:39 This entry has tags!
 


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->

This is a first stab at #1454. The basic idea was to include a message stating how many entries were found when searching.

#### Changes
1. Renamed `_search_journal()` -> `_filter_journal_entries()` to remove the need for a comment explaining what it does.
2. Added `_has_search_args()` which checks if there are any search arguments provided by the user.
3. Added `_print_entries_found_count()` which prints a message based upon the number of entries found and prints warnings if the user was trying to edit or delete and there are no entries.

I decided that it probably doesn't make sense to output the number of entries found when the user is just changing the timestamps on or deleting entries. Currently it only displays that information if the user is editing or searching.

I'm also not sure if this needs new tests but extra checks could probably be added to the current BDD tests that reflect these changes. I just decided to wait on that until I got some feedback.