### PR TITLE
Document temporary file extension behavior when using template

### DIFF
--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -67,6 +67,22 @@ Windows doesn't log history to disk, but it does keep it in your command prompt
 session. Close the command prompt or press `Alt`+`F7` to clear your history
 after journaling.
 
+## Files in transit from editor to jrnl
+
+When creating or editing an entry, `jrnl` uses a unencrypted temporary file on
+disk in order to give your editor access to your journal. After you close your
+editor, `jrnl` then deletes this temporary file.
+
+So, if you have saved a journal entry but haven't closed your editor yet, the
+unencrypted temporary remains on your disk. If your computer were to shut off
+during this time, or the `jrnl` process were killed unexpectedly, then the
+unencrypted temporary file will remain on your disk. You can mitigate this
+issue by only saving with your editor right before closing it. You can also
+manually delete these files from your temporary folder. By default, they
+are named `jrnl*.jrnl` but if you use a
+[template](reference-config-file.md#template), they will have the same
+extension as the template.
+
 ## Editor history
 
 Some editors keep usage history stored on disk for future use. This can be a
@@ -83,7 +99,8 @@ the `workbench.localHistory.enabled` setting in the
 Alternatively, you can disable this feature for specific files by configuring a
 [pattern](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options)
 in the `workbench.localHistory.exclude` setting. To exclude unencrypted temporary files generated
-by `jrnl`, you can set the `**/jrnl*.jrnl` pattern for the `workbench.localHistory.exclude` setting
+by `jrnl`, you can set the `**/jrnl*.jrnl` (unless you are using a
+[template](reference-config-file.md#template)) pattern for the `workbench.localHistory.exclude` setting
 in the [Settings editor](https://code.visualstudio.com/docs/getstarted/settings#_settings-editor).
 
 !!! note
@@ -129,7 +146,11 @@ autocommand can be used. Place this in your `~/.vimrc`:
 autocmd BufNewFile,BufReadPre *.jrnl setlocal viminfo= noswapfile noundofile nobackup nowritebackup noshelltemp history=0 nomodeline secure
 ```
 
-Please see `:h <option>` in Vim for more information about the options mentioned.
+!!! note
+    If you're using a [template](reference-config-file.md#template), you will
+    have to use the template's file extension instead of `.jrnl`.
+
+See `:h <option>` in Vim for more information about the options mentioned.
 
 ### Neovim
 
@@ -171,23 +192,11 @@ vim.api.nvim_create_autocmd( {"BufNewFile","BufReadPre" }, {
 })
 ```
 
+!!! note
+    If you're using a [template](reference-config-file.md#template), you will
+    have to use the template's file extension instead of `.jrnl`.
+
 Please see `:h <option>` in Neovim for more information about the options mentioned.
-
-## Files in transit from editor to jrnl
-
-When creating or editing an entry, `jrnl` uses a unencrypted temporary file on
-disk in order to give your editor access to your journal. After you close your
-editor, `jrnl` then deletes this temporary file.
-
-So, if you have saved a journal entry but haven't closed your editor yet, the
-unencrypted temporary remains on your disk. If your computer were to shut off
-during this time, or the `jrnl` process were killed unexpectedly, then the
-unencrypted temporary file will remain on your disk. You can mitigate this
-issue by only saving with your editor right before closing it. You can also
-manually delete these files from your temporary folder. By default, they
-are named `jrnl*.jrnl` but if you use a
-[template](reference-config-file.md#template), they will have the same
-extension as the template.
 
 ## Plausible deniability
 

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -184,8 +184,10 @@ unencrypted temporary remains on your disk. If your computer were to shut off
 during this time, or the `jrnl` process were killed unexpectedly, then the
 unencrypted temporary file will remain on your disk. You can mitigate this
 issue by only saving with your editor right before closing it. You can also
-manually delete these files (i.e. files named `jrnl*.jrnl`) from your temporary
-folder.
+manually delete these files from your temporary folder. By default, they
+are named `jrnl*.jrnl` but if you use a
+[template](reference-config-file.md#template), they will have the same
+extension as the template.
 
 ## Plausible deniability
 

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -79,7 +79,7 @@ during this time, or the `jrnl` process were killed unexpectedly, then the
 unencrypted temporary file will remain on your disk. You can mitigate this
 issue by only saving with your editor right before closing it. You can also
 manually delete these files from your temporary folder. By default, they
-are named `jrnl*.jrnl` but if you use a
+are named `jrnl*.jrnl`, but if you use a
 [template](reference-config-file.md#template), they will have the same
 extension as the template.
 

--- a/docs/reference-config-file.md
+++ b/docs/reference-config-file.md
@@ -59,7 +59,9 @@ value for journals that already have data in them.
 
 ### template
 The path to a text file to use as a template for new entries. Only works when you
-have the `editor` field configured.
+have the `editor` field configured. If you use a template, the editor's
+[temporary files](privacy-and-security.md#files-in-transit-from-editor-to-jrnl)
+will have the same extension as the template.
 
 ### tagsymbols
 Symbols to be interpreted as tags.


### PR DESCRIPTION
Fixes #1677.

I feel that that some of the additions I've made are a bit redundant, but I think the redundancy might be good, since I really don't want anyone missing this information while trying to protect their privacy.

Also, I moved the "Files in transit from editor to jrnl" section above the editor instructions, since those instructions are based on understanding that concept.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
