### PR TITLE
Resolve failing GitHub Actions linting by replacing deprecated set-output command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,7 +111,7 @@ jobs:
       id: pypi-version-getter
       run: |
         pypi_version="$(find dist/jrnl-*.tar.gz | sed -r 's!dist/jrnl-(.*)\.tar\.gz!\1!')"
-        echo 'pypi_version="$pypi_version"' >> $GITHUB_OUTPUT
+        echo "pypi_version=$pypi_version" >> "$GITHUB_OUTPUT"
 
   release_homebrew:
     if: ${{ github.event.inputs.include_brew == 'true' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,7 +111,7 @@ jobs:
       id: pypi-version-getter
       run: |
         pypi_version="$(find dist/jrnl-*.tar.gz | sed -r 's!dist/jrnl-(.*)\.tar\.gz!\1!')"
-        echo "pypi_version=$pypi_version" >> $GITHUB_OUTPUT
+        echo 'pypi_version="$pypi_version"' >> $GITHUB_OUTPUT
 
   release_homebrew:
     if: ${{ github.event.inputs.include_brew == 'true' }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,7 +111,7 @@ jobs:
       id: pypi-version-getter
       run: |
         pypi_version="$(find dist/jrnl-*.tar.gz | sed -r 's!dist/jrnl-(.*)\.tar\.gz!\1!')"
-        echo "::set-output name=pypi_version::$pypi_version"
+        echo "pypi_version=$pypi_version" >> $GITHUB_OUTPUT
 
   release_homebrew:
     if: ${{ github.event.inputs.include_brew == 'true' }}


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

Our action linting [kicks out an error](https://github.com/jrnl-org/jrnl/actions/runs/3373764194/jobs/5614587551) due to a deprecated set-output command. I'm hoping this PR will fix it.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
