### PR TITLE
Add documentation about information leaks in Vim/Neovim

### DIFF
--- a/docs/external-editors.md
+++ b/docs/external-editors.md
@@ -37,6 +37,9 @@ jrnl yesterday: All my troubles seemed so far away. --edit
 
 All editors must be [blocking processes](https://en.wikipedia.org/wiki/Blocking_(computing)) to work with jrnl. Some editors, such as [micro](https://micro-editor.github.io/), are blocking by default, though others can be made to block with additional arguments, such as many of those documented below. If jrnl opens your editor but finishes running immediately, then your editor is not a blocking process, and you may be able to correct that with one of the suggestions below.
 
+Please see [this section](./privacy-and-security.md#editor-history) about how
+your editor might leak sensitive information and how to mitigate that risk.
+
 ## Sublime Text
 
 To use [Sublime Text](https://www.sublimetext.com/), install the command line

--- a/docs/external-editors.md
+++ b/docs/external-editors.md
@@ -71,6 +71,17 @@ back to journal. In the case of MacVim, this is `-f`:
 editor: "mvim -f"
 ```
 
+## Vim/Neovim
+
+To use any of the Vim derivatives as editor in Linux, simply set the `editor`
+to the executable:
+
+```yaml
+editor: "vim"
+# or
+editor: "nvim"
+```
+
 ## iA Writer
 
 On OS X, you can use the fabulous [iA

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -90,7 +90,7 @@ editor: "vim -c 'set viminfo= noswapfile noundofile nobackup nowritebackup noshe
 
 To disable all plugins and custom configurations and start Vim with the default
 configuration `-u NONE` can be passed on the command line as well. This will
-ensure that any rouge plugins or other difficult to catch information leaks are
+ensure that any rogue plugins or other difficult to catch information leaks are
 eliminated. The downside to this is that the editor experience will decrease
 quite a bit.
 

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -67,6 +67,84 @@ Windows doesn't log history to disk, but it does keep it in your command prompt
 session. Close the command prompt or press `Alt`+`F7` to clear your history
 after journaling.
 
+## Editor history
+
+Some editors keep usage history stored on disk for future use. This can be a
+security risk in the sense that sensitive information can leak via recent
+search patterns or editor commands.
+
+### Vim
+
+Vim stores progress data in a so called Viminfo file located at `~/.viminfo`
+which contains all sorts of user data including command line history, search
+string history, search/substitute patterns, contents of register etc. Also to
+be able to recover opened files after an unexpected application close Vim uses
+swap files.
+
+These options as well as other leaky features can be disabled by setting the
+`editor` key in the Jrnl settings like this:
+
+``` yaml
+editor: "vim -c 'set viminfo= noswapfile noundofile nobackup nowritebackup noshelltemp history=0 nomodeline secure'"
+```
+
+To disable all plugins and custom configurations and start Vim with the default
+configuration `-u NONE` can be passed on the command line as well. This will
+ensure that any rouge plugins or other difficult to catch information leaks are
+eliminated. The downside to this is that the editor experience will decrease
+quite a bit.
+
+To instead let Vim automatically detect when a Jrnl file is being edited an
+autocommand can be used. Place this in your `~/.vimrc`:
+
+``` vim
+autocmd BufNewFile,BufReadPre *.jrnl setlocal viminfo= noswapfile noundofile nobackup nowritebackup noshelltemp history=0 nomodeline secure
+```
+
+Please see `:h <option>` in Vim for more information about the options mentioned.
+
+### Neovim
+
+Neovim strives to be mostly compatible with Vim and has therefore similar
+functionality as Vim. One difference in Neovim is that the Viminfo file is
+instead called the ShaDa ("shared data") file which resides in
+`~/.local/state/nvim` (`~/.local/share/nvim` pre Neovim v0.8.0). The ShaDa file
+can be disabled in the same way as for Vim.
+
+``` yaml
+editor: "nvim -c 'set shada= noswapfile noundofile nobackup nowritebackup noshelltemp history=0 nomodeline secure'"
+```
+
+`-u NONE` can be passed here as well to start a session with the default configs.
+
+As for Vim above we can create an autocommand in Vimscript:
+
+``` vim
+autocmd BufNewFile,BufReadPre *.jrnl setlocal shada= noswapfile noundofile nobackup nowritebackup noshelltemp history=0 nomodeline secure
+```
+
+or the same but in Lua:
+
+``` lua
+vim.api.nvim_create_autocmd( {"BufNewFile","BufReadPre" }, {
+  group = vim.api.nvim_create_augroup("PrivateJrnl", {}),
+  pattern = "*.jrnl",
+  callback = function()
+    vim.o.shada = ""
+    vim.o.swapfile = false
+    vim.o.undofile = false
+    vim.o.backup = false
+    vim.o.writebackup = false
+    vim.o.shelltemp = false
+    vim.o.history = 0
+    vim.o.modeline = false
+    vim.o.secure = true
+  end,
+})
+```
+
+Please see `:h <option>` in Neovim for more information about the options mentioned.
+
 ## Files in transit from editor to jrnl
 
 When creating or editing an entry, `jrnl` uses a unencrypted temporary file on


### PR DESCRIPTION
### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] **(found none)** I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] **(not needed)** I have written new tests for these changes, as needed. 
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->

This PR aims to increase the knowledge about "leaky editors" and how to mitigate that risk. I have only experience in Vim-like editors, but this could be a base for future docs about other editors as well.

***Note:** This is a re-creation of my first PR #1603 as per request.*