### PR TITLE
Change default timestamp to `%F %r`

### DIFF
--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -97,7 +97,7 @@ def get_default_config():
         "template": False,
         "default_hour": 9,
         "default_minute": 0,
-        "timeformat": "%Y-%m-%d %H:%M",
+        "timeformat": "%F %r",
         "tagsymbols": "#@",
         "highlight": True,
         "linewrap": 79,


### PR DESCRIPTION
Fixes #1100

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
