### PR TITLE
Correctly extract titles with multiple line breaks

### DIFF
--- a/jrnl/journals/Entry.py
+++ b/jrnl/journals/Entry.py
@@ -223,7 +223,8 @@ SENTENCE_SPLITTER_ONLY_NEWLINE = re.compile("\n")
 
 def split_title(text: str) -> tuple[str, str]:
     """Splits the first sentence off from a text."""
-    sep = SENTENCE_SPLITTER_ONLY_NEWLINE.search(text.lstrip())
+    text = text.lstrip()
+    sep = SENTENCE_SPLITTER_ONLY_NEWLINE.search(text)
     if not sep:
         sep = SENTENCE_SPLITTER.search(text)
         if not sep:


### PR DESCRIPTION
Closes #1676 (Starting an entry with multiple line breaks splits the end of the first line by the number of line breaks)

Since the location of the separator was computed on the `text.lstrip()` but the function returned the substring of `text` the title would be cut off.

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [X] I have included a link to the relevant issue number.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
