### PR TITLE
Allow custom file extensions for directory-based journal

### DIFF
--- a/jrnl/journals/FolderJournal.py
+++ b/jrnl/journals/FolderJournal.py
@@ -4,6 +4,7 @@
 import codecs
 import os
 import pathlib
+import re
 from typing import TYPE_CHECKING
 
 from jrnl import time
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
 DIGIT_PATTERN = "[0123456789]"
 YEAR_PATTERN = DIGIT_PATTERN * 4
 MONTH_PATTERN = "[01]" + DIGIT_PATTERN
-DAY_PATTERN = "[0123]" + DIGIT_PATTERN + ".txt"
+DAY_PATTERN = "[0-3][0-9].(txt|md)"
 
 
 class Folder(Journal):
@@ -144,9 +145,11 @@ class Folder(Journal):
 
     @staticmethod
     def _get_day_files(path: pathlib.Path) -> list[str]:
-        for child in path.glob(DAY_PATTERN):
+        for child in path.iterdir():
+            match = re.search(DAY_PATTERN, str(child))
             if (
-                int(child.stem) > 0
+                match is not None
+                and int(child.stem) > 0
                 and int(child.stem) <= 31
                 and time.is_valid_date(
                     year=int(path.parent.name),

--- a/jrnl/journals/FolderJournal.py
+++ b/jrnl/journals/FolderJournal.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
 DIGIT_PATTERN = "[0123456789]"
 YEAR_PATTERN = DIGIT_PATTERN * 4
 MONTH_PATTERN = "[01]" + DIGIT_PATTERN
-DAY_PATTERN = "[0-3][0-9].(txt|md)"
 
 
 class Folder(Journal):
@@ -35,7 +34,7 @@ class Folder(Journal):
         self.entries = []
 
         if os.path.exists(self.config["journal"]):
-            filenames = Folder._get_files(self.config["journal"])
+            filenames = Folder._get_files(self, self.config["journal"])
             for filename in filenames:
                 with codecs.open(filename, "r", "utf-8") as f:
                     journal = f.read()
@@ -46,6 +45,8 @@ class Folder(Journal):
 
     def write(self) -> None:
         """Writes only the entries that have been modified into proper files."""
+        if self.config["extension"] is not None:
+            EXTENSION = self.config["extension"]
         # Create a list of dates of modified entries. Start with diff_entry_dates
         modified_dates = self._diff_entry_dates
         seen_dates = set(self._diff_entry_dates)
@@ -64,7 +65,7 @@ class Folder(Journal):
                 self.config["journal"],
                 d.strftime("%Y"),
                 d.strftime("%m"),
-                d.strftime("%d") + ".txt",
+                d.strftime("%d") + "." + EXTENSION,
             )
             dirname = os.path.dirname(filename)
             # create directory if it doesn't exist
@@ -82,7 +83,7 @@ class Folder(Journal):
                 journal_file.write(journal)
         # look for and delete empty files
         filenames = []
-        filenames = Folder._get_files(self.config["journal"])
+        filenames = Folder._get_files(self, self.config["journal"])
         for filename in filenames:
             if os.stat(filename).st_size <= 0:
                 os.remove(filename)
@@ -122,12 +123,14 @@ class Folder(Journal):
         self.entries = mod_entries
 
     @staticmethod
-    def _get_files(journal_path: str) -> list[str]:
+    def _get_files(self, journal_path: str) -> list[str]:
         """Searches through sub directories starting with journal_path and find all text
         files that look like entries"""
+        if self.config["extension"] is not None:
+            EXTENSION = self.config["extension"]
         for year_folder in Folder._get_year_folders(pathlib.Path(journal_path)):
             for month_folder in Folder._get_month_folders(year_folder):
-                yield from Folder._get_day_files(month_folder)
+                yield from Folder._get_day_files(self, EXTENSION, month_folder)
 
     @staticmethod
     def _get_year_folders(path: pathlib.Path) -> list[pathlib.Path]:
@@ -144,9 +147,11 @@ class Folder(Journal):
         return
 
     @staticmethod
-    def _get_day_files(path: pathlib.Path) -> list[str]:
+    def _get_day_files(self, extension, path: pathlib.Path) -> list[str]:
+        EXTENSION = extension
+        DAY_PATTERN = "[0-3][0-9]." + EXTENSION
         for child in path.iterdir():
-            match = re.search(DAY_PATTERN, str(child))
+            match = re.fullmatch(DAY_PATTERN, str(child.name))
             if (
                 match is not None
                 and int(child.stem) > 0


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

This PR seeks to resolve #1289, which I opened a while back. This PR utilizes a new config option `extension` which permits the user to change the file extensionNow, when a directory-based journal is searched or a new entry is created, jrnl will recognize files with the custom file extension or create a file using the custom file extension, respectively.

This PR makes use of regex for the filename recognition.

A previous version of this code attempted to implement the possibility to use an array of extensions, but eventually I bumped into the rigid structure alluded to in https://github.com/jrnl-org/jrnl/issues/1289#issuecomment-876170381. I reviewed the code in order to understand what was happening. Now that I understand what the code is doing, I see that implementing an array would require a much larger amount of work. A single file extension change should be much more manageable at this time.[^0]

I have tested basic functionality and the code is working, but this PR is flagged as a draft because I have to learn how to handle output from `poe test` and then review that output. I am opening this PR as draft in order to share my work and to receive help.

```
=========== 111 failed, 528 passed, 40 skipped in 72.57s (0:01:12) ===========
```

When setting "extension: txt", I get:

```
=========== 111 failed, 528 passed, 40 skipped in 74.00s (0:01:14) ===========
```

Several of these appear to be related to me having to pass along additional positional arguments. Hopefully I can resolve these with time.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->

---

[^0]: For posterity's sake, when implementing an array of extensions, I found that the code worked—except and unless there are multiple files on the same day with different extensions. The code is looking for a single file extension in part because once the entries are read from the files, the file paths are no longer passed along to the rest of the code, rather the file paths are retrieved and then reassigned. And so when attempting to use such functionality, the `--delete` option more or less no longer functions properly—not on .txt files or the first extension set in the config file—but on additional extensions beyond these. Without being able to specify the file, the delete option ceases working as intended. Perhaps to summarize, jrnl's internal code operates off of journal entries, not off of files.