### PR TITLE
Run pipeline tests weekly

### DIFF
--- a/.github/workflows/testing_pipelines.yaml
+++ b/.github/workflows/testing_pipelines.yaml
@@ -14,6 +14,8 @@ on:
     paths:
     - '.github/workflows/**'
     - '.github/actions/**'
+  schedule:
+    - cron: '0 0 * * SAT'
 
 jobs:
   test:


### PR DESCRIPTION
We recently had an issue with actionlint tests failing in a pipeline (#1719). This wasn't related to the PR itself, but was likely a different issue that we didn't notice since we don't run these tests regularly (only when certain files have changed). This PR runs these tests weekly (along with the other scheduled tests), so we'll hopefully catch these issues sooner in the future.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
