### PR TITLE
Add machine readable --list output

### DIFF
--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -85,7 +85,13 @@ def parse_args(args=[]):
         action="store_const",
         const=postconfig_list,
         dest="postconfig_cmd",
-        help="List all configured journals",
+        help="""
+        List all configured journals.
+
+        Optional parameters:
+
+        --format [json or yaml]
+        """,
     )
     standalone.add_argument(
         "--ls",

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -56,10 +56,10 @@ def preconfig_version(_):
     print(output)
 
 
-def postconfig_list(config, **kwargs):
+def postconfig_list(args, config, **kwargs):
     from jrnl.output import list_journals
 
-    print(list_journals(config))
+    print(list_journals(config, args.export))
 
 
 def postconfig_import(args, config, **kwargs):

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -25,30 +25,48 @@ def deprecated_cmd(old_cmd, new_cmd, callback=None, **kwargs):
         callback(**kwargs)
 
 
+def journal_list_to_json(journal_list):
+    import json
+
+    return json.dumps(journal_list)
+
+
+def journal_list_to_yaml(journal_list):
+    from io import StringIO
+
+    from ruamel.yaml import YAML
+
+    output = StringIO()
+    YAML().dump(journal_list, output)
+    return output.getvalue()
+
+
+def journal_list_to_stdout(journal_list):
+    result = f"Journals defined in config ({journal_list['config_path']})\n"
+    ml = min(max(len(k) for k in journal_list["journals"]), 20)
+    for journal, cfg in journal_list["journals"].items():
+        result += " * {:{}} -> {}\n".format(
+            journal, ml, cfg["journal"] if isinstance(cfg, dict) else cfg
+        )
+    return result
+
+
 def list_journals(configuration, format=None):
     from jrnl import config
 
     """List the journals specified in the configuration file"""
+
+    journal_list = {
+        "config_path": config.get_config_path(),
+        "journals": configuration["journals"],
+    }
+
     if format == "json":
-        import json
-
-        return json.dumps(configuration["journals"])
+        return journal_list_to_json(journal_list)
     elif format == "yaml":
-        from io import StringIO
-
-        from ruamel.yaml import YAML
-
-        output = StringIO()
-        YAML().dump(configuration["journals"], output)
-        return output.getvalue()
+        return journal_list_to_yaml(journal_list)
     else:
-        result = f"Journals defined in config ({config.get_config_path()})\n"
-        ml = min(max(len(k) for k in configuration["journals"]), 20)
-        for journal, cfg in configuration["journals"].items():
-            result += " * {:{}} -> {}\n".format(
-                journal, ml, cfg["journal"] if isinstance(cfg, dict) else cfg
-            )
-        return result
+        return journal_list_to_stdout(journal_list)
 
 
 def print_msg(msg: Message, **kwargs) -> Union[None, str]:

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -25,17 +25,30 @@ def deprecated_cmd(old_cmd, new_cmd, callback=None, **kwargs):
         callback(**kwargs)
 
 
-def list_journals(configuration):
+def list_journals(configuration, format=None):
     from jrnl import config
 
     """List the journals specified in the configuration file"""
-    result = f"Journals defined in config ({config.get_config_path()})\n"
-    ml = min(max(len(k) for k in configuration["journals"]), 20)
-    for journal, cfg in configuration["journals"].items():
-        result += " * {:{}} -> {}\n".format(
-            journal, ml, cfg["journal"] if isinstance(cfg, dict) else cfg
-        )
-    return result
+    if format == "json":
+        import json
+
+        return json.dumps(configuration["journals"])
+    elif format == "yaml":
+        from io import StringIO
+
+        from ruamel.yaml import YAML
+
+        output = StringIO()
+        YAML().dump(configuration["journals"], output)
+        return output.getvalue()
+    else:
+        result = f"Journals defined in config ({config.get_config_path()})\n"
+        ml = min(max(len(k) for k in configuration["journals"]), 20)
+        for journal, cfg in configuration["journals"].items():
+            result += " * {:{}} -> {}\n".format(
+                journal, ml, cfg["journal"] if isinstance(cfg, dict) else cfg
+            )
+        return result
 
 
 def print_msg(msg: Message, **kwargs) -> Union[None, str]:

--- a/tests/bdd/features/format.feature
+++ b/tests/bdd/features/format.feature
@@ -597,3 +597,19 @@ Feature: Custom formats
         When we run "jrnl --format text --file {cache_dir}"
         Then the cache directory should contain 5 files
         And we should get no error
+
+    Scenario: Export journal list to multiple formats.
+        Given we use the config "basic_onefile.yaml"
+        And the home directory is called "home"
+        When we run "jrnl --list"
+        Then the output should match
+            Journals defined in config \(/[\w/]+/basic_onefile\.yaml\)
+             \* default -> features/journals/basic_onefile\.journal
+        When we run "jrnl --list --format json"
+        Then the output should match
+            {"config_path": "/[\w/]+/basic_onefile\.yaml", "journals": {"default": "features/journals/basic_onefile\.journal"}}
+        When we run "jrnl --list --format yaml"
+        Then the output should match
+            config_path: /[\w/]+/basic_onefile\.yaml
+            journals:
+              default: features/journals/basic_onefile\.journal

--- a/tests/bdd/features/format.feature
+++ b/tests/bdd/features/format.feature
@@ -600,16 +600,15 @@ Feature: Custom formats
 
     Scenario: Export journal list to multiple formats.
         Given we use the config "basic_onefile.yaml"
-        And the home directory is called "home"
         When we run "jrnl --list"
         Then the output should match
-            Journals defined in config \(/[\w/]+/basic_onefile\.yaml\)
+            Journals defined in config \(.+basic_onefile\.yaml\)
              \* default -> features/journals/basic_onefile\.journal
         When we run "jrnl --list --format json"
         Then the output should match
-            {"config_path": "/[\w/]+/basic_onefile\.yaml", "journals": {"default": "features/journals/basic_onefile\.journal"}}
+            {"config_path": ".+basic_onefile\.yaml", "journals": {"default": "features/journals/basic_onefile\.journal"}}
         When we run "jrnl --list --format yaml"
         Then the output should match
-            config_path: /[\w/]+/basic_onefile\.yaml
+            config_path: .+basic_onefile\.yaml
             journals:
               default: features/journals/basic_onefile\.journal

--- a/tests/lib/then_steps.py
+++ b/tests/lib/then_steps.py
@@ -23,6 +23,7 @@ def should_get_no_error(cli_run):
     assert cli_run["status"] == 0, cli_run["status"]
 
 
+@then(parse("the output should match\n{regex}"))
 @then(parse('the output should match "{regex}"'))
 def output_should_match(regex, cli_run):
     out = cli_run["stdout"]


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->

This closes #1445.

The following options are now available for the list command. If another format option is chosen that isn't yaml or json, it just returns the default list.

```sh
jrnl --list
jrnl --list --format json
jrnl --list --format yaml
```