### PR TITLE
Replace `flake8` with `flakeheaven` in linting steps

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -140,7 +140,6 @@ import argparse
 from Crypto.Cipher import AES
 import getpass
 import hashlib
-import sys
 
 parser = argparse.ArgumentParser()
 parser.add_argument("filepath", help="journal file to decrypt")

--- a/poetry.lock
+++ b/poetry.lock
@@ -179,6 +179,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "entrypoints"
+version = "0.4"
+description = "Discover and load entry points from installed packages."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "execnet"
 version = "1.9.0"
 description = "execnet: rapid multi-Python deployment"
@@ -221,6 +229,25 @@ python-versions = ">=3.6"
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "flakeheaven"
+version = "3.2.0"
+description = "FlakeHeaven is a [Flake8](https://gitlab.com/pycqa/flake8) wrapper to make it cool."
+category = "dev"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+colorama = "*"
+entrypoints = "*"
+flake8 = ">=4.0.1,<5.0.0"
+pygments = "*"
+toml = "*"
+urllib3 = "*"
+
+[package.extras]
+docs = ["alabaster", "myst-parser (>=0.18.0,<0.19.0)", "pygments-github-lexers", "sphinx"]
 
 [[package]]
 name = "ghp-import"
@@ -714,18 +741,6 @@ python-versions = ">=3.6.8"
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
-name = "pyproject-flake8"
-version = "0.0.1a5"
-description = "pyproject-flake8 (`pflake8`), a monkey patching wrapper to connect flake8 with pyproject.toml configuration"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-flake8 = "<5.0.0"
-tomli = {version = "*", markers = "python_version < \"3.11\""}
-
-[[package]]
 name = "pytest"
 version = "7.1.2"
 description = "pytest: simple powerful testing with Python"
@@ -1128,7 +1143,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9.0, <3.12"
-content-hash = "c9bebe280520ae31feec25f734a8404eee0e0f3b3691e9e7e75af0c54a1b02db"
+content-hash = "57ed0eb87ee7fe21231b53feb5e4bfdcd154bbb91e52c38d484ab193ff582ec8"
 
 [metadata.files]
 ansiwrap = [
@@ -1297,6 +1312,10 @@ distlib = [
     {file = "distlib-0.3.5-py2.py3-none-any.whl", hash = "sha256:b710088c59f06338ca514800ad795a132da19fda270e3ce4affc74abf955a26c"},
     {file = "distlib-0.3.5.tar.gz", hash = "sha256:a7f75737c70be3b25e2bee06288cec4e4c221de18455b2dd037fe2a795cab2fe"},
 ]
+entrypoints = [
+    {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
+    {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
+]
 execnet = [
     {file = "execnet-1.9.0-py2.py3-none-any.whl", hash = "sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142"},
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
@@ -1312,6 +1331,10 @@ filelock = [
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+flakeheaven = [
+    {file = "flakeheaven-3.2.0-py3-none-any.whl", hash = "sha256:ec5a508c3db64d73128b65cb2a5a2c0a2d9f2e4b435e9fa2bcc03bf0df86da79"},
+    {file = "flakeheaven-3.2.0.tar.gz", hash = "sha256:225333d7bf309079f19a2c5f02d427fc7558a0d0c065944de88041ca94f5525c"},
 ]
 ghp-import = [
     {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
@@ -1515,10 +1538,6 @@ pygments = [
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
-]
-pyproject-flake8 = [
-    {file = "pyproject-flake8-0.0.1a5.tar.gz", hash = "sha256:22542080ba90d4bd80ee060852db15a24aeea61c9a29ed7c16f5b59b0e47a03a"},
-    {file = "pyproject_flake8-0.0.1a5-py2.py3-none-any.whl", hash = "sha256:c843d760c49d7b270e9abda58a57765c031918a9d10da25aa43572f5d77cac43"},
 ]
 pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ filterwarnings = [
 
 [tool.flakeheaven]
 max_line_length = 88
+exclude = [".venv"]
 
 [tool.flakeheaven.plugins]
 "py*" = ["+*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,13 +42,13 @@ rich = "^12.2.0"
 # dayone-only deps
 tzlocal = ">=4.0"   # https://github.com/regebro/tzlocal/blob/master/CHANGES.txt
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 black = { version = ">=21.5b2", allow-prereleases = true }
+flakeheaven = ">=3.0"
 ipdb = "*"
 isort = ">=5.10"
 mkdocs = ">=1.0,<1.3"
 poethepoet = "*"
-pyproject-flake8 = "*"
 pytest = ">=6.2"
 pytest-bdd = ">=4.0.1,<6.0"
 pytest-clarity = "*"
@@ -150,9 +150,26 @@ filterwarnings = [
     "ignore:[WinError 5].*"
 ]
 
-[tool.flake8]
-# ignore formatting warnings and errors because we use Black to autoformat
-extend-ignore = "E101,E111,E114,E115,E116,E117,E12,E13,E2,E3,E401,E5,E70,W1,W2,W3,W5"
+[tool.flakeheaven]
+max_line_length = 88
+
+[tool.flakeheaven.plugins]
+pyflakes = ["+*"]
+pycodestyle = [
+  "+*",
+  "-E101",
+  "-E111", "-E114", "-E115", "-E116", "-E117",
+  "-E12*",
+  "-E13*",
+  "-E2*",
+  "-E3*",
+  "-E401",
+  "-E5*",
+  "-E70",
+  "-W1*", "-W2*", "-W3*", "-W5*",
+]
+"flake8-*" = ["+*"]
+
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,7 @@ filterwarnings = [
 
 [tool.flakeheaven]
 max_line_length = 88
-exclude = [".venv"]
+exclude = [".git", ".tox", ".venv", "node_modules"]
 
 [tool.flakeheaven.plugins]
 "py*" = ["+*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,9 +154,9 @@ filterwarnings = [
 max_line_length = 88
 
 [tool.flakeheaven.plugins]
-pyflakes = ["+*"]
+"flake8-*" = ["+*"]
+"py*" = ["+*"]
 pycodestyle = [
-  "+*",
   "-E101",
   "-E111", "-E114", "-E115", "-E116", "-E117",
   "-E12*",
@@ -168,7 +168,6 @@ pycodestyle = [
   "-E70",
   "-W1*", "-W2*", "-W3*", "-W5*",
 ]
-"flake8-*" = ["+*"]
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ rich = "^12.2.0"
 # dayone-only deps
 tzlocal = ">=4.0"   # https://github.com/regebro/tzlocal/blob/master/CHANGES.txt
 
-[tool.poetry.group.dev.dependencies]
+[tool.poetry.dev-dependencies]
 black = { version = ">=21.5b2", allow-prereleases = true }
 flakeheaven = ">=3.0"
 ipdb = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,9 @@ format-check = [
   {cmd = "black --check --diff ."},
 ]
 style-check = [
-  {cmd = "pflake8 --version"},
-  {cmd = "pflake8 jrnl tests tasks.py"},
+  {cmd = "flakeheaven --version"},
+  {cmd = "flakeheaven plugins"},
+  {cmd = "flakeheaven lint"},
 ]
 sort-run = [
   {cmd = "isort ."},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ filterwarnings = [
 max_line_length = 88
 
 [tool.flakeheaven.plugins]
-"flake8-*" = ["+*"]
 "py*" = ["+*"]
 pycodestyle = [
   "-E101",


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

In order to support `pyproject.toml`, we've been using `pflake8` to add support to `flake8`. This is fine, but the project is very small, doesn't update often, and only adds the very specific support. The other project, `flakeheaven`, on the other hand adds `pyproject.toml` support among other fixes and updates to `flake8`, is a larger project, not in alpha, and updates often.

This PR changes out `pflake8` and `flake8` for `flakeheaven` in our linting steps.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
