### PR TITLE
Suppress "Entry added" message if using default journal

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -7,6 +7,7 @@ import sys
 from jrnl import install
 from jrnl import plugins
 from jrnl import time
+from jrnl.config import DEFAULT_JOURNAL_KEY
 from jrnl.config import get_config_path
 from jrnl.config import get_journal_name
 from jrnl.config import scope_config
@@ -146,13 +147,14 @@ def write_mode(args, config, journal, **kwargs):
         'Write mode: appending raw text to journal "%s": %s', args.journal_name, raw
     )
     journal.new_entry(raw)
-    print_msg(
-        Message(
-            MsgText.JournalEntryAdded,
-            MsgStyle.NORMAL,
-            {"journal_name": args.journal_name},
+    if args.journal_name != DEFAULT_JOURNAL_KEY:
+        print_msg(
+            Message(
+                MsgText.JournalEntryAdded,
+                MsgStyle.NORMAL,
+                {"journal_name": args.journal_name},
+            )
         )
-    )
     journal.write()
     logging.debug("Write mode: completed journal.write()")
 

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -7,7 +7,7 @@ Feature: Reading and writing to journal with custom date formats
         # https://github.com/jrnl-org/jrnl/issues/117
         Given we use the config "simple.yaml"
         When we run "jrnl 2013-11-30 15:42: Project Started."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -999"
         Then the output should contain "2013-11-30 15:42 Project Started."
 
@@ -16,7 +16,7 @@ Feature: Reading and writing to journal with custom date formats
         # https://github.com/jrnl-org/jrnl/issues/185
         Given we use the config "simple.yaml"
         When we run "jrnl 26/06/2099: Planet? Earth. Year? 2099."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -999"
         Then the output should contain "2099-06-26 09:00 Planet?"
 
@@ -37,7 +37,7 @@ Feature: Reading and writing to journal with custom date formats
     Scenario Outline: Writing an entry from command line with custom date
         Given we use the config "<config_file>"
         When we run "jrnl <command>"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -n 1"
         Then the output should contain "<expected_output>"
 
@@ -91,7 +91,7 @@ Feature: Reading and writing to journal with custom date formats
         Given we use the config "simple.yaml"
         And now is "2019-03-12 01:30:32 PM"
         When we run "jrnl <command>"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -1"
         Then the output should contain "<expected_output>"
         Then the output should contain the date "<date>"
@@ -113,7 +113,7 @@ Feature: Reading and writing to journal with custom date formats
         Given we use the config "simple.yaml"
         And now is "2019-03-12 01:30:32 PM"
         When we run "jrnl <command>"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -1"
         Then the output should contain "<expected_output>"
         Then the output should contain the date "<date>"
@@ -183,11 +183,11 @@ Feature: Reading and writing to journal with custom date formats
         Given we use the config "dayone.yaml"
         And now is "<date>"
         When we run "jrnl yesterday: This thing happened yesterday"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl today at 11:59pm: Adding an entry right now."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl tomorrow: A future entry."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -from yesterday -to today"
         Then the output should contain "This thing happened yesterday"
         And the output should contain "Adding an entry right now."

--- a/tests/bdd/features/file_storage.feature
+++ b/tests/bdd/features/file_storage.feature
@@ -6,7 +6,7 @@ Feature: Journals iteracting with the file system in a way that users can see
     Scenario: Adding entries to a Folder journal should generate date files
         Given we use the config "empty_folder.yaml"
         When we run "jrnl 23 July 2013: Testing folder journal."
-        Then the output should contain "Entry added"
+        Then we should get no error
         And the journal directory should contain
             2013/07/23.txt
 
@@ -14,7 +14,7 @@ Feature: Journals iteracting with the file system in a way that users can see
         Given we use the config "empty_folder.yaml"
         When we run "jrnl 23 July 2013: Testing folder journal."
         And we run "jrnl 3/7/2014: Second entry of journal."
-        Then the output should contain "Entry added"
+        Then we should get no error
         And the journal directory should contain
             2013/07/23.txt
 

--- a/tests/bdd/features/override.feature
+++ b/tests/bdd/features/override.feature
@@ -72,7 +72,6 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
         And we use the password "test" if prompted
         When we run "jrnl --config-override journals.default features/journals/simple.journal 20 Mar 2000: The rain in Spain comes from clouds"
         Then we should get no error
-        And the output should contain "Entry added"
         When we run "jrnl -3 --config-override journals.default features/journals/simple.journal"
         Then the output should be
             2000-03-20 09:00 The rain in Spain comes from clouds

--- a/tests/bdd/features/search.feature
+++ b/tests/bdd/features/search.feature
@@ -6,7 +6,7 @@ Feature: Searching in a journal
     Scenario Outline: Displaying entries using -on today should display entries created today
         Given we use the config "<config_file>"
         When we run "jrnl today: Adding an entry right now."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -on today"
         Then the output should contain "Adding an entry right now."
         But the output should not contain "Everything is alright"
@@ -21,11 +21,11 @@ Feature: Searching in a journal
     Scenario Outline: Displaying entries using -from day should display correct entries
         Given we use the config "<config_file>"
         When we run "jrnl yesterday: This thing happened yesterday"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl today at 11:59pm: Adding an entry right now."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl tomorrow: A future entry."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -from today"
         Then the output should contain "Adding an entry right now."
         And the output should contain "A future entry."
@@ -41,11 +41,11 @@ Feature: Searching in a journal
         Given we use the config "<config_file>"
         And now is "2022-03-10 02:32:00 PM"
         When we run "jrnl yesterday: This thing happened yesterday"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl today at 11:59pm: Adding an entry right now."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl tomorrow: A future entry."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -from yesterday -to today"
         Then the output should contain "This thing happened yesterday"
         And the output should contain "Adding an entry right now."
@@ -122,9 +122,9 @@ Feature: Searching in a journal
     Scenario: Out of order entries to a Folder journal should be listed in date order
         Given we use the config "empty_folder.yaml"
         When we run "jrnl 3/7/2014 4:37pm: Second entry of journal."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl 23 July 2013: Testing folder journal."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -2"
         Then the output should be
             2013-07-23 09:00 Testing folder journal.

--- a/tests/bdd/features/star.feature
+++ b/tests/bdd/features/star.feature
@@ -6,7 +6,7 @@ Feature: Starring entries
     Scenario Outline: Starring an entry will mark it in the journal file
         Given we use the config "<config_file>"
         When we run "jrnl 20 july 2013 *: Best day of my life!"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -on 2013-07-20 -starred"
         Then the output should contain "2013-07-20 09:00 Best day of my life!"
 
@@ -34,6 +34,6 @@ Feature: Starring entries
         Given we use the config "encrypted.yaml"
         And we use the password "bad doggie no biscuit" if prompted
         When we run "jrnl 20 july 2013 *: Best day of my life!"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -on 2013-07-20 -starred" and enter "bad doggie no biscuit"
         Then the output should contain "2013-07-20 09:00 Best day of my life!"

--- a/tests/bdd/features/write.feature
+++ b/tests/bdd/features/write.feature
@@ -49,7 +49,7 @@ Feature: Writing new entries.
         Given we use the config "<config_file>"
         And we use the password "bad doggie no biscuit" if prompted
         When we run "jrnl 23 july 2013: A cold and stormy day. I ate crisps on the sofa."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -n 1"
         Then the output should contain "2013-07-23 09:00 A cold and stormy day."
 
@@ -64,7 +64,7 @@ Feature: Writing new entries.
         Given we use the config "<config_file>"
         And we use the password "test" if prompted
         When we run "jrnl this is a partial --edit"
-        Then the output should contain "Entry added"
+        Then we should get no error
         Then the editor should have been called
         And the editor file content should be
             this is a partial
@@ -128,7 +128,7 @@ Feature: Writing new entries.
         Given we use the config "<config_file>"
         And we use the password "bad doggie no biscuit" if prompted
         When we run "jrnl 23 july 2013: A cold and stormy day. I ate crisps on the sofa."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -n 1"
         Then the output should not contain "Life is good"
 
@@ -143,7 +143,7 @@ Feature: Writing new entries.
         Given we use the config "<config_file>"
         And we use the password "bad doggie no biscuit" if prompted
         When we run "jrnl 04-24-2014: Created a new website - empty.com. Hope to get a lot of traffic."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -1"
         Then the output should be
             2014-04-24 09:00 Created a new website - empty.com.
@@ -160,7 +160,7 @@ Feature: Writing new entries.
         Given we use the config "<config_file>"
         And we use the password "bad doggie no biscuit" if prompted
         When we run "jrnl 23 july 2013: 🌞 sunny day. Saw an 🐘"
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -n 1"
         Then the output should contain "🌞"
         And the output should contain "🐘"
@@ -217,7 +217,7 @@ Feature: Writing new entries.
     Scenario: Title with an embedded period on DayOne journal
         Given we use the config "dayone.yaml"
         When we run "jrnl 04-24-2014: Ran 6.2 miles today in 1:02:03. I am feeling sore because I forgot to stretch."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -1"
         Then the output should be
             2014-04-24 09:00 Ran 6.2 miles today in 1:02:03.
@@ -226,7 +226,7 @@ Feature: Writing new entries.
     Scenario: Opening an folder that's not a DayOne folder should treat as folder journal
         Given we use the config "empty_folder.yaml"
         When we run "jrnl 23 july 2013: Testing folder journal."
-        Then the output should contain "Entry added"
+        Then we should get no error
         When we run "jrnl -1"
         Then the output should be "2013-07-23 09:00 Testing folder journal."
 

--- a/tests/bdd/features/write.feature
+++ b/tests/bdd/features/write.feature
@@ -313,3 +313,24 @@ Feature: Writing new entries.
         | basic_encrypted.yaml |
         | basic_folder.yaml    |
         | basic_dayone.yaml    |
+
+    Scenario Outline: No "Entry added" message should appear when writing to the default journal
+        Given we use the config "<config_file>"
+        And we use the password "test" if prompted
+        When we run "jrnl This is a new entry"
+        Then the output should not contain "Entry added"
+        And we should get no error
+
+        Examples: configs
+        | config_file          |
+        | basic_onefile.yaml   |
+        | basic_encrypted.yaml |
+        | basic_folder.yaml    |
+        | basic_dayone.yaml    |
+
+    Scenario: An "Entry added" message should appear when writing to a non-default journal
+        Given we use the config "multiple.yaml"
+        And we use the password "test" if prompted
+        When we run "jrnl work This is a new entry"
+        Then the output should contain "Entry added to work journal"
+        And we should get no error


### PR DESCRIPTION
This PR fixes #1543 by suppressing output if you successfully add a new entry to your default journal.

If you're working on any other journal, it will still show the message. I hope this is a good compromise for jrnl's default behavior, though I think it's also worth revisiting later to see if we're best saved by a "quiet" or "verbose" mode.

Example of this behavior:
```
>jrnl this is a new entry to my default journal
>jrnl testing this is a new entry to my testing journal
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  Entry added to testing journal  ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
>jrnl testign I wanted this to be a new entry in my testing journal but I misspelled the journal name
>
```

Feedback welcome!

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
