### PR TITLE
Fix for #1639 journal overwrite

### DIFF
--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -187,12 +187,6 @@ def search_mode(args: "Namespace", journal: Journal, **kwargs) -> None:
     if args.edit:
         # If we want to both edit and change time in one action
         if args.change_time:
-            if not journal:
-                # --edit can be called on an empty journal, but --edit
-                # and --change-time together means the user is likely
-                # expecting to have selected some entries; bail out
-                return
-
             # Generate a new list instead of assigning so it won't be
             # modified by _change_time_search_results
             selected_entries = [e for e in journal.entries]
@@ -210,9 +204,7 @@ def search_mode(args: "Namespace", journal: Journal, **kwargs) -> None:
         _edit_search_results(**kwargs)
 
     elif not journal:
-        # Bail out if there are no entries and we're not editing; we
-        # could put this before the above edit block, but there are
-        # some use cases where --edit is called on an empty journal
+        # Bail out if there are no entries and we're not editing
         return
 
     elif args.change_time:
@@ -445,16 +437,15 @@ def _change_time_search_results(
             MsgText.ChangeTimeEntryQuestion
         )
 
-    if entries_to_change:
-        other_entries += [e for e in journal.entries if e not in entries_to_change]
-        journal.entries = entries_to_change
+    other_entries += [e for e in journal.entries if e not in entries_to_change]
+    journal.entries = entries_to_change
 
-        date = time.parse(args.change_time)
-        journal.change_date_entries(date)
+    date = time.parse(args.change_time)
+    journal.change_date_entries(date)
 
-        journal.entries += other_entries
-        journal.sort()
-        journal.write()
+    journal.entries += other_entries
+    journal.sort()
+    journal.write()
 
 
 def _display_search_results(args: "Namespace", journal: Journal, **kwargs) -> None:

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -183,14 +183,16 @@ def search_mode(args: "Namespace", journal: Journal, **kwargs) -> None:
         _filter_journal_entries(**kwargs)
         _print_entries_found_count(len(journal), args)
 
-    if not journal:
-        # Bail out if there are no entries
-        return
-
     # Where do the search results go?
-    elif args.edit:
+    if args.edit:
         # If we want to both edit and change time in one action
         if args.change_time:
+            if not journal:
+                # --edit can be called on an empty journal, but --edit
+                # and --change-time together means the user is likely
+                # expecting to have selected some entries; bail out
+                return
+
             # Generate a new list instead of assigning so it won't be
             # modified by _change_time_search_results
             selected_entries = [e for e in journal.entries]
@@ -206,6 +208,13 @@ def search_mode(args: "Namespace", journal: Journal, **kwargs) -> None:
             journal.entries = selected_entries
 
         _edit_search_results(**kwargs)
+
+    elif not journal:
+        # Bail out if there are no entries and we're not editing; we
+        # could put this before the above edit block, but there are
+        # some use cases where --edit is called on an empty journal
+        return
+
     elif args.change_time:
         _change_time_search_results(**kwargs)
 

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -183,8 +183,12 @@ def search_mode(args: "Namespace", journal: Journal, **kwargs) -> None:
         _filter_journal_entries(**kwargs)
         _print_entries_found_count(len(journal), args)
 
+    if not journal:
+        # Bail out if there are no entries
+        return
+
     # Where do the search results go?
-    if args.edit:
+    elif args.edit:
         # If we want to both edit and change time in one action
         if args.change_time:
             # Generate a new list instead of assigning so it won't be
@@ -202,11 +206,6 @@ def search_mode(args: "Namespace", journal: Journal, **kwargs) -> None:
             journal.entries = selected_entries
 
         _edit_search_results(**kwargs)
-
-    elif not journal:
-        # Bail out if there are no entries and we're not editing
-        return
-
     elif args.change_time:
         _change_time_search_results(**kwargs)
 

--- a/tests/bdd/features/change_time.feature
+++ b/tests/bdd/features/change_time.feature
@@ -243,19 +243,19 @@ Feature: Change entry times in journal
         # | basic_dayone.yaml    | @todo
 
 
-    Scenario Outline: --change-time with --edit and an empty search adds an entry
+    Scenario Outline: --change-time with --edit and an empty search adds an entry at the specified time
         Given we use the config "<config_file>"
         And we write nothing to the editor if opened
         And we use the password "test" if prompted
         And we append to the editor if opened
-            [2022-11-13 11:25] worked on jrnl tests
-        When we run "jrnl -on tomorrow --change-time --edit"
+            worked on jrnl tests
+        When we run "jrnl -on tomorrow --change-time '2022-11-13 13:25' --edit"
         When we run "jrnl -99 --short"
         Then the output should be
             2020-08-29 11:11 Entry the first.
             2020-08-31 14:32 A second entry in what I hope to be a long series.
             2020-09-24 09:14 The third entry finally after weeks without writing.
-            2022-11-13 11:25 worked on jrnl tests
+            2022-11-13 13:25 worked on jrnl tests
 
         Examples: Configs
         | config_file        |

--- a/tests/bdd/features/change_time.feature
+++ b/tests/bdd/features/change_time.feature
@@ -241,3 +241,22 @@ Feature: Change entry times in journal
         | basic_onefile.yaml |
         | basic_folder.yaml  |
         # | basic_dayone.yaml    | @todo
+
+
+    Scenario Outline: --change-time with --edit and no selected entries doesn't overwrite journal
+        Given we use the config "<config_file>"
+        And we write nothing to the editor if opened
+        And we use the password "test" if prompted
+        When we run "jrnl -on tomorrow --change-time '2022-04-23 10:30' --edit"
+        #Then the error output should contain "No entry to modify"
+        When we run "jrnl -99 --short"
+        Then the output should be
+            2020-08-29 11:11 Entry the first.
+            2020-08-31 14:32 A second entry in what I hope to be a long series.
+            2020-09-24 09:14 The third entry finally after weeks without writing.
+
+        Examples: Configs
+        | config_file        |
+        | basic_onefile.yaml |
+        | basic_folder.yaml  |
+        # | basic_dayone.yaml    | @todo

--- a/tests/bdd/features/change_time.feature
+++ b/tests/bdd/features/change_time.feature
@@ -243,17 +243,19 @@ Feature: Change entry times in journal
         # | basic_dayone.yaml    | @todo
 
 
-    Scenario Outline: --change-time with --edit and no selected entries doesn't overwrite journal
+    Scenario Outline: --change-time with --edit and an empty search adds an entry
         Given we use the config "<config_file>"
         And we write nothing to the editor if opened
         And we use the password "test" if prompted
-        When we run "jrnl -on tomorrow --change-time '2022-04-23 10:30' --edit"
-        #Then the error output should contain "No entry to modify"
+        And we append to the editor if opened
+            [2022-11-13 11:25] worked on jrnl tests
+        When we run "jrnl -on tomorrow --change-time --edit"
         When we run "jrnl -99 --short"
         Then the output should be
             2020-08-29 11:11 Entry the first.
             2020-08-31 14:32 A second entry in what I hope to be a long series.
             2020-09-24 09:14 The third entry finally after weeks without writing.
+            2022-11-13 11:25 worked on jrnl tests
 
         Examples: Configs
         | config_file        |


### PR DESCRIPTION
This fixes the journal overwrite bug in #1639. 

There's a bit of awkward branching to account for existing use cases of calling `jrnl --edit` on empty journals; if we drop those, the cleaner fix in fce5afff0632a273de1713bc3a3f6f90c6b7706a could likely work.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.