### PR TITLE
Update to use renamed flag for `brew bump-formula-pr`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -196,7 +196,7 @@ jobs:
           --url $(jq ".releases[\"${PYPI_VERSION}\"][1].url" -r api_response.json)
           --sha256 $(jq ".releases[\"${PYPI_VERSION}\"][1].digests.sha256" -r api_response.json)
           --no-audit
-          --write
+          --write-only
           --force
 
     - name: Create Pull Request


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
Homebrew release pipeline is currently failing with this error:
```sh
Error: Calling `brew bump-formula-pr --write` is disabled! Use `brew bump-formula-pr --write-only` instead.
```

Example: https://github.com/jrnl-org/jrnl/runs/8171524126?check_suite_focus=true#step:7:44
### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
