### PR TITLE
Fix bug where changelog is always slightly out of date on release tags

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -157,7 +157,7 @@ jobs:
         run: |
           # This is a tag build (releases and prereleases)
           # update the tag to include the changelog
-          git tag -fam "${GITHUB_REF##*/}" "${GITHUB_REF##*/}"
+          git tag -fam "$GITHUB_REF_NAME" "$GITHUB_REF_NAME"
           git push --tags --force
 
       - name: Merge to Release branch

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -151,6 +151,11 @@ jobs:
           git add "$FILENAME"
           git commit -m "Update changelog [ci skip]"
           git push origin "$BRANCH"
+
+      - name: Update tag to include changelog
+        if: startsWith(env.GITHUB_REF, 'refs/tags/')
+        run: |
+          # This is a tag build (releases and prereleases)
           # update the tag to include the changelog
           git tag -fam "${GITHUB_REF##*/}" "${GITHUB_REF##*/}"
           git push --tags --force

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -151,6 +151,9 @@ jobs:
           git add "$FILENAME"
           git commit -m "Update changelog [ci skip]"
           git push origin "$BRANCH"
+          # update the tag to include the changelog
+          git tag -fam "${GITHUB_REF##*/}" "${GITHUB_REF##*/}"
+          git push --tags --force
 
       - name: Merge to Release branch
         if: env.FULL_RELEASE == 'true'


### PR DESCRIPTION
As the title says, there's currently a bug in our release process where the release is tagged and published, and then the changelog is updated afterward. You can actually see it if you go through the tags in our repo and click on the changelog file for each one.

This PR makes it a part of the changelog step in CI to update the tag to the proper commit after the changelog is generated (the changelog generator itself requires a tag to work, which is why the tag has to be moved afterward instead of beforehand).

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
