### PR TITLE
Update docs to include time and title in arguments with `--edit`

### DIFF
--- a/docs/external-editors.md
+++ b/docs/external-editors.md
@@ -6,10 +6,31 @@ License: https://www.gnu.org/licenses/gpl-3.0.html
 # External editors
 
 Configure your preferred external editor by updating the `editor` option
-in your [configuration file](./reference-config-file.md#editor)
+in your [configuration file](./reference-config-file.md#editor). If your editor is not 
+in your operating system's `PATH` environment variable, then you will have to 
+enter the full path of your editor.
 
-If your editor is not in your operating system's `PATH` environment variable,
-then you will have to enter in the full path of your editor.
+Once it's configured, you can create an entry as a new document in your editor using the `jrnl` 
+command by itself:
+
+``` text
+jrnl
+```
+
+You can specify the time and title of the entry as usual on the first line of the document. 
+
+If you want, you can skip the editor by including a quick entry with the `jrnl` command:
+
+``` text
+jrnl yesterday: All my troubles seemed so far away.
+```
+
+If you want to start the entry on the command line and continue writing in your chosen editor, 
+use the `--edit` flag. For example:
+
+``` text
+jrnl yesterday: All my troubles seemed so far away. --edit
+```
 
 !!! note
     To save and log any entry edits, save and close the file.


### PR DESCRIPTION
Fixes #1072.

The issue was that it wasn't clear how to specify a time when using an external editor. 
I added a few notes based on the comment by @micahellison. Ultimately, it might make
sense to describe somewhere the fact that `jrnl` uses the first line to figure out the time/date,
no matter how you slice it, so that it's clear that you can just start typing `Last week:` or 
whatever, even when you're in an external editor. For now, though, I think these added lines
in the `external-editors.md` file will help.


### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed. **N/A I think**

