### PR TITLE
Fix #1486

### DIFF
--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -121,18 +121,19 @@ def parse_args(args=[]):
     )
     standalone.add_argument(
         "--import",
-        action="store_const",
         metavar="TYPE",
-        const=postconfig_import,
-        dest="postconfig_cmd",
+        dest="import_format",
+        nargs="?",
+        choices=IMPORT_FORMATS,
+        default="jrnl",
         help=f"""
         Import entries from another journal.
+
+        TYPE is the format to import [{util.oxford_list(IMPORT_FORMATS)}] (default: jrnl)
 
         Optional parameters:
 
         --file FILENAME (default: uses stdin)
-
-        --format [{util.oxford_list(IMPORT_FORMATS)}] (default: jrnl)
         """,
     )
     standalone.add_argument(

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -69,8 +69,7 @@ def postconfig_import(args, config, **kwargs):
     # Requires opening the journal
     journal = open_journal(args.journal_name, config)
 
-    format = args.export if args.export else "jrnl"
-    get_importer(format).import_(journal, args.filename)
+    get_importer(args.import_format).import_(journal, args.filename)
 
 
 def postconfig_encrypt(args, config, original_config, **kwargs):


### PR DESCRIPTION
Fix #1486 

Instead of --import paying attention to --format, leave --format
just for the export-format and give --import itself an optional
arguent that is the import format.  This of course defaults to 'jrnl'.
This allows argparse to do the choice-checking.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
