### PR TITLE
Update version key in config file after version changes

### DIFF
--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -9,6 +9,7 @@ import sys
 
 from rich.pretty import pretty_repr
 
+from jrnl import __version__
 from jrnl.config import DEFAULT_JOURNAL_KEY
 from jrnl.config import get_config_path
 from jrnl.config import get_default_config
@@ -32,12 +33,20 @@ def upgrade_config(config_data: dict, alt_config_path: str | None = None) -> Non
     """Checks if there are keys missing in a given config dict, and if so, updates the config file accordingly.
     This essentially automatically ports jrnl installations if new config parameters are introduced in later
     versions.
+    Also checks for existence of and difference in version number between config dict and current jrnl version,
+    and if so, update the config file accordingly.
     Supply alt_config_path if using an alternate config through --config-file."""
     default_config = get_default_config()
     missing_keys = set(default_config).difference(config_data)
     if missing_keys:
         for key in missing_keys:
             config_data[key] = default_config[key]
+        
+    different_version = (config_data["version"] != __version__)
+    if different_version:
+        config_data["version"] = __version__
+
+    if missing_keys or different_version:
         save_config(config_data, alt_config_path)
         config_path = alt_config_path if alt_config_path else get_config_path()
         print_msg(

--- a/tests/bdd/features/config_file.feature
+++ b/tests/bdd/features/config_file.feature
@@ -133,3 +133,9 @@ Feature: Multiple journals
         Given we use the config "multiple.yaml"
         When we run "jrnl --config-override highlight false"
         Then the output should not contain "There is at least one duplicate key in your configuration file"
+
+    Scenario: Update version number in config file when running newer version
+        Given we use the config "format_md.yaml"
+        When we run "jrnl -1"
+        Then the output should contain "Configuration updated to newest version at"
+        And the version in the config file should be up-to-date


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

This PR fixes #1638 
As mentioned in #1638 the reference states: 

> version
>jrnl automatically updates this field to the version that it is running. There is no need to change this field manually.


jrnl now checks if the version in the config file differs from the current version, and if so, updates it. And I also added a BDD test for this functionality.

_Side question: While working on this, I saw no BDD test for adding missing keys in the config. But for some reason the message 'Configuration updated to newest version at' prints when testing in 'poetry shell', but not while running in a test. Do BDD tests automatically fill in the config fields that aren't there yet?_

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
