### PR TITLE
Don't create empty file when attempting a YAML export to a non-existing folder

### DIFF
--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -31,18 +31,19 @@ class TextExporter:
     @classmethod
     def write_file(cls, journal, path):
         """Exports a journal into a single file."""
+        export_str = cls.export_journal(journal)
         with open(path, "w", encoding="utf-8") as f:
-            f.write(cls.export_journal(journal))
-            print_msg(
-                Message(
-                    MsgText.JournalExportedTo,
-                    MsgStyle.NORMAL,
-                    {
-                        "path": path,
-                    },
-                )
+            f.write(export_str)
+        print_msg(
+            Message(
+                MsgText.JournalExportedTo,
+                MsgStyle.NORMAL,
+                {
+                    "path": path,
+                },
             )
-            return ""
+        )
+        return ""
 
     @classmethod
     def make_filename(cls, entry):

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -10,7 +10,7 @@ from ruamel.yaml import YAML
 from jrnl.exception import JrnlException
 from jrnl.Journal import PlainJournal
 from jrnl.plugins.fancy_exporter import check_provided_linewrap_viability
-from jrnl.plugins.text_exporter import TextExporter
+from jrnl.plugins.yaml_exporter import YAMLExporter
 
 
 @pytest.fixture()
@@ -49,5 +49,5 @@ class TestYaml:
         with TemporaryDirectory() as tmpdir:
             p = Path(tmpdir / "non_existing_folder")
             with pytest.raises(JrnlException):
-                TextExporter.write_file(simple_journal, p)
+                YAMLExporter.write_file(simple_journal, p)
             assert not p.exists()

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,15 +1,29 @@
 # Copyright © 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
 import pytest
+from ruamel.yaml import YAML
 
 from jrnl.exception import JrnlException
+from jrnl.Journal import PlainJournal
 from jrnl.plugins.fancy_exporter import check_provided_linewrap_viability
+from jrnl.plugins.text_exporter import TextExporter
 
 
 @pytest.fixture()
 def datestr():
     yield "2020-10-20 16:59"
+
+
+@pytest.fixture()
+def simple_journal():
+    with open("tests/data/configs/simple.yaml") as f:
+        yaml = YAML(typ="safe")
+        config = yaml.load(f)
+    return PlainJournal("simple_journal", **config).open()
 
 
 def build_card_header(datestr):
@@ -28,3 +42,12 @@ class TestFancy:
 
         with pytest.raises(JrnlException):
             check_provided_linewrap_viability(total_linewrap, [content], journal)
+
+
+class TestYaml:
+    def test_export_to_nonexisting_folder(self, simple_journal):
+        with TemporaryDirectory() as tmpdir:
+            p = Path(tmpdir / "non_existing_folder")
+            with pytest.raises(JrnlException):
+                TextExporter.write_file(simple_journal, p)
+            assert not p.exists()


### PR DESCRIPTION
### Changes
call `export_journal` which raises the exception before opening the file handle so that no empty file is created

Also I thought I'd add a unit test for that situation, but I don't quite understand how to do that (see the changes in test_export.py; the test fails currently). Would much appreciate some guidance on this.

Closes: #1593

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [X] I have included a link to the relevant issue number.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [X] I have written new tests for these changes, as needed.
