### PR TITLE
Lock ruamel.yaml version to v0.17.21 until bug is fixed

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1969,4 +1969,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10.0, <3.13"
-content-hash = "dfc32ee61025dae6033987a8ff8290d4c2a34197502b8030cef02db58b86baf1"
+content-hash = "1306520c524e8cf20ca672e3b77eb0aa1fcc67e5994c86bd99a293415a0795b8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ keyring = ">=21.0"       # https://github.com/jaraco/keyring#integration
 parsedatetime = ">=2.6"
 python-dateutil = "^2.8" # https://github.com/dateutil/dateutil/blob/master/RELEASING
 pyxdg = ">=0.27.0"
-"ruamel.yaml" = "^0.17.21"
+"ruamel.yaml" = "0.17.21" # locked to this version until bug is resolved: https://github.com/jrnl-org/jrnl/issues/1736
 rich = ">=12.2.0, <14.0.0"
 
 # dayone-only deps


### PR DESCRIPTION
This locks the ruamel.yaml version to `0.17.21` until bug is fixed (was introduced in `0.17.22`. This gets our pipelines to pass for the moment (cc: #1736). 

I'll update this with a reference to the issue with ruamel.yaml when it's filed.