### PR TITLE
Remove Windows 7 known issue since Windows 7 is no longer supported

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -115,12 +115,3 @@ jrnl --config-file ~/foo/jrnl/work-config.yaml
 # Use default configuration file (created on first run)
 jrnl
 ```
-
-## Known Issues
-
-### Unicode on Windows
-
-The Windows shell prior to Windows 7 has issues with unicode encoding.
-To use non-ascii characters, first tweak Python to recognize the encoding by adding `'cp65001': 'utf_8'`, to `Lib/encoding/aliases.py`. Then, change the codepage with `chcp 1252` before using `jrnl`.
-
-(Related issue: [#486](https://github.com/jrnl-org/jrnl/issues/486))


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

We have a "known issue" about Windows 7, but jrnl's minimum Python version doesn't support Windows 7. And Windows 7 has been past its official end of life for almost three years now. So, I'm removing it.


### Checklist

- [ ] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
