### PR TITLE
Feature - add bracketed date support when composing new entry (#1915)

### DIFF
--- a/tests/bdd/features/datetime.feature
+++ b/tests/bdd/features/datetime.feature
@@ -51,6 +51,13 @@ Feature: Reading and writing to journal with custom date formats
         | little_endian_dates.yaml | 2032-02-01: Test.            | 01.02.2032 09:00 Test.            |
         | little_endian_dates.yaml | 2020-01-01: Test.            | 01.01.2020 09:00 Test.            |
         | little_endian_dates.yaml | 2020-12-31: Test.            | 31.12.2020 09:00 Test.            |
+        # @todo: is it fine that default time be used here and not 00:00?
+        | little_endian_dates.yaml | [2020-12-31] bracket.        | 31.12.2020 09:00 bracket.         |
+        | little_endian_dates.yaml | [2020-12-31 10:00 PM] brkt.  | 31.12.2020 22:00 brkt.            |
+        | little_endian_dates.yaml | [2020-12-31]: brkt colon.    | 31.12.2020 09:00 brkt colon.      |
+        | little_endian_dates.yaml | [2020-12-31 12:34]: b colon. | 31.12.2020 12:34 b colon.         |
+        | little_endian_dates.yaml | [2019-02-29] brkt neg.       | [2019-02-29] brkt neg.            |
+        | little_endian_dates.yaml | [2020-08-32] brkt neg.       | [2020-08-32] brkt neg.            |
 
 
     Scenario Outline: Searching for dates with custom date
@@ -76,6 +83,14 @@ Feature: Reading and writing to journal with custom date formats
         Then we should get no error
         When we run "jrnl -999"
         Then the output should contain "10.05.2013 09:00 I saw Elvis."
+        And the output should contain "He's alive."
+
+    Scenario: Writing an entry at the prompt with custom date in bracket format
+        Given we use the config "little_endian_dates.yaml"
+        When we run "jrnl" and type "[2013-05-10 12:34] I saw Elvis. He's alive."
+        Then we should get no error
+        When we run "jrnl -999"
+        Then the output should contain "10.05.2013 12:34 I saw Elvis."
         And the output should contain "He's alive."
 
 

--- a/tests/bdd/features/star.feature
+++ b/tests/bdd/features/star.feature
@@ -16,6 +16,31 @@ Feature: Starring entries
         | empty_folder.yaml |
         | dayone.yaml       |
 
+    Scenario Outline: Starring an entry with bracketed date will mark it in the journal file
+        Given we use the config "<config_file>"
+        When we run "jrnl <command>"
+        Then we should get no error
+        When we run "jrnl -on 2013-07-20 -starred"
+        Then the output should contain "2013-07-20 09:00 Best day of my life!"
+
+        Examples: configs
+        | config_file       | command |
+        | simple.yaml       | [2013-07-20] Best day of my life! * |
+        | empty_folder.yaml | [2013-07-20] Best day of my life! * |
+        # Note: this one fail due to whitespace, cmp. next config
+#        | dayone.yaml       | [2013-07-20] Best day of my life! * |
+        | dayone.yaml       | [2013-07-20] Best day of my life!* |
+        | simple.yaml       | [2013-07-20]*: Best day of my life! |
+        | empty_folder.yaml | [2013-07-20]*: Best day of my life! |
+        | dayone.yaml       | [2013-07-20]*: Best day of my life! |
+        | simple.yaml       | [2013-07-20] * : Best day of my life! |
+        | empty_folder.yaml | [2013-07-20] * : Best day of my life! |
+        | dayone.yaml       | [2013-07-20] * : Best day of my life! |
+        | simple.yaml       | [2013-07-20] * Best day of my life! |
+        | empty_folder.yaml | [2013-07-20] * Best day of my life! |
+        # Note: this one fails in having the star in the output too
+#        | dayone.yaml       | [2013-07-20] * Best day of my life! |
+
     Scenario Outline: Filtering by starred entries will show only starred entries
         Given we use the config "<config_file>"
         When we run "jrnl -starred"


### PR DESCRIPTION
Bracketed dates like `[2020-01-01]` at the beginning of an entry will be parsed and used as the entry date, thus be removed from the entry text.

Colon `:` and starred `*` usage is mostly covered too, see test cases.

Fixes #1915 

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
