### PR TITLE
Resolve parsedatetime "flag style" DeprecationWarning

### DIFF
--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -77,7 +77,7 @@ def parse(
             return None
 
     if hasDate and not hasTime:
-        date = datetime.datetime( # Use the default time
+        date = datetime.datetime(  # Use the default time
             *date[:3],
             hour=23 if inclusive else default_hour or 0,
             minute=59 if inclusive else default_minute or 0,

--- a/jrnl/time.py
+++ b/jrnl/time.py
@@ -9,14 +9,11 @@ DEFAULT_PAST = datetime.datetime(FAKE_YEAR, 1, 1, 0, 0)
 
 
 def __get_pdt_calendar():
-    try:
-        import parsedatetime.parsedatetime_consts as pdt
-    except ImportError:
-        import parsedatetime as pdt
+    import parsedatetime as pdt
 
     consts = pdt.Constants(usePyICU=False)
     consts.DOWParseStyle = -1  # "Monday" will be either today or the last Monday
-    calendar = pdt.Calendar(consts)
+    calendar = pdt.Calendar(consts, version=pdt.VERSION_CONTEXT_STYLE)
 
     return calendar
 
@@ -42,6 +39,10 @@ def parse(
     default_date = DEFAULT_FUTURE if inclusive else DEFAULT_PAST
     date = None
     year_present = False
+
+    hasTime = False
+    hasDate = False
+
     while not date:
         try:
             from dateutil.parser import parse as dateparse
@@ -53,7 +54,8 @@ def parse(
                 )
             else:
                 year_present = True
-            flag = 1 if date.hour == date.minute == 0 else 2
+            hasTime = not (date.hour == date.minute == 0)
+            hasDate = True
             date = date.timetuple()
         except Exception as e:
             if e.args[0] == "day is out of range for month":
@@ -61,9 +63,11 @@ def parse(
                 default_date = datetime.datetime(y, m, d - 1, H, M, S)
             else:
                 calendar = __get_pdt_calendar()
-                date, flag = calendar.parse(date_str)
+                date, parse_context = calendar.parse(date_str)
+                hasTime = parse_context.hasTime
+                hasDate = parse_context.hasDate
 
-    if not flag:  # Oops, unparsable.
+    if not hasDate and not hasTime:
         try:  # Try and parse this as a single year
             year = int(date_str)
             return datetime.datetime(year, 1, 1)
@@ -72,8 +76,8 @@ def parse(
         except TypeError:
             return None
 
-    if flag == 1:  # Date found, but no time. Use the default time.
-        date = datetime.datetime(
+    if hasDate and not hasTime:
+        date = datetime.datetime( # Use the default time
             *date[:3],
             hour=23 if inclusive else default_hour or 0,
             minute=59 if inclusive else default_minute or 0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,6 @@ addopts = [
 
 filterwarnings = [
     "ignore::DeprecationWarning",
-    "ignore:Flag style will be deprecated in.*",
     "ignore:[WinError 32].*",
     "ignore:[WinError 5].*"
 ]


### PR DESCRIPTION
Fixes #1817. Makes `time.py` slightly more readable with named booleans instead of that "flag" and its magic numbers.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
