### PR TITLE
Force rich to use color codes when pretty printing

### DIFF
--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -136,7 +136,7 @@ def format_msg_text(msg: Message) -> Text:
 def wrap_with_ansi_colors(text: str, width: int) -> str:
     richtext = Text.from_ansi(text, no_wrap=False, tab_size=None)
 
-    console = Console(width=width)
+    console = Console(width=width, no_color=False)
     with console.capture() as capture:
         console.print(richtext, sep="", end="")
     return capture.get()

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -136,7 +136,7 @@ def format_msg_text(msg: Message) -> Text:
 def wrap_with_ansi_colors(text: str, width: int) -> str:
     richtext = Text.from_ansi(text, no_wrap=False, tab_size=None)
 
-    console = Console(width=width, no_color=False)
+    console = Console(width=width, force_terminal=True)
     with console.capture() as capture:
         console.print(richtext, sep="", end="")
     return capture.get()


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

Fixes #1819.

When piping, `rich`'s default behavior is to suppress color codes. This is very useful except in the particular scenario that we want to use rich to wrap text with color codes, which happens to be the situation that we're using rich in since #1693. This PR forces rich to supply codes by treating it as a terminal.

Unfortunately, I don't see how to test this automatically, but I was able to manually verify this with the following steps in WSL/Ubuntu from the jrnl source root:

```
poetry build
pipx uninstall jrnl
pipx install ./dist/jrnl-4.1b0-py3-none-any.whl
jrnl_log="$(jrnl -1 --format pretty)"
echo "$jrnl_log"
```

My default journal has colors configured, so once I got this working, the colors appeared in the terminal after running the above commands.


### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
