### PR TITLE
Add `simplify` plugin to linting checks

### DIFF
--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -1,6 +1,7 @@
 # Copyright © 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import contextlib
 import datetime
 import fnmatch
 import os
@@ -75,40 +76,23 @@ class DayOne(Journal.Journal):
                     ]
 
                     """Extended DayOne attributes"""
-                    try:
+                    # just ignore it if the keys don't exist
+                    with contextlib.suppress(KeyError):
                         entry.creator_device_agent = dict_entry["Creator"][
                             "Device Agent"
                         ]
-                    except:  # noqa: E722
-                        pass
-                    try:
-                        entry.creator_generation_date = dict_entry["Creator"][
-                            "Generation Date"
-                        ]
-                    except:  # noqa: E722
-                        entry.creator_generation_date = date
-                    try:
                         entry.creator_host_name = dict_entry["Creator"]["Host Name"]
-                    except:  # noqa: E722
-                        pass
-                    try:
                         entry.creator_os_agent = dict_entry["Creator"]["OS Agent"]
-                    except:  # noqa: E722
-                        pass
-                    try:
                         entry.creator_software_agent = dict_entry["Creator"][
                             "Software Agent"
                         ]
-                    except:  # noqa: E722
-                        pass
-                    try:
                         entry.location = dict_entry["Location"]
-                    except:  # noqa: E722
-                        pass
-                    try:
                         entry.weather = dict_entry["Weather"]
-                    except:  # noqa: E722
-                        pass
+
+                    entry.creator_generation_date = dict_entry.get("Creator", {}).get(
+                        "Generation Date", date
+                    )
+
                     self.entries.append(entry)
         self.sort()
         return self

--- a/jrnl/EncryptedJournal.py
+++ b/jrnl/EncryptedJournal.py
@@ -2,6 +2,7 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import base64
+import contextlib
 import hashlib
 import logging
 import os
@@ -202,10 +203,9 @@ def set_keychain(journal_name, password):
     import keyring
 
     if password is None:
-        try:
+        cm = contextlib.suppress(keyring.errors.KeyringError)
+        with cm:
             keyring.delete_password("jrnl", journal_name)
-        except keyring.errors.KeyringError:
-            pass
     else:
         try:
             keyring.set_password("jrnl", journal_name, password)

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -120,10 +120,7 @@ class Journal:
     def validate_parsing(self):
         """Confirms that the jrnl is still parsed correctly after being dumped to text."""
         new_entries = self._parse(self._to_text())
-        for i, entry in enumerate(self.entries):
-            if entry != new_entries[i]:
-                return False
-        return True
+        return all(entry == new_entries[i] for i, entry in enumerate(self.entries))
 
     @staticmethod
     def create_file(filename):

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -1,6 +1,7 @@
 # Copyright © 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import contextlib
 import glob
 import logging
 import os
@@ -126,10 +127,8 @@ def install():
 
     # If the folder doesn't exist, create it
     path = os.path.split(journal_path)[0]
-    try:
+    with contextlib.suppress(OSError):
         os.makedirs(path)
-    except OSError:
-        pass
 
     # Encrypt it?
     encrypt = yesno(Message(MsgText.EncryptJournalQuestion), default=False)

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -236,7 +236,8 @@ def _get_editor_template(config, **kwargs):
     template_path = expand_path(config["template"])
 
     try:
-        template = open(template_path).read()
+        with open(template_path) as f:
+            template = f.read()
         logging.debug("Write mode: template loaded: %s", template)
     except OSError:
         logging.error("Write mode: template not loaded")

--- a/jrnl/messages/__init__.py
+++ b/jrnl/messages/__init__.py
@@ -1,6 +1,10 @@
 # Copyright © 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from jrnl.messages.Message import Message  # noqa: F401
-from jrnl.messages.MsgStyle import MsgStyle  # noqa: F401
-from jrnl.messages.MsgText import MsgText  # noqa: F401
+from jrnl.messages import Message
+from jrnl.messages import MsgStyle
+from jrnl.messages import MsgText
+
+Message = Message.Message
+MsgStyle = MsgStyle.MsgStyle
+MsgText = MsgText.MsgText

--- a/jrnl/messages/__init__.py
+++ b/jrnl/messages/__init__.py
@@ -1,10 +1,6 @@
 # Copyright © 2012-2022 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-from jrnl.messages.Message import Message
-from jrnl.messages.MsgStyle import MsgStyle
-from jrnl.messages.MsgText import MsgText
-
-Message = Message
-MsgStyle = MsgStyle
-MsgText = MsgText
+from jrnl.messages.Message import Message  # noqa: F401
+from jrnl.messages.MsgStyle import MsgStyle  # noqa: F401
+from jrnl.messages.MsgText import MsgText  # noqa: F401

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -2,7 +2,7 @@
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import textwrap
-from typing import Union
+from typing import Optional
 
 from rich.console import Console
 from rich.text import Text
@@ -69,7 +69,7 @@ def list_journals(configuration, format=None):
         return journal_list_to_stdout(journal_list)
 
 
-def print_msg(msg: Message, **kwargs) -> Union[None, str]:
+def print_msg(msg: Message, **kwargs) -> Optional[str]:
     """Helper function to print a single message"""
     kwargs["style"] = msg.style
     return print_msgs([msg], **kwargs)
@@ -81,7 +81,7 @@ def print_msgs(
     style: MsgStyle = MsgStyle.NORMAL,
     get_input: bool = False,
     hide_input: bool = False,
-) -> Union[None, str]:
+) -> Optional[str]:
     # Same as print_msg, but for a list
     text = Text("", end="")
     kwargs = style.decoration.args

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -78,11 +78,11 @@ class MarkdownExporter(TextExporter):
         out = []
         year, month = -1, -1
         for e in journal.entries:
-            if not e.date.year == year:
+            if e.date.year != year:
                 year = e.date.year
                 out.append("# " + str(year))
                 out.append("")
-            if not e.date.month == month:
+            if e.date.month != month:
                 month = e.date.month
                 out.append("## " + e.date.strftime("%B"))
                 out.append("")

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,6 +18,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "astor"
+version = "0.8.1"
+description = "Read/rewrite/write Python ASTs"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[[package]]
 name = "asttokens"
 version = "2.0.5"
 description = "Annotate AST trees with source code positions"
@@ -228,6 +236,18 @@ python-versions = ">=3.6"
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.8.0,<2.9.0"
 pyflakes = ">=2.4.0,<2.5.0"
+
+[[package]]
+name = "flake8-simplify"
+version = "0.19.3"
+description = "flake8 plugin which checks for code that can be simplified"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+astor = ">=0.1"
+flake8 = ">=3.7"
 
 [[package]]
 name = "flakeheaven"
@@ -1130,7 +1150,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10.0, <3.13"
-content-hash = "e2a31438b3c6fbf90093531b3f877818d8dbf85e2c4f95e879888a3aa66a4ee3"
+content-hash = "22d7179ea395349b05b32de694b47746b83f7bfc2e80fd55a39f9b0c1020b092"
 
 [metadata.files]
 ansiwrap = [
@@ -1140,6 +1160,10 @@ ansiwrap = [
 appnope = [
     {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
     {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
+]
+astor = [
+    {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
+    {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
 ]
 asttokens = [
     {file = "asttokens-2.0.5-py2.py3-none-any.whl", hash = "sha256:0844691e88552595a6f4a4281a9f7f79b8dd45ca4ccea82e5e05b4bbdb76705c"},
@@ -1318,6 +1342,10 @@ filelock = [
 flake8 = [
     {file = "flake8-4.0.1-py2.py3-none-any.whl", hash = "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d"},
     {file = "flake8-4.0.1.tar.gz", hash = "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"},
+]
+flake8-simplify = [
+    {file = "flake8_simplify-0.19.3-py3-none-any.whl", hash = "sha256:1057320e9312d75849541fee822900d27bcad05b2405edc84713affee635629e"},
+    {file = "flake8_simplify-0.19.3.tar.gz", hash = "sha256:2fb083bf5142a98d9c9554755cf2f56f8926eb4a33eae30c0809041b1546879e"},
 ]
 flakeheaven = [
     {file = "flakeheaven-3.2.0-py3-none-any.whl", hash = "sha256:ec5a508c3db64d73128b65cb2a5a2c0a2d9f2e4b435e9fa2bcc03bf0df86da79"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ tzlocal = ">=4.0"   # https://github.com/regebro/tzlocal/blob/master/CHANGES.txt
 [tool.poetry.dev-dependencies]
 black = { version = ">=21.5b2", allow-prereleases = true }
 flakeheaven = ">=3.0"
+flake8-simplify = ">=0.19"
 ipdb = "*"
 isort = ">=5.10"
 mkdocs = ">=1.0,<1.3"
@@ -169,6 +170,7 @@ pycodestyle = [
   "-E70",
   "-W1*", "-W2*", "-W3*", "-W5*",
 ]
+"flake8-*" = ["+*"]
 
 
 [build-system]

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -293,7 +293,7 @@ class TestDeserialization:
 
         runtime_config = make_yaml_valid_dict(input_str)
         assert runtime_config.__class__ == dict
-        assert input_str[0] in runtime_config.keys()
+        assert input_str[0] in runtime_config
         assert runtime_config[input_str[0]] == input_str[1]
 
     def test_deserialize_multiple_datatypes(self):


### PR DESCRIPTION
We recently added `flakeheaven` to our linting checks. This PR adds a `flake8-simplify` to look for more general issues with code complexity, and provide specific advice on how to fix those issues. Running this locally, we had a few issues already in the codebase, so this PR also fixes those issues so the new checks can start from a neutral state.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
