### PR TITLE
Update copyright notices for 2023

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 name: Changelog

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 name: Docs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 name: Release

--- a/.github/workflows/testing_pipelines.yaml
+++ b/.github/workflows/testing_pipelines.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 name: Testing Pipeline Files

--- a/.github/workflows/testing_prs.yaml
+++ b/.github/workflows/testing_prs.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 name: Testing

--- a/.github/workflows/testing_schedule.yaml
+++ b/.github/workflows/testing_schedule.yaml
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 name: Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/external-editors.md
+++ b/docs/external-editors.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/journal-types.md
+++ b/docs/journal-types.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/reference-command-line.md
+++ b/docs/reference-command-line.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/reference-config-file.md
+++ b/docs/reference-config-file.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs_theme/assets/colors.css
+++ b/docs_theme/assets/colors.css
@@ -1,5 +1,5 @@
 /*
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 */
 

--- a/docs_theme/assets/highlight.css
+++ b/docs_theme/assets/highlight.css
@@ -1,5 +1,5 @@
 /*
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Atom One Dark With support for ReasonML by Gidi Morris, based off work by

--- a/docs_theme/assets/index.css
+++ b/docs_theme/assets/index.css
@@ -1,5 +1,5 @@
 /*
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 */
 

--- a/docs_theme/assets/theme.css
+++ b/docs_theme/assets/theme.css
@@ -1,5 +1,5 @@
 /*
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 */
 

--- a/docs_theme/index.html
+++ b/docs_theme/index.html
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs_theme/main.html
+++ b/docs_theme/main.html
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/docs_theme/search.html
+++ b/docs_theme/search.html
@@ -1,5 +1,5 @@
 <!--
-Copyright © 2012-2022 jrnl contributors
+Copyright © 2012-2023 jrnl contributors
 License: https://www.gnu.org/licenses/gpl-3.0.html
 -->
 

--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import contextlib

--- a/jrnl/Entry.py
+++ b/jrnl/Entry.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import datetime

--- a/jrnl/FolderJournal.py
+++ b/jrnl/FolderJournal.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import codecs

--- a/jrnl/Journal.py
+++ b/jrnl/Journal.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import datetime

--- a/jrnl/__init__.py
+++ b/jrnl/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 try:

--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import sys

--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import argparse

--- a/jrnl/cli.py
+++ b/jrnl/cli.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import logging

--- a/jrnl/color.py
+++ b/jrnl/color.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import re

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 """
@@ -47,7 +47,7 @@ def preconfig_version(_):
     output = f"""
     {__title__} {__version__}
 
-    Copyright © 2012-2022 jrnl contributors
+    Copyright © 2012-2023 jrnl contributors
 
     This is free software, and you are welcome to redistribute it under certain
     conditions; for details, see: https://www.gnu.org/licenses/gpl-3.0.html

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -14,6 +14,7 @@ run.
 Also, please note that all (non-builtin) imports should be scoped to each function to
 avoid any possible overhead for these standalone commands.
 """
+
 import argparse
 import logging
 import platform

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import argparse

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import logging

--- a/jrnl/encryption/BaseEncryption.py
+++ b/jrnl/encryption/BaseEncryption.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 import logging
 from abc import ABC

--- a/jrnl/encryption/BaseEncryption.py
+++ b/jrnl/encryption/BaseEncryption.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import logging
 from abc import ABC
 from abc import abstractmethod

--- a/jrnl/encryption/BaseKeyEncryption.py
+++ b/jrnl/encryption/BaseKeyEncryption.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 from .BaseEncryption import BaseEncryption
 

--- a/jrnl/encryption/BaseKeyEncryption.py
+++ b/jrnl/encryption/BaseKeyEncryption.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from .BaseEncryption import BaseEncryption
 
 

--- a/jrnl/encryption/BasePasswordEncryption.py
+++ b/jrnl/encryption/BasePasswordEncryption.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 import logging
 

--- a/jrnl/encryption/BasePasswordEncryption.py
+++ b/jrnl/encryption/BasePasswordEncryption.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import logging
 
 from jrnl.encryption.BaseEncryption import BaseEncryption

--- a/jrnl/encryption/Jrnlv1Encryption.py
+++ b/jrnl/encryption/Jrnlv1Encryption.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import hashlib
 import logging
 

--- a/jrnl/encryption/Jrnlv1Encryption.py
+++ b/jrnl/encryption/Jrnlv1Encryption.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 import hashlib
 import logging

--- a/jrnl/encryption/Jrnlv2Encryption.py
+++ b/jrnl/encryption/Jrnlv2Encryption.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 import base64
 import logging

--- a/jrnl/encryption/Jrnlv2Encryption.py
+++ b/jrnl/encryption/Jrnlv2Encryption.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import base64
 import logging
 

--- a/jrnl/encryption/NoEncryption.py
+++ b/jrnl/encryption/NoEncryption.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 import logging
 

--- a/jrnl/encryption/NoEncryption.py
+++ b/jrnl/encryption/NoEncryption.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import logging
 
 from jrnl.encryption.BaseEncryption import BaseEncryption

--- a/jrnl/encryption/__init__.py
+++ b/jrnl/encryption/__init__.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from enum import Enum
 from importlib import import_module
 from typing import TYPE_CHECKING

--- a/jrnl/encryption/__init__.py
+++ b/jrnl/encryption/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 from enum import Enum
 from importlib import import_module

--- a/jrnl/exception.py
+++ b/jrnl/exception.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from typing import TYPE_CHECKING

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import contextlib

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 import logging
 import sys

--- a/jrnl/jrnl.py
+++ b/jrnl/jrnl.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import logging
 import sys
 from typing import TYPE_CHECKING

--- a/jrnl/keyring.py
+++ b/jrnl/keyring.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 import keyring
 
 from jrnl.messages import Message

--- a/jrnl/keyring.py
+++ b/jrnl/keyring.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 import keyring
 

--- a/jrnl/messages/Message.py
+++ b/jrnl/messages/Message.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from typing import TYPE_CHECKING

--- a/jrnl/messages/MsgStyle.py
+++ b/jrnl/messages/MsgStyle.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from enum import Enum

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from enum import Enum

--- a/jrnl/messages/__init__.py
+++ b/jrnl/messages/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from jrnl.messages import Message

--- a/jrnl/os_compat.py
+++ b/jrnl/os_compat.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import shlex

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import textwrap

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 from typing import TYPE_CHECKING
 

--- a/jrnl/override.py
+++ b/jrnl/override.py
@@ -1,5 +1,6 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
+
 from typing import TYPE_CHECKING
 
 from jrnl.config import make_yaml_valid_dict

--- a/jrnl/path.py
+++ b/jrnl/path.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os.path

--- a/jrnl/plugins/__init__.py
+++ b/jrnl/plugins/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from typing import Type

--- a/jrnl/plugins/dates_exporter.py
+++ b/jrnl/plugins/dates_exporter.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from collections import Counter

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import logging

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import sys

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import json

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/jrnl/plugins/tag_exporter.py
+++ b/jrnl/plugins/tag_exporter.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from typing import TYPE_CHECKING

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import errno

--- a/jrnl/plugins/util.py
+++ b/jrnl/plugins/util.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from typing import TYPE_CHECKING

--- a/jrnl/plugins/xml_exporter.py
+++ b/jrnl/plugins/xml_exporter.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from typing import TYPE_CHECKING

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/jrnl/prompt.py
+++ b/jrnl/prompt.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from jrnl.messages import Message

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import datetime

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import logging

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import json

--- a/tests/bdd/features/build.feature
+++ b/tests/bdd/features/build.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Build process

--- a/tests/bdd/features/change_time.feature
+++ b/tests/bdd/features/change_time.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Change entry times in journal

--- a/tests/bdd/features/config_file.feature
+++ b/tests/bdd/features/config_file.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Multiple journals

--- a/tests/bdd/features/core.feature
+++ b/tests/bdd/features/core.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Functionality of jrnl outside of actually handling journals

--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Reading and writing to journal with custom date formats

--- a/tests/bdd/features/delete.feature
+++ b/tests/bdd/features/delete.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Delete entries from journal

--- a/tests/bdd/features/encrypt.feature
+++ b/tests/bdd/features/encrypt.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Encrypting and decrypting journals

--- a/tests/bdd/features/file_storage.feature
+++ b/tests/bdd/features/file_storage.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Journals iteracting with the file system in a way that users can see

--- a/tests/bdd/features/format.feature
+++ b/tests/bdd/features/format.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Custom formats

--- a/tests/bdd/features/import.feature
+++ b/tests/bdd/features/import.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Importing data

--- a/tests/bdd/features/multiple_journals.feature
+++ b/tests/bdd/features/multiple_journals.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Multiple journals

--- a/tests/bdd/features/override.feature
+++ b/tests/bdd/features/override.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Implementing Runtime Overrides for Select Configuration Keys

--- a/tests/bdd/features/password.feature
+++ b/tests/bdd/features/password.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Using the installed keyring

--- a/tests/bdd/features/search.feature
+++ b/tests/bdd/features/search.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Searching in a journal

--- a/tests/bdd/features/star.feature
+++ b/tests/bdd/features/star.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Starring entries

--- a/tests/bdd/features/tag.feature
+++ b/tests/bdd/features/tag.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Tagging

--- a/tests/bdd/features/upgrade.feature
+++ b/tests/bdd/features/upgrade.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Upgrading Journals from 1.x.x to 2.x.x

--- a/tests/bdd/features/write.feature
+++ b/tests/bdd/features/write.feature
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 Feature: Writing new entries.

--- a/tests/bdd/test_features.py
+++ b/tests/bdd/test_features.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from pytest_bdd import scenarios

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from pytest import mark

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/tests/lib/given_steps.py
+++ b/tests/lib/given_steps.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import json

--- a/tests/lib/helpers.py
+++ b/tests/lib/helpers.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import functools

--- a/tests/lib/then_steps.py
+++ b/tests/lib/then_steps.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import json

--- a/tests/lib/when_steps.py
+++ b/tests/lib/when_steps.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/tests/unit/test_color.py
+++ b/tests/unit/test_color.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import pytest

--- a/tests/unit/test_config_file.py
+++ b/tests/unit/test_config_file.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import os

--- a/tests/unit/test_export.py
+++ b/tests/unit/test_export.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from unittest import mock

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import sys

--- a/tests/unit/test_jrnl.py
+++ b/tests/unit/test_jrnl.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import random

--- a/tests/unit/test_os_compat.py
+++ b/tests/unit/test_os_compat.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from unittest import mock

--- a/tests/unit/test_output.py
+++ b/tests/unit/test_output.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from unittest.mock import Mock

--- a/tests/unit/test_override.py
+++ b/tests/unit/test_override.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 from argparse import Namespace

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import shlex

--- a/tests/unit/test_path.py
+++ b/tests/unit/test_path.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import random

--- a/tests/unit/test_time.py
+++ b/tests/unit/test_time.py
@@ -1,4 +1,4 @@
-# Copyright © 2012-2022 jrnl contributors
+# Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
 import datetime


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
This updates the copyright notices on all the files to 2023 (from 2022):
```
Copyright © 2012-2023 jrnl contributors
License: https://www.gnu.org/licenses/gpl-3.0.html
```

It also standardizes the whitespace after the copyright notices to include one blank line (most files did this already, but a few did not).

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
