### PR TITLE
Move existing linting into `flakeheaven`

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -100,16 +100,16 @@ something like `pip3 install crytography`)
 import base64
 import getpass
 from pathlib import Path
+
 from cryptography.fernet import Fernet
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
-
 filepath = input("journal file path: ")
 password = getpass.getpass("Password: ")
 
-with open(Path(filepath),"rb") as f:
+with open(Path(filepath), "rb") as f:
     ciphertext = f.read()
 
 password = password.encode("utf-8")
@@ -123,7 +123,7 @@ kdf = PBKDF2HMAC(
 
 key = base64.urlsafe_b64encode(kdf.derive(password))
 
-print(Fernet(key).decrypt(ciphertext).decode('utf-8'))
+print(Fernet(key).decrypt(ciphertext).decode("utf-8"))
 ```
 
 **Example for jrnl v1 files**:
@@ -137,18 +137,19 @@ like `pip3 install pycrypto`)
 """
 
 import argparse
-from Crypto.Cipher import AES
 import getpass
 import hashlib
+
+from Crypto.Cipher import AES
 
 parser = argparse.ArgumentParser()
 parser.add_argument("filepath", help="journal file to decrypt")
 args = parser.parse_args()
 
 pwd = getpass.getpass()
-key = hashlib.sha256(pwd.encode('utf-8')).digest()
+key = hashlib.sha256(pwd.encode("utf-8")).digest()
 
-with open(args.filepath, 'rb') as f:
+with open(args.filepath, "rb") as f:
     ciphertext = f.read()
 
 crypto = AES.new(key, AES.MODE_CBC, ciphertext[:16])

--- a/poetry.lock
+++ b/poetry.lock
@@ -230,6 +230,34 @@ pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
 
 [[package]]
+name = "flake8-black"
+version = "0.3.3"
+description = "flake8 plugin to call black as a code style validator"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+black = ">=22.1.0"
+flake8 = ">=3.0.0"
+tomli = "*"
+
+[[package]]
+name = "flake8-isort"
+version = "5.0.0"
+description = "flake8 plugin that integrates isort ."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+flake8 = "*"
+isort = ">=4.3.5,<6"
+
+[package.extras]
+test = ["pytest"]
+
+[[package]]
 name = "flakeheaven"
 version = "3.2.0"
 description = "FlakeHeaven is a [Flake8](https://gitlab.com/pycqa/flake8) wrapper to make it cool."
@@ -1130,7 +1158,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10.0, <3.13"
-content-hash = "e2a31438b3c6fbf90093531b3f877818d8dbf85e2c4f95e879888a3aa66a4ee3"
+content-hash = "13e2102b7ddeb9ac4f1f2fddcfa6275d565c3eec9fa8da1b4657a02e20f900c9"
 
 [metadata.files]
 ansiwrap = [
@@ -1318,6 +1346,14 @@ filelock = [
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+flake8-black = [
+    {file = "flake8-black-0.3.3.tar.gz", hash = "sha256:8211f5e20e954cb57c709acccf2f3281ce27016d4c4b989c3e51f878bb7ce12a"},
+    {file = "flake8_black-0.3.3-py3-none-any.whl", hash = "sha256:7d667d0059fd1aa468de1669d77cc934b7f1feeac258d57bdae69a8e73c4cd90"},
+]
+flake8-isort = [
+    {file = "flake8-isort-5.0.0.tar.gz", hash = "sha256:e336f928c7edc509684930ab124414194b7f4e237c712af8fcbdf49d8747b10c"},
+    {file = "flake8_isort-5.0.0-py3-none-any.whl", hash = "sha256:c73f9cbd1bf209887f602a27b827164ccfeba1676801b2aa23cb49051a1be79c"},
 ]
 flakeheaven = [
     {file = "flakeheaven-3.2.0-py3-none-any.whl", hash = "sha256:ec5a508c3db64d73128b65cb2a5a2c0a2d9f2e4b435e9fa2bcc03bf0df86da79"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,8 @@ tzlocal = ">=4.0"   # https://github.com/regebro/tzlocal/blob/master/CHANGES.txt
 [tool.poetry.dev-dependencies]
 black = { version = ">=21.5b2", allow-prereleases = true }
 flakeheaven = ">=3.0"
+flake8-black = ">=0.3.3"
+flake8-isort = ">=5.0.0"
 ipdb = "*"
 isort = ">=5.10"
 mkdocs = ">=1.0,<1.3"
@@ -62,26 +64,6 @@ xmltodict = "*"
 jrnl = 'jrnl.cli:cli'
 
 [tool.poe.tasks]
-format-run = [
-  {cmd = "black ."},
-]
-format-check = [
-  {cmd = "black --version"},
-  {cmd = "black --check --diff ."},
-]
-style-check = [
-  {cmd = "flakeheaven --version"},
-  {cmd = "flakeheaven plugins"},
-  {cmd = "flakeheaven lint"},
-]
-sort-run = [
-  {cmd = "isort ."},
-]
-sort-check = [
-  {cmd = "isort --version"},
-  {cmd = "isort --check ."},
-]
-
 docs-check.default_item_type = "script"
 docs-check.sequence = [
   "tasks:delete_files(['sitemap.xml', 'config.json'])",
@@ -100,21 +82,17 @@ test-run = [
   {cmd = "tox -q -e py --"},
 ]
 
-installer-check = [
-  {cmd = "poetry --version"},
-  {cmd = "poetry check"},
-]
-
 # Groups of tasks
 format = [
-  "format-run",
-  "sort-run",
+  {cmd = "isort ."},
+  {cmd = "black ."},
 ]
 lint = [
-  "installer-check",
-  "style-check",
-  "sort-check",
-  "format-check",
+  {cmd = "poetry --version"},
+  {cmd = "poetry check"},
+  {cmd = "flakeheaven --version"},
+  {cmd = "flakeheaven plugins"},
+  {cmd = "flakeheaven lint"},
 ]
 test = [
   "lint",
@@ -169,6 +147,7 @@ pycodestyle = [
   "-E70",
   "-W1*", "-W2*", "-W3*", "-W5*",
 ]
+"flake8-*" = ["+*"]
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ pycodestyle = [
   "-W1*", "-W2*", "-W3*", "-W5*",
 ]
 "flake8-*" = ["+*"]
+flake8-black = ["-BLK901"]
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ format.sequence = [
   "black .",
 ]
 
+lint.env = { FLAKEHEAVEN_CACHE_TIMEOUT = "0" }
 lint.default_item_type = "cmd"
 lint.sequence = [
   "poetry --version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,17 +83,21 @@ test-run = [
 ]
 
 # Groups of tasks
-format = [
-  {cmd = "isort ."},
-  {cmd = "black ."},
+format.default_item_type = "cmd"
+format.sequence = [
+  "isort .",
+  "black .",
 ]
-lint = [
-  {cmd = "poetry --version"},
-  {cmd = "poetry check"},
-  {cmd = "flakeheaven --version"},
-  {cmd = "flakeheaven plugins"},
-  {cmd = "flakeheaven lint"},
+
+lint.default_item_type = "cmd"
+lint.sequence = [
+  "poetry --version",
+  "poetry check",
+  "flakeheaven --version",
+  "flakeheaven plugins",
+  "flakeheaven lint",
 ]
+
 test = [
   "lint",
   "test-run",


### PR DESCRIPTION
We recently added `flakeheaven` to our linting checks. And we've been running `black` and `isort` checks previously. This PR moves the `black` and `isort` checks into `flakeheaven` so that all linting checks happen in one step, instead of multiple calls to multiple tools. `flakeheaven` still uses `black` and `isort` under the hood, but this centralizes reporting if any checks are failing, and also makes it easier to integrate with editors (`flakeheaven` reporting is `flake8` compatible, so it works with pretty much any editor).

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
