### PR TITLE
Add user-friendly message when missing importer

### DIFF
--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -76,7 +76,17 @@ def postconfig_import(args: argparse.Namespace, config: dict, **_) -> int:
     journal = open_journal(args.journal_name, config)
 
     format = args.export if args.export else "jrnl"
-    get_importer(format).import_(journal, args.filename)
+
+    if (importer := get_importer(format)) is None:
+        raise JrnlException(
+            Message(
+                MsgText.ImporterNotFound,
+                MsgStyle.ERROR,
+                {"format": format},
+            )
+        )
+
+    importer.import_(journal, args.filename)
 
     return 0
 

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -266,6 +266,11 @@ class MsgText(Enum):
         {count} imported to {journal_name} journal
         """
 
+    ImporterNotFound = """
+        No importer found for file type '{format}'.
+        '{format}' is likely to be an export-only format.
+        """
+
     # --- Color --- #
     InvalidColor = "{key} set to invalid color: {color}"
 


### PR DESCRIPTION
Fixes #1486.

Add a clear error message if a user tries to import a non-jrnl file, since that's the only importer available right now.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.


**Note:** I had to make some changes in line with PR #1955 to have passing tests via `tox`. Everything's fine with `pytest` because of the pinned version of `pytest-bdd==7.3.0`.