### PR TITLE
Remove wrong option in configuration file reference

### DIFF
--- a/docs/reference-config-file.md
+++ b/docs/reference-config-file.md
@@ -90,9 +90,6 @@ See the [python docs](http://docs.python.org/library/time.html#time.strftime) fo
 Do not change this for an existing journal, since that might lead
 to data loss.
 
-If you would just like to change how `jrnl` displays dates,
-use display_format instead.
-
 !!! note
     `jrnl` doesn't support the `%z` or `%Z` time zone identifiers.
 


### PR DESCRIPTION
There is a wrong statement in the documentation about the `display_format` format, which is removed in this commit.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
#1617
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
