### PR TITLE
Add note about messages going to `stderr` and the implication for piping

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -118,8 +118,8 @@ programs. Even so, they can still be used in the same way as any other format (l
 written to a file, or displayed in your terminal, if you want).
 
 !!! note
-While you may see boxed messages like "2 entries found" when using these formats,
-those messages are written to STDERR instead of STDOUT, and won't be piped when
+You may see boxed messages like "2 entries found" when using these formats, but
+those messages are written to `stderr` instead of `stdout`, and won't be piped when
 using the `|` operator.
 
 ### JSON

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -119,7 +119,7 @@ written to a file, or displayed in your terminal, if you want).
 
 !!! note
 While you may see boxed messages like "2 entries found" when using these formats,
-those messages are exported to STDERR instead of STDOUT, and won't be piped when
+those messages are written to STDERR instead of STDOUT, and won't be piped when
 using the `|` operator.
 
 ### JSON

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -117,6 +117,11 @@ These formats are mainly intended for piping or exporting your journal to other
 programs. Even so, they can still be used in the same way as any other format (like
 written to a file, or displayed in your terminal, if you want).
 
+!!! note
+While you may see boxed messages like "2 entries found" when using these formats,
+those messages are exported to STDERR instead of STDOUT, and won't be piped when
+using the `|` operator.
+
 ### JSON
 
 ``` sh


### PR DESCRIPTION
This PR adds a note in the "Data Formats" section of the docs about which data goes to `stdout` vs `stderr`.

While this is standard behavior for console apps, we have gotten a few issues about the record count messages appearing to interfere with piping because people weren't aware of this, so I'm hoping that this will help.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
