### PR TITLE
Add message with config location and docs location when installation is complete

### DIFF
--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -154,6 +154,15 @@ def install() -> dict:
         default_config["colors"] = get_default_colors()
 
     save_config(default_config)
+
+    print_msg(
+        Message(
+            MsgText.InstallComplete,
+            MsgStyle.NORMAL,
+            params={"config_path": get_config_path()},
+        )
+    )
+
     return default_config
 
 

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -28,6 +28,11 @@ class MsgText(Enum):
 
     AllDoneUpgrade = "We're all done here and you can start enjoying jrnl 2"
 
+    InstallComplete = """
+        jrnl configuration created at {config_path}
+        For advanced features, read the docs at https://jrnl.sh
+    """
+
     # --- Prompts --- #
     InstallJournalPathQuestion = """
         Path to your journal file (leave blank for {default_journal_path}):

--- a/tests/bdd/features/install.feature
+++ b/tests/bdd/features/install.feature
@@ -6,7 +6,9 @@ Feature: Installing jrnl
             \n
             \n
             \n
-        Then the output should contain "Journal 'default' created"
+        Then the output should contain "jrnl configuration created at"
+        And the output should contain "For advanced features, read the docs at https://jrnl.sh"
+        And the output should contain "Journal 'default' created"
         And the default journal "journal.txt" should be in the "." directory
         And the config should contain "encrypt: false"
         And the version in the config file should be up-to-date


### PR DESCRIPTION
Fixes #1694.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/CONTRIBUTING.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
