### PR TITLE
Refactor flow for easier access to some files (avoid things like `jrnl.Journal.Journal` and `jrnl.jrnl` co-existing)

### DIFF
--- a/jrnl/DayOneJournal.py
+++ b/jrnl/DayOneJournal.py
@@ -74,7 +74,8 @@ class DayOne(Journal.Journal):
                         self.config["tagsymbols"][0] + tag.lower()
                         for tag in dict_entry.get("Tags", [])
                     ]
-                    if entry._tags: entry._tags.sort()
+                    if entry._tags:
+                        entry._tags.sort()
 
                     """Extended DayOne attributes"""
                     # just ignore it if the keys don't exist
@@ -196,7 +197,8 @@ class DayOne(Journal.Journal):
 
         for entry in entries_from_editor:
             entry = self._get_and_remove_uuid_from_entry(entry)
-            if entry._tags: entry._tags.sort()
+            if entry._tags:
+                entry._tags.sort()
 
         # Remove deleted entries
         edited_uuids = [e.uuid for e in entries_from_editor]
@@ -207,7 +209,9 @@ class DayOne(Journal.Journal):
             for old_entry in self.entries:
                 if entry.uuid == old_entry.uuid:
                     if old_entry._tags:
-                        tags_not_in_body = [tag for tag in old_entry._tags if(tag not in entry._body)]
+                        tags_not_in_body = [
+                            tag for tag in old_entry._tags if (tag not in entry._body)
+                        ]
                         if tags_not_in_body:
                             entry._tags.extend(tags_not_in_body.sort())
                     self._update_old_entry(old_entry, entry)

--- a/jrnl/__main__.py
+++ b/jrnl/__main__.py
@@ -3,7 +3,7 @@
 
 import sys
 
-from jrnl.cli import cli
+from jrnl.main import run
 
 if __name__ == "__main__":
-    sys.exit(cli())
+    sys.exit(run())

--- a/jrnl/color.py
+++ b/jrnl/color.py
@@ -11,7 +11,7 @@ import colorama
 from jrnl.os_compat import on_windows
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
+    from jrnl.journals import Entry
 
 if on_windows():
     colorama.init()

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -69,7 +69,7 @@ def postconfig_list(args: argparse.Namespace, config: dict, **_) -> int:
 
 @cmd_requires_valid_journal_name
 def postconfig_import(args: argparse.Namespace, config: dict, **_) -> int:
-    from jrnl.Journal import open_journal
+    from jrnl.journals import open_journal
     from jrnl.plugins import get_importer
 
     # Requires opening the journal
@@ -90,7 +90,7 @@ def postconfig_encrypt(
     """
     from jrnl.config import update_config
     from jrnl.install import save_config
-    from jrnl.Journal import open_journal
+    from jrnl.journals import open_journal
 
     # Open the journal
     journal = open_journal(args.journal_name, config)
@@ -145,7 +145,7 @@ def postconfig_decrypt(
     """Decrypts into new file. If filename is not set, we encrypt the journal file itself."""
     from jrnl.config import update_config
     from jrnl.install import save_config
-    from jrnl.Journal import open_journal
+    from jrnl.journals import open_journal
 
     journal = open_journal(args.journal_name, config)
 

--- a/jrnl/controller.py
+++ b/jrnl/controller.py
@@ -15,8 +15,8 @@ from jrnl.config import scope_config
 from jrnl.editor import get_text_from_editor
 from jrnl.editor import get_text_from_stdin
 from jrnl.exception import JrnlException
-from jrnl.Journal import Journal
-from jrnl.Journal import open_journal
+from jrnl.journals import Journal
+from jrnl.journals import open_journal
 from jrnl.messages import Message
 from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
@@ -28,7 +28,7 @@ from jrnl.path import expand_path
 if TYPE_CHECKING:
     from argparse import Namespace
 
-    from jrnl.Entry import Entry
+    from jrnl.journals import Entry
 
 
 def start(args: "Namespace"):

--- a/jrnl/controller.py
+++ b/jrnl/controller.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from jrnl.journals import Entry
 
 
-def start(args: "Namespace"):
+def run(args: "Namespace"):
     """
     Flow:
     1. Run standalone command if it doesn't require config (help, version, etc), then exit

--- a/jrnl/controller.py
+++ b/jrnl/controller.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from jrnl.Entry import Entry
 
 
-def run(args: "Namespace"):
+def start(args: "Namespace"):
     """
     Flow:
     1. Run standalone command if it doesn't require config (help, version, etc), then exit

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -41,8 +41,8 @@ def upgrade_config(config_data: dict, alt_config_path: str | None = None) -> Non
     if missing_keys:
         for key in missing_keys:
             config_data[key] = default_config[key]
-        
-    different_version = (config_data["version"] != __version__)
+
+    different_version = config_data["version"] != __version__
     if different_version:
         config_data["version"] = __version__
 

--- a/jrnl/journals/DayOneJournal.py
+++ b/jrnl/journals/DayOneJournal.py
@@ -17,13 +17,14 @@ from xml.parsers.expat import ExpatError
 
 import tzlocal
 
-from jrnl import Entry
-from jrnl import Journal
 from jrnl import __title__
 from jrnl import __version__
 
+from .Entry import Entry
+from .Journal import Journal
 
-class DayOne(Journal.Journal):
+
+class DayOne(Journal):
     """A special Journal handling DayOne files"""
 
     # InvalidFileException was added to plistlib in Python3.4
@@ -63,7 +64,7 @@ class DayOne(Journal.Journal):
                     if timezone.key != "UTC":
                         date = date.replace(fold=1) + timezone.utcoffset(date)
 
-                    entry = Entry.Entry(
+                    entry = Entry(
                         self,
                         date,
                         text=dict_entry["Entry Text"],

--- a/jrnl/journals/Entry.py
+++ b/jrnl/journals/Entry.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING
 
 import ansiwrap
 
-from .color import colorize
-from .color import highlight_tags_with_background_color
+from jrnl.color import colorize
+from jrnl.color import highlight_tags_with_background_color
 
 if TYPE_CHECKING:
     from .Journal import Journal

--- a/jrnl/journals/FolderJournal.py
+++ b/jrnl/journals/FolderJournal.py
@@ -6,11 +6,12 @@ import fnmatch
 import os
 from typing import TYPE_CHECKING
 
-from jrnl import Journal
 from jrnl import time
 
+from .Journal import Journal
+
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
+    from jrnl.journals import Entry
 
 
 def get_files(journal_config: str) -> list[str]:
@@ -22,7 +23,7 @@ def get_files(journal_config: str) -> list[str]:
     return filenames
 
 
-class Folder(Journal.Journal):
+class Folder(Journal):
     """A Journal handling multiple files in a folder"""
 
     def __init__(self, name: str = "default", **kwargs):

--- a/jrnl/journals/Journal.py
+++ b/jrnl/journals/Journal.py
@@ -6,7 +6,6 @@ import logging
 import os
 import re
 
-from jrnl import Entry
 from jrnl import time
 from jrnl.config import validate_journal_name
 from jrnl.encryption import determine_encryption_method
@@ -16,6 +15,8 @@ from jrnl.messages import MsgText
 from jrnl.output import print_msg
 from jrnl.path import expand_path
 from jrnl.prompt import yesno
+
+from .Entry import Entry
 
 
 class Tag:
@@ -184,11 +185,11 @@ class Journal:
                 if entries:
                     entries[-1].text = journal_txt[last_entry_pos : match.start()]
                 last_entry_pos = match.end()
-                entries.append(Entry.Entry(self, date=new_date))
+                entries.append(Entry(self, date=new_date))
 
         # If no entries were found, treat all the existing text as an entry made now
         if not entries:
-            entries.append(Entry.Entry(self, date=time.parse("now")))
+            entries.append(Entry(self, date=time.parse("now")))
 
         # Fill in the text of the last entry
         entries[-1].text = journal_txt[last_entry_pos:]
@@ -354,7 +355,7 @@ class Journal:
         )
         if not date:  # Still nothing? Meh, just live in the moment.
             date = time.parse("now")
-        entry = Entry.Entry(self, date, raw, starred=starred)
+        entry = Entry(self, date, raw, starred=starred)
         entry.modified = True
         self.entries.append(entry)
         if sort:
@@ -410,7 +411,7 @@ class LegacyJournal(Journal):
                 else:
                     starred = False
 
-                current_entry = Entry.Entry(
+                current_entry = Entry(
                     self, date=new_date, text=line[date_length + 1 :], starred=starred
                 )
             except ValueError:
@@ -455,21 +456,21 @@ def open_journal(journal_name, config, legacy=False):
         if config["journal"].strip("/").endswith(".dayone") or "entries" in os.listdir(
             config["journal"]
         ):
-            from jrnl import DayOneJournal
+            from jrnl.journals import DayOne
 
-            return DayOneJournal.DayOne(**config).open()
+            return DayOne(**config).open()
         else:
-            from jrnl import FolderJournal
+            from jrnl.journals import Folder
 
-            return FolderJournal.Folder(journal_name, **config).open()
+            return Folder(journal_name, **config).open()
 
     if not config["encrypt"]:
         if legacy:
             return LegacyJournal(journal_name, **config).open()
         if config["journal"].endswith(os.sep):
-            from jrnl import FolderJournal
+            from jrnl.journals import Folder
 
-            return FolderJournal.Folder(journal_name, **config).open()
+            return Folder(journal_name, **config).open()
         return Journal(journal_name, **config).open()
 
     if legacy:

--- a/jrnl/journals/__init__.py
+++ b/jrnl/journals/__init__.py
@@ -1,0 +1,5 @@
+from .DayOneJournal import DayOne
+from .Entry import Entry
+from .FolderJournal import Folder
+from .Journal import Journal
+from .Journal import open_journal

--- a/jrnl/main.py
+++ b/jrnl/main.py
@@ -7,7 +7,7 @@ import traceback
 
 from rich.logging import RichHandler
 
-from jrnl import jrnl
+from jrnl import controller
 from jrnl.args import parse_args
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
@@ -41,7 +41,7 @@ def run(manual_args: list[str] | None = None) -> int:
         configure_logger(args.debug)
         logging.debug("Parsed args:\n%s", args)
 
-        status_code = jrnl.run(args)
+        status_code = controller.start(args)
 
     except JrnlException as e:
         status_code = 1

--- a/jrnl/main.py
+++ b/jrnl/main.py
@@ -7,9 +7,9 @@ import traceback
 
 from rich.logging import RichHandler
 
+from jrnl import jrnl
 from jrnl.args import parse_args
 from jrnl.exception import JrnlException
-from jrnl.jrnl import run
 from jrnl.messages import Message
 from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
@@ -32,7 +32,7 @@ def configure_logger(debug: bool = False) -> None:
     logging.debug("Logging start")
 
 
-def cli(manual_args: list[str] | None = None) -> int:
+def run(manual_args: list[str] | None = None) -> int:
     try:
         if manual_args is None:
             manual_args = sys.argv[1:]
@@ -41,7 +41,7 @@ def cli(manual_args: list[str] | None = None) -> int:
         configure_logger(args.debug)
         logging.debug("Parsed args:\n%s", args)
 
-        status_code = run(args)
+        status_code = jrnl.run(args)
 
     except JrnlException as e:
         status_code = 1

--- a/jrnl/main.py
+++ b/jrnl/main.py
@@ -41,7 +41,7 @@ def run(manual_args: list[str] | None = None) -> int:
         configure_logger(args.debug)
         logging.debug("Parsed args:\n%s", args)
 
-        status_code = controller.start(args)
+        status_code = controller.run(args)
 
     except JrnlException as e:
         status_code = 1

--- a/jrnl/plugins/dates_exporter.py
+++ b/jrnl/plugins/dates_exporter.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from jrnl.plugins.text_exporter import TextExporter
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
-    from jrnl.Journal import Journal
+    from jrnl.journals import Entry
+    from jrnl.journals import Journal
 
 
 class DatesExporter(TextExporter):

--- a/jrnl/plugins/fancy_exporter.py
+++ b/jrnl/plugins/fancy_exporter.py
@@ -13,8 +13,8 @@ from jrnl.messages import MsgText
 from jrnl.plugins.text_exporter import TextExporter
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
-    from jrnl.Journal import Journal
+    from jrnl.journals import Entry
+    from jrnl.journals import Journal
 
 
 class FancyExporter(TextExporter):

--- a/jrnl/plugins/jrnl_importer.py
+++ b/jrnl/plugins/jrnl_importer.py
@@ -11,7 +11,7 @@ from jrnl.messages import MsgText
 from jrnl.output import print_msg
 
 if TYPE_CHECKING:
-    from jrnl.Journal import Journal
+    from jrnl.journals import Journal
 
 
 class JRNLImporter:

--- a/jrnl/plugins/json_exporter.py
+++ b/jrnl/plugins/json_exporter.py
@@ -8,8 +8,8 @@ from jrnl.plugins.text_exporter import TextExporter
 from jrnl.plugins.util import get_tags_count
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
-    from jrnl.Journal import Journal
+    from jrnl.journals import Entry
+    from jrnl.journals import Journal
 
 
 class JSONExporter(TextExporter):

--- a/jrnl/plugins/markdown_exporter.py
+++ b/jrnl/plugins/markdown_exporter.py
@@ -12,8 +12,8 @@ from jrnl.output import print_msg
 from jrnl.plugins.text_exporter import TextExporter
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
-    from jrnl.Journal import Journal
+    from jrnl.journals import Entry
+    from jrnl.journals import Journal
 
 
 class MarkdownExporter(TextExporter):

--- a/jrnl/plugins/tag_exporter.py
+++ b/jrnl/plugins/tag_exporter.py
@@ -7,8 +7,8 @@ from jrnl.plugins.text_exporter import TextExporter
 from jrnl.plugins.util import get_tags_count
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
-    from jrnl.Journal import Journal
+    from jrnl.journals import Entry
+    from jrnl.journals import Journal
 
 
 class TagExporter(TextExporter):

--- a/jrnl/plugins/text_exporter.py
+++ b/jrnl/plugins/text_exporter.py
@@ -13,8 +13,8 @@ from jrnl.messages import MsgText
 from jrnl.output import print_msg
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
-    from jrnl.Journal import Journal
+    from jrnl.journals import Entry
+    from jrnl.journals import Journal
 
 
 class TextExporter:

--- a/jrnl/plugins/util.py
+++ b/jrnl/plugins/util.py
@@ -4,7 +4,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from jrnl.Journal import Journal
+    from jrnl.journals import Journal
 
 
 def get_tags_count(journal: "Journal") -> set[tuple[int, str]]:

--- a/jrnl/plugins/xml_exporter.py
+++ b/jrnl/plugins/xml_exporter.py
@@ -8,8 +8,8 @@ from jrnl.plugins.json_exporter import JSONExporter
 from jrnl.plugins.util import get_tags_count
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
-    from jrnl.Journal import Journal
+    from jrnl.journals import Entry
+    from jrnl.journals import Journal
 
 
 class XMLExporter(JSONExporter):

--- a/jrnl/plugins/yaml_exporter.py
+++ b/jrnl/plugins/yaml_exporter.py
@@ -13,8 +13,8 @@ from jrnl.output import print_msg
 from jrnl.plugins.text_exporter import TextExporter
 
 if TYPE_CHECKING:
-    from jrnl.Entry import Entry
-    from jrnl.Journal import Journal
+    from jrnl.journals import Entry
+    from jrnl.journals import Journal
 
 
 class YAMLExporter(TextExporter):
@@ -34,7 +34,7 @@ class YAMLExporter(TextExporter):
         body = body_wrapper + entry.body
 
         tagsymbols = entry.journal.config["tagsymbols"]
-        # see also Entry.Entry.rag_regex
+        # see also Entry.rag_regex
         multi_tag_regex = re.compile(rf"(?u)^\s*([{tagsymbols}][-+*#/\w]+\s*)+$")
 
         """Increase heading levels in body text"""

--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -4,12 +4,13 @@
 import logging
 import os
 
-from jrnl import Journal
 from jrnl import __version__
 from jrnl.config import is_config_json
 from jrnl.config import load_config
 from jrnl.config import scope_config
 from jrnl.exception import JrnlException
+from jrnl.journals import Journal
+from jrnl.journals import open_journal
 from jrnl.messages import Message
 from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
@@ -129,14 +130,14 @@ def upgrade_jrnl(config_path: str) -> None:
         )
 
         backup(path, binary=True)
-        old_journal = Journal.open_journal(
+        old_journal = open_journal(
             journal_name, scope_config(config, journal_name), legacy=True
         )
 
         logging.debug(f"Clearing encryption method for '{journal_name}' journal")
 
         # Update the encryption method
-        new_journal = Journal.Journal.from_journal(old_journal)
+        new_journal = Journal.from_journal(old_journal)
         new_journal.config["encrypt"] = "jrnlv2"
         new_journal._get_encryption_method()
         # Copy over password (jrnlv1 only supported password-based encryption)
@@ -156,10 +157,10 @@ def upgrade_jrnl(config_path: str) -> None:
         )
 
         backup(path)
-        old_journal = Journal.open_journal(
+        old_journal = open_journal(
             journal_name, scope_config(config, journal_name), legacy=True
         )
-        all_journals.append(Journal.Journal.from_journal(old_journal))
+        all_journals.append(Journal.from_journal(old_journal))
 
     # loop through lists to validate
     failed_journals = [j for j in all_journals if not j.validate_parsing()]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ tox = "*"
 xmltodict = "*"
 
 [tool.poetry.scripts]
-jrnl = 'jrnl.cli:cli'
+jrnl = 'jrnl.main:run'
 
 [tool.poe.tasks]
 docs-check.default_item_type = "script"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,8 @@ pycodestyle = [
 "flake8-*" = ["+*"]
 flake8-black = ["-BLK901"]
 
+[tool.flakeheaven.exceptions."jrnl/journals/__init__.py"]
+pyflakes = ["-F401"]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -144,7 +144,7 @@ def mock_overrides(config_in_memory):
 
     return {
         "overrides": lambda: patch(
-            "jrnl.jrnl.apply_overrides", side_effect=my_overrides
+            "jrnl.controller.apply_overrides", side_effect=my_overrides
         )
     }
 

--- a/tests/lib/when_steps.py
+++ b/tests/lib/when_steps.py
@@ -8,7 +8,7 @@ from pytest_bdd import when
 from pytest_bdd.parsers import parse
 from pytest_bdd.parsers import re
 
-from jrnl.cli import cli
+from jrnl.main import run
 
 
 @when(parse('we change directory to "{directory_name}"'))
@@ -44,7 +44,7 @@ def we_run_jrnl(cli_run, capsys, keyring):
             mocks[id] = stack.enter_context(factories[id]())
 
         try:
-            cli_run["status"] = cli() or 0
+            cli_run["status"] = run() or 0
         except StopIteration:
             # This happens when input is expected, but don't have any input left
             pass

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -19,10 +19,10 @@ def random_string():
 
 @pytest.mark.parametrize("export_format", ["pretty", "short"])
 @mock.patch("builtins.print")
-@mock.patch("jrnl.Journal.Journal.pprint")
+@mock.patch("jrnl.controller.Journal.pprint")
 def test_display_search_results_pretty_short(mock_pprint, mock_print, export_format):
     mock_args = parse_args(["--format", export_format])
-    test_journal = mock.Mock(wraps=jrnl.Journal.Journal)
+    test_journal = mock.Mock(wraps=jrnl.journals.Journal)
 
     _display_search_results(mock_args, test_journal)
 
@@ -40,7 +40,7 @@ def test_display_search_results_builtin_plugins(
     test_filename = random_string
     mock_args = parse_args(["--format", export_format, "--file", test_filename])
 
-    test_journal = mock.Mock(wraps=jrnl.Journal.Journal)
+    test_journal = mock.Mock(wraps=jrnl.journals.Journal)
     mock_export = mock.Mock()
     mock_exporter.return_value.export = mock_export
 

--- a/tests/unit/test_controller.py
+++ b/tests/unit/test_controller.py
@@ -9,7 +9,7 @@ import pytest
 
 import jrnl
 from jrnl.args import parse_args
-from jrnl.jrnl import _display_search_results
+from jrnl.controller import _display_search_results
 
 
 @pytest.fixture


### PR DESCRIPTION
This fixes a few issues with file naming in the codebase. Mainly, we want to avoid things like `jrnl.Journal.Journal` co-existing with `jrnl.jrnl` because it leads to a lot of confusion when talking about the code, and for new contributors. This doesn't fix everything, but gets the ball rolling on some quality-of-life fixes.

- rename `cli.py` to `main.py`
- rename `jrnl.py` to `controller.py`
- move journal class files into `journals` dir

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
