### PR TITLE
Add double encryption test

### DIFF
--- a/tests/bdd/features/encrypt.feature
+++ b/tests/bdd/features/encrypt.feature
@@ -46,6 +46,22 @@ Feature: Encrypting and decrypting journals
         Then we should be prompted for a password
         And the output should contain "2013-06-10 15:40 Life is good"
 
+    Scenario: Encrypt journal twice and get prompted each time
+        Given we use the config "simple.yaml"
+        When we run "jrnl --encrypt" and enter
+            swordfish
+            swordfish
+            y
+        Then we should get no error
+        And the output should contain "Journal encrypted"
+        When we run "jrnl --encrypt" and enter
+            swordfish
+            swordfish
+            y
+        Then we should get no error
+        And the output should contain "Journal default is already encrypted. Create a new password."
+        And we should be prompted for a password
+        And the config for journal "default" should contain "encrypt: true"
 
     Scenario Outline: Running jrnl with encrypt: true on unencryptable journals
         Given we use the config "<config_file>"


### PR DESCRIPTION
This adds a test for when a user encrypts the same journal twice, to ensure the current behavior isn't unintentionally modified by #1602.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
