### PR TITLE
Document `-tagged`, `-not -tagged`, and `-not -starred`

### DIFF
--- a/docs/reference-command-line.md
+++ b/docs/reference-command-line.md
@@ -76,8 +76,11 @@ entries, such as `yesterday`, `today`, `Tuesday`, or `2021-08-01`.
 | -contains TEXT | Show entries containing specific text (put quotes around text with spaces) |
 | -and | Show only entries that match all conditions, like saying "x AND y" (default: OR) |
 | -starred | Show only starred entries (marked with *) |
+| -tagged | Show only tagged entries (marked with the [configured tagsymbols](reference-config-file.md#tagsymbols)) |
 | -n [NUMBER] | Show a maximum of NUMBER entries (note: '-n 3' and '-3' have the same effect) |
 | -not [TAG] | Exclude entries with this tag |
+| -not -starred | Exclude entries that are starred |
+| -not -tagged | Exclude entries that are tagged |
 
 ## Searching Options
 These help you do various tasks with the selected entries from your search.


### PR DESCRIPTION
Fixes #1668. Documents the behavior modified in #1663.

In the long run, I think we'll want a more polymorphic approach to documenting `-not`, but since it only supports three different inputs and two of them are already search arguments, I thought it best to keep it all separate for now. This also helps with the table layout on the site, since it can't be widened nicely in our current docs style.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
