### PR TITLE
Update documentation on temporary files naming

### DIFF
--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -78,7 +78,7 @@ unencrypted temporary remains on your disk. If your computer were to shut off
 during this time, or the `jrnl` process were killed unexpectedly, then the
 unencrypted temporary file will remain on your disk. You can mitigate this
 issue by only saving with your editor right before closing it. You can also
-manually delete these files (i.e. files named `jrnl_*.txt`) from your temporary
+manually delete these files (i.e. files named `jrnl*.jrnl`) from your temporary
 folder.
 
 ## Plausible deniability


### PR DESCRIPTION
According to the [documentation](https://jrnl.sh/en/stable/privacy-and-security/#files-in-transit-from-editor-to-jrnl), temporary files are named `jrnl_*.txt`.
Actually, from #1139, temporary files are named `jrnl*.jrnl`.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
