### PR TITLE
Add `type-checking` plugin to linting checks

### DIFF
--- a/jrnl/exception.py
+++ b/jrnl/exception.py
@@ -1,14 +1,18 @@
 # Copyright © 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from jrnl.messages import Message
+from typing import TYPE_CHECKING
+
 from jrnl.output import print_msg
+
+if TYPE_CHECKING:
+    from jrnl.messages import Message
 
 
 class JrnlException(Exception):
     """Common exceptions raised by jrnl."""
 
-    def __init__(self, *messages: Message):
+    def __init__(self, *messages: "Message"):
         self.messages = messages
 
     def print(self) -> None:

--- a/jrnl/messages/Message.py
+++ b/jrnl/messages/Message.py
@@ -4,6 +4,7 @@
 from typing import TYPE_CHECKING
 from typing import Mapping
 from typing import NamedTuple
+
 from jrnl.messages.MsgStyle import MsgStyle
 
 if TYPE_CHECKING:

--- a/jrnl/messages/Message.py
+++ b/jrnl/messages/Message.py
@@ -1,14 +1,16 @@
 # Copyright © 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+from typing import TYPE_CHECKING
 from typing import Mapping
 from typing import NamedTuple
-
 from jrnl.messages.MsgStyle import MsgStyle
-from jrnl.messages.MsgText import MsgText
+
+if TYPE_CHECKING:
+    from jrnl.messages.MsgText import MsgText
 
 
 class Message(NamedTuple):
-    text: MsgText
+    text: "MsgText"
     style: MsgStyle = MsgStyle.NORMAL
     params: Mapping = {}

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -1,14 +1,15 @@
 # Copyright © 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
-
-from argparse import Namespace
+from typing import TYPE_CHECKING
 
 from jrnl.config import make_yaml_valid_dict
 from jrnl.config import update_config
 
+if TYPE_CHECKING:
+    from argparse import Namespace
 
 # import logging
-def apply_overrides(args: Namespace, base_config: dict) -> dict:
+def apply_overrides(args: "Namespace", base_config: dict) -> dict:
     """Unpack CLI provided overrides into the configuration tree.
 
     :param overrides: List of configuration key-value pairs collected from the CLI

--- a/poetry.lock
+++ b/poetry.lock
@@ -113,6 +113,14 @@ python-versions = ">=3.6.0"
 unicode-backport = ["unicodedata2"]
 
 [[package]]
+name = "classify-imports"
+version = "4.2.0"
+description = "Utilities for refactoring imports in python-like syntax."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
@@ -228,6 +236,18 @@ python-versions = ">=3.6"
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "flake8-type-checking"
+version = "2.2.0"
+description = "A flake8 plugin for managing type-checking imports & forward references"
+category = "dev"
+optional = false
+python-versions = ">=3.8"
+
+[package.dependencies]
+classify-imports = "*"
+flake8 = "*"
 
 [[package]]
 name = "flakeheaven"
@@ -1130,7 +1150,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10.0, <3.13"
-content-hash = "e2a31438b3c6fbf90093531b3f877818d8dbf85e2c4f95e879888a3aa66a4ee3"
+content-hash = "c927c7c2bff0ae139d7b22a96d5cef97064e9d586e977b4d19f5ba905de602f1"
 
 [metadata.files]
 ansiwrap = [
@@ -1255,6 +1275,10 @@ charset-normalizer = [
     {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
     {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
 ]
+classify-imports = [
+    {file = "classify_imports-4.2.0-py2.py3-none-any.whl", hash = "sha256:dbbc264b70a470ed8c6c95976a11dfb8b7f63df44ed1af87328bbed2663f5161"},
+    {file = "classify_imports-4.2.0.tar.gz", hash = "sha256:7abfb7ea92149b29d046bd34573d247ba6e68cc28100c801eba4af17964fc40e"},
+]
 click = [
     {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
     {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
@@ -1318,6 +1342,10 @@ filelock = [
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+flake8-type-checking = [
+    {file = "flake8_type_checking-2.2.0-py3-none-any.whl", hash = "sha256:c7d9d7adc6cd635a5a1a7859e5e0140f4f8f1705982a22db45872dd9acd49753"},
+    {file = "flake8_type_checking-2.2.0.tar.gz", hash = "sha256:f7972fc9102f3f632ace1f4b1c5c20b900b8b7b529f04bb6c1fe0a11801e9658"},
 ]
 flakeheaven = [
     {file = "flakeheaven-3.2.0-py3-none-any.whl", hash = "sha256:ec5a508c3db64d73128b65cb2a5a2c0a2d9f2e4b435e9fa2bcc03bf0df86da79"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ tzlocal = ">=4.0"   # https://github.com/regebro/tzlocal/blob/master/CHANGES.txt
 [tool.poetry.dev-dependencies]
 black = { version = ">=21.5b2", allow-prereleases = true }
 flakeheaven = ">=3.0"
+flake8-type-checking = ">=2.2.0"
 ipdb = "*"
 isort = ">=5.10"
 mkdocs = ">=1.0,<1.3"
@@ -169,6 +170,7 @@ pycodestyle = [
   "-E70",
   "-W1*", "-W2*", "-W3*", "-W5*",
 ]
+"flake8-*" = ["+*"]
 
 
 [build-system]


### PR DESCRIPTION
We've been adding more type hints to code, and have a PR waiting (#1614) to add even more. `flake8-type-checking` will add type checking to our current linting checks, which will make use of those type hints to hopefully catch errors early in development.

cc: #1608 

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
