### PR TITLE
Force brighter color with XML syntax highlighting

### DIFF
--- a/docs_theme/assets/highlight.css
+++ b/docs_theme/assets/highlight.css
@@ -139,3 +139,9 @@ Original One Dark Syntax theme from https://github.com/atom/one-dark-syntax
 .rst-content .tip .admonition {
   background: var(--light-blue);
 }
+
+/* hack to bypass a11y issue with conflicting highlight.css files */
+code.language-xml span.hljs-meta span.hljs-string {
+  color: var(--green) !important;
+}
+


### PR DESCRIPTION
Fixes #1934.

Our docs use a couple competing `highlight.css` files, I think due to something in the mkdocs framework that conflicts with the `highlight.css` file in our theme. Accessibility checks fail on only string in one XML snippet, which is clearly too dark for its background, so I'm overriding the style in that particular case.

It's not the most elegant solution, but I don't want to sink more time into these style sheet issues now that our accessibility checks are passing. Better solutions are welcome if anyone else wants to tackle this.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
