### PR TITLE
Add hint for how to get vi to go to end-of-file

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -211,3 +211,12 @@ display_format: markdown
 
 For more information on how `jrnl` outputs your entries in Markdown, please visit the [Formats](./formats.md) section.
 
+
+## Jump to end of buffer (with vi)
+
+To cause vi to jump to the end of the last line of the entry you edit, in your config file set:
+
+```yaml
+editor: vi + -c "call cursor('.',strwidth(getline('.')))"
+```
+


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [NA] I have included a link to the relevant issue number.
- [NA] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [NA] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
Added a hint for vi users to the docs.