### PR TITLE
Quick fix follow up for actionlint

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,17 +10,17 @@ on:
         type: string
         required: true
       include_repo_version:
-        description: 'Update version in repo? (true/false)'
+        description: 'Update version in repo?'
         type: boolean
         required: true
         default: true
       include_pypi:
-        description: 'Publish to PyPI? (true/false)'
+        description: 'Publish to PyPI?'
         type: boolean
         required: true
         default: true
       include_brew:
-        description: 'Publish to Homebrew? (true/false)'
+        description: 'Publish to Homebrew?'
         type: boolean
         required: true
         default: true


### PR DESCRIPTION
This is a quick fix to follow up on #1555.

- Takes out old helptext (these used to be needed because the `type` field didn't exist)



### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
