### PR TITLE
Set new required build fields in the ReadTheDocs config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,9 @@ version: 2
 # Set the OS
 build:
   os: ubuntu-22.04
+  tools:
+    python: 3
+
 
 # Build documentation in the docs/ directory
 mkdocs:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: 3
+    python: "3"
 
 
 # Build documentation in the docs/ directory

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,10 @@
 # Required
 version: 2
 
+# Set the OS
+build:
+  os: ubuntu-22.04
+
 # Build documentation in the docs/ directory
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

[ReadTheDocs is warning us that we need to add build.os to our configuration file](https://blog.readthedocs.com/use-build-os-config/) before October 16. This PR makes the change by selecting the latest available Ubuntu version.

Edit: Turns out they need build.tools.python as well, so I'm setting that here too. I think setting to "3" for the latest version of Python 3 is acceptable for documentation builds, rather than pinning to a specific version, but I'm open to changing it.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
