### PR TITLE
Document that editors must be blocking processes

### DIFF
--- a/docs/external-editors.md
+++ b/docs/external-editors.md
@@ -14,7 +14,7 @@ then you will have to enter in the full path of your editor.
 !!! note
     To save and log any entry edits, save and close the file.
 
-All editors must be [blocking processes](https://en.wikipedia.org/wiki/Blocking_(computing)) to work with jrnl. Some editors, such as vim, are blocking by default, though others can be made to block with additional arguments, such as many of those documented below. If jrnl opens your editor but finishes running immediately, then your editor is not a blocking process, and you may be able to correct that with one of the suggestions below.
+All editors must be [blocking processes](https://en.wikipedia.org/wiki/Blocking_(computing)) to work with jrnl. Some editors, such as [micro](https://micro-editor.github.io/), are blocking by default, though others can be made to block with additional arguments, such as many of those documented below. If jrnl opens your editor but finishes running immediately, then your editor is not a blocking process, and you may be able to correct that with one of the suggestions below.
 
 ## Sublime Text
 

--- a/docs/external-editors.md
+++ b/docs/external-editors.md
@@ -8,11 +8,13 @@ License: https://www.gnu.org/licenses/gpl-3.0.html
 Configure your preferred external editor by updating the `editor` option
 in your [configuration file](./reference-config-file.md#editor)
 
+If your editor is not in your operating system's `PATH` environment variable,
+then you will have to enter in the full path of your editor.
+
 !!! note
     To save and log any entry edits, save and close the file.
 
-If your editor is not in your operating system's `PATH` environment variable,
-then you will have to enter in the full path of your editor.
+All editors must be [blocking processes](https://en.wikipedia.org/wiki/Blocking_(computing)) to work with jrnl. Some editors, such as vim, are blocking by default, though others can be made to block with additional arguments, such as many of those documented below. If jrnl opens your editor but finishes running immediately, then your editor is not a blocking process, and you may be able to correct that with one of the suggestions below.
 
 ## Sublime Text
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -39,7 +39,7 @@ read them or edit them.
 `jrnl` plays nicely with your favorite text editor. You may prefer to write
 journal entries in an editor. Or you may want to make changes that require a
 more comprehensive application. `jrnl` can filter specific entries and pass them
-to the external editor of your choice.
+to the [external editor](./external-editors.md) of your choice.
 
 ## Encryption
   

--- a/docs/reference-config-file.md
+++ b/docs/reference-config-file.md
@@ -47,10 +47,11 @@ key will be used instead.
 If set, executes this command to launch an external editor for
 writing and editing your entries. The path to a temporary file
 is passed after it, and `jrnl` processes the file once
-the editor is closed.
+the editor returns control to `jrnl`.
 
-Some editors require special options to work properly. See
-[External Editors](external-editors.md) for details.
+Some editors require special options to work properly, since they must be
+blocking processes to work with `jrnl`. See [External Editors](external-editors.md)
+for details.
 
 ### encrypt
 If `true`, encrypts your journal using AES. Do not change this


### PR DESCRIPTION
Fixes #1456. Updates documentation to specify that editors must be blocking processes.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
