### PR TITLE
i18n formatting and Japanese language strings for MsgText.py

### DIFF
--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -332,15 +332,19 @@ class MsgText(Enum):
         To finish writing, press {how_to_quit} on a blank line.
         """,
         ja="""
+        エントリ書き込み中
+        書き込みを終了するには、空白行で {how_to_quit} を押して下さい。
         """,
         )
+
     HowToQuitWindows = T(
         en="Ctrl+z and then Enter",
-        ja="",
+        ja="Ctrl+z を押してから Enter を押して下さい",
         )
+    
     HowToQuitLinux = T(
         en="Ctrl+d",
-        ja="",
+        ja="Ctrl+d",
         )
 
     EditorMisconfigured = T(
@@ -351,6 +355,10 @@ class MsgText(Enum):
             editor: '{editor_key}'
         """,
         ja="""
+        このファイルまたはディレクトリはありません: '{editor_key}'
+
+        構成ファイルの 'editor' キーにエラーがないか確認してください:
+            エディター: '{editor_key}'
         """,
         )
 
@@ -358,13 +366,20 @@ class MsgText(Enum):
         en="""
         There is no editor configured
 
-        To use the --edit option, please specify an editor your config file:
+        To use the --edit option, please specify an editor in your config file:
             {config_file}
 
         For examples of how to configure an external editor, see:
             https://jrnl.sh/en/stable/external-editors/
         """,
         ja="""
+        エディターが設定されていません
+
+        --edit オプションを使用するには、構成ファイルでエディターを指定してください:
+            {config_file}
+
+        外部エディタを設定する例については、次を見てください:
+            https://jrnl.sh/en/stable/external-editors/
         """,
         )
 
@@ -377,12 +392,17 @@ class MsgText(Enum):
         To delete all entries, use the --delete option.
         """,
         ja="""
+        エディタからテキストを受信しませんでした。すべてのエントリを削除しようとしましたか?
+
+        これは少し極端なため、操作はキャンセルされました。
+
+        すべてのエントリを削除するには、--delete オプションを使用して下さい。
         """,
         )
 
     NoEditsReceived = T(
         en="No edits to save, because nothing was changed",
-        ja="",
+        ja="変更がなかったため、保存する編集はありません",
         )
 
     NoTextReceived = T(
@@ -390,13 +410,16 @@ class MsgText(Enum):
         No entry to save, because no text was received
         """,
         ja="""
+        テキストが受信されてないため、保存するエントリがありません
         """,
         )
+
     NoChangesToTemplate = T(
         en="""
         No entry to save, because the template was not changed
         """,
         ja="""
+        テンプレートが変更されていないため、保存するエントリがありません
         """,
         )
 

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -1,6 +1,20 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+# format example, delete later
+# OneLineMessage = T(
+#     en="something",
+#     ja="何か",
+# )
+# MultiLineMessage = T(
+#     en="""
+#     something
+#     """,
+#     ja="""
+#     何か
+#     """,
+# )
+
 from enum import Enum
 
 
@@ -9,7 +23,8 @@ class MsgText(Enum):
         return self.value
 
     # -- Welcome --- #
-    WelcomeToJrnl = """
+    WelcomeToJrnl = T(
+        en="""
         Welcome to jrnl {version}!
 
         It looks like you've been using an older version of jrnl until now. That's
@@ -24,30 +39,79 @@ class MsgText(Enum):
         Please note that jrnl 1.x is NOT forward compatible with this version of jrnl.
         If you choose to proceed, you will not be able to use your journals with
         older versions of jrnl anymore.
-        """
+        """,
+        ja="""
+        jrnl {version} へようこそ!
 
-    AllDoneUpgrade = "We're all done here and you can start enjoying jrnl 2"
+        これまでは古いバージョンの jrnl を使用していたようです。問題ありません。jrnl はこれから
+        設定ファイルとジャーナル ファイルをアップグレードします。その後は、jrnl 2 に付属する
+        すばらしい新機能をすべてお楽しめます:
 
-    InstallComplete = """
+        - ジャーナルを複数のファイルに保存するためのサポート
+        - 大きなジャーナルの読み取りと書き込みの高速化
+        - jrnl のインストールを大幅に容易にする新しい暗号化バックエンド
+        - 多数のバグ修正
+
+        jrnl 1.x は、このバージョンの jrnl と前方互換性がありませんのでご注意ください。
+        続行する場合は、古いバージョンの jrnl ではジャーナルを使用できなくなります。
+        """,
+        )
+
+    AllDoneUpgrade = T(
+        en="We're all done here and you can start enjoying jrnl 2",
+        ja="これですべて完了です、jrnl 2 をお楽しみください",
+        )
+    
+    InstallComplete = T(
+        en="""
         jrnl configuration created at {config_path}
         For advanced features, read the docs at https://jrnl.sh
-    """
+        """,
+        ja="""
+        jrnl 構成がここに作成されました： {config_path} 
+        高度な機能については、https://jrnl.sh のドキュメントをお読みください。
+        """,
+        )
 
     # --- Prompts --- #
-    InstallJournalPathQuestion = """
+    InstallJournalPathQuestion = T(
+        en="""
         Path to your journal file (leave blank for {default_journal_path}):
-        """
-    DeleteEntryQuestion = "Delete entry '{entry_title}'?"
-    ChangeTimeEntryQuestion = "Change time for '{entry_title}'?"
-    EncryptJournalQuestion = """
+        """,
+        ja="""
+        ジャーナル ファイルへのパス ({default_journal_path} で良ければ空白のままにしてください):
+        """,
+        )
+    DeleteEntryQuestion = T(
+        en="Delete entry '{entry_title}'?",
+        ja="エントリ '{entry_title}' を削除しますか?",
+        )
+    ChangeTimeEntryQuestion = T(
+        en="Change time for '{entry_title}'?",
+        ja="'{entry_title}' の時間を変更しますか？",
+        )
+    EncryptJournalQuestion = T(
+        en="""
         Do you want to encrypt your journal? (You can always change this later)
-        """
-    UseColorsQuestion = """
+        """,
+        ja="""
+        ジャーナルを暗号化しますか？（これは後でいつでも変更できます）
+        """,
+        )
+    UseColorsQuestion = T(
+        en="""
         Do you want jrnl to use colors to display entries? (You can always change this later)
-        """  # noqa: E501 - the line is still under 88 when dedented
+        """,  # noqa: E501 - the line is still under 88 when dedented
+        ja="""
+        jrnl でエントリの表示に色を使用しますか？（これは後でいつでも変更できます）
+        """,
+        )
     YesOrNoPromptDefaultYes = "[Y/n]"
     YesOrNoPromptDefaultNo = "[y/N]"
-    ContinueUpgrade = "Continue upgrading jrnl?"
+    ContinueUpgrade = T(
+        en="Continue upgrading jrnl?",
+        ja="jrnl のアップグレードを続行しますか？",
+        )
 
     # these should be lowercase, if possible in language
     # "lowercase" means whatever `.lower()` returns
@@ -55,30 +119,60 @@ class MsgText(Enum):
     OneCharacterNo = "n"
 
     # --- Exceptions ---#
-    Error = "Error"
-    UncaughtException = """
+    Error = T(
+        en="Error",
+        ja="エラー",
+        )
+    UncaughtException = T(
+        en="""
         {name}
         {exception}
 
         This is probably a bug. Please file an issue at:
         https://github.com/jrnl-org/jrnl/issues/new/choose
-        """
+        """,
+        ja="""
+        {name}
+        {exception}
 
-    ConfigDirectoryIsFile = """
+        これはおそらくバグです。問題を報告してください:
+        https://github.com/jrnl-org/jrnl/issues/new/choose
+        """,
+        )
+
+    ConfigDirectoryIsFile = T(
+        en="""
         Problem with config file!
         The path to your jrnl configuration directory is a file, not a directory:
 
         {config_directory_path}
 
         Removing this file will allow jrnl to save its configuration.
-        """
+        """,
+        ja="""
+        構成ファイルに問題があります!
+        jrnl 構成ディレクトリへのパスはディレクトリではなくファイルです:
 
-    CantParseConfigFile = """
+        {config_directory_path}
+
+        このファイルを削除すると、jrnl が構成を保存できるようになります。
+        
+        """,
+        )
+
+    CantParseConfigFile = T(
+        en="""
         Unable to parse config file at:
         {config_path}
-        """
+        """,
+        ja="""
+        ここにある構成ファイルを解析できません:
+        {config_path}
+        """,
+        )
 
-    LineWrapTooSmallForDateFormat = """
+    LineWrapTooSmallForDateFormat = T(
+        en="""
         The provided linewrap value of {config_linewrap} is too small by
         {columns} columns to display the timestamps in the configured time
         format for journal {journal}.
@@ -86,72 +180,157 @@ class MsgText(Enum):
         You can avoid this error by specifying a linewrap value that is larger
         by at least {columns} in the configuration file or by using
         --config-override at the command line
-        """
+        """,
+        ja="""
+        
+        """,
+        )
 
-    CannotEncryptJournalType = """
+    CannotEncryptJournalType = T(
+        en="""
         The journal {journal_name} can't be encrypted because it is a
         {journal_type} journal.
 
         To encrypt it, create a new journal referencing a file, export
         this journal to the new journal, then encrypt the new journal.
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    ConfigEncryptedForUnencryptableJournalType = """
+    ConfigEncryptedForUnencryptableJournalType = T(
+        en="""
         The config for journal "{journal_name}" has 'encrypt' set to true, but this type
         of journal can't be encrypted. Please fix your config file.
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    DecryptionFailedGeneric = "The decryption of journal data failed."
+    DecryptionFailedGeneric = T(
+        en="The decryption of journal data failed.",
+        ja="",
+        )
 
-    KeyboardInterruptMsg = "Aborted by user"
+    KeyboardInterruptMsg = T(
+        en="Aborted by user",
+        ja="",
+        )
 
-    CantReadTemplate = """
+    CantReadTemplate = T(
+        en="""
         Unable to find a template file {template_path}.
 
         The following paths were checked:
          * {jrnl_template_dir}{template_path}
          * {actual_template_path}
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    NoNamedJournal = "No '{journal_name}' journal configured\n{journals}"
+    NoNamedJournal = T(
+        en="No '{journal_name}' journal configured\n{journals}",
+        ja="",
+        )
 
-    DoesNotExist = "{name} does not exist"
+    DoesNotExist = T(
+        en="{name} does not exist",
+        ja="",
+        )
 
     # --- Journal status ---#
-    JournalNotSaved = "Entry NOT saved to journal"
-    JournalEntryAdded = "Entry added to {journal_name} journal"
+    JournalNotSaved = T(
+        en="Entry NOT saved to journal",
+        ja="",
+        )
+    JournalEntryAdded = T(
+        en="Entry added to {journal_name} journal",
+        ja="",
+        )
 
-    JournalCountAddedSingular = "{num} entry added"
-    JournalCountModifiedSingular = "{num} entry modified"
-    JournalCountDeletedSingular = "{num} entry deleted"
+    JournalCountAddedSingular = T(
+        en="{num} entry added",
+        ja="",
+        )
+    JournalCountModifiedSingular = T(
+        en="{num} entry modified",
+        ja="",
+        )
+    JournalCountDeletedSingular = T(
+        en="{num} entry deleted",
+        ja="",
+        )
 
-    JournalCountAddedPlural = "{num} entries added"
-    JournalCountModifiedPlural = "{num} entries modified"
-    JournalCountDeletedPlural = "{num} entries deleted"
+    JournalCountAddedPlural = T(
+        en="{num} entries added",
+        ja="",
+        )
+    JournalCountModifiedPlural = T(
+        en="{num} entries modified",
+        ja="",
+        )
+    JournalCountDeletedPlural = T(
+        en="{num} entries deleted",
+        ja="",
+        )
 
-    JournalCreated = "Journal '{journal_name}' created at {filename}"
-    DirectoryCreated = "Directory {directory_name} created"
-    JournalEncrypted = "Journal will be encrypted"
-    JournalEncryptedTo = "Journal encrypted to {path}"
-    JournalDecryptedTo = "Journal decrypted to {path}"
-    BackupCreated = "Created a backup at {filename}"
+    JournalCreated = T(
+        en="Journal '{journal_name}' created at {filename}",
+        ja="",
+        )
+    DirectoryCreated = T(
+        en="Directory {directory_name} created",
+        ja="",
+        )
+    JournalEncrypted = T(
+        en="Journal will be encrypted",
+        ja="",
+        )
+    JournalEncryptedTo = T(
+        en="Journal encrypted to {path}",
+        ja="",
+        )
+    JournalDecryptedTo = T(
+        en="Journal decrypted to {path}",
+        ja="",
+        )
+    BackupCreated = T(
+        en="Created a backup at {filename}",
+        ja="",
+        )
 
     # --- Editor ---#
-    WritingEntryStart = """
+    WritingEntryStart = T(
+        en="""
         Writing Entry
         To finish writing, press {how_to_quit} on a blank line.
-        """
-    HowToQuitWindows = "Ctrl+z and then Enter"
-    HowToQuitLinux = "Ctrl+d"
+        """,
+        ja="""
+        """,
+        )
+    HowToQuitWindows = T(
+        en="Ctrl+z and then Enter",
+        ja="",
+        )
+    HowToQuitLinux = T(
+        en="Ctrl+d",
+        ja="",
+        )
 
-    EditorMisconfigured = """
+    EditorMisconfigured = T(
+        en="""
         No such file or directory: '{editor_key}'
 
         Please check the 'editor' key in your config file for errors:
             editor: '{editor_key}'
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    EditorNotConfigured = """
+    EditorNotConfigured = T(
+        en="""
         There is no editor configured
 
         To use the --edit option, please specify an editor your config file:
@@ -159,128 +338,250 @@ class MsgText(Enum):
 
         For examples of how to configure an external editor, see:
             https://jrnl.sh/en/stable/external-editors/
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    NoEditsReceivedJournalNotDeleted = """
+    NoEditsReceivedJournalNotDeleted = T(
+        en="""
         No text received from editor. Were you trying to delete all the entries?
 
         This seems a bit drastic, so the operation was cancelled.
 
         To delete all entries, use the --delete option.
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    NoEditsReceived = "No edits to save, because nothing was changed"
+    NoEditsReceived = T(
+        en="No edits to save, because nothing was changed",
+        ja="",
+        )
 
-    NoTextReceived = """
+    NoTextReceived = T(
+        en="""
         No entry to save, because no text was received
-        """
-    NoChangesToTemplate = """
+        """,
+        ja="""
+        """,
+        )
+    NoChangesToTemplate = T(
+        en="""
         No entry to save, because the template was not changed
-    """
+        """,
+        ja="""
+        """,
+        )
+
     # --- Upgrade --- #
-    JournalFailedUpgrade = """
+    JournalFailedUpgrade = T(
+        en="""
         The following journal{s} failed to upgrade:
         {failed_journals}
 
         Please tell us about this problem at the following URL:
         https://github.com/jrnl-org/jrnl/issues/new?title=JournalFailedUpgrade
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    UpgradeAborted = "jrnl was NOT upgraded"
+    UpgradeAborted = T(
+        en="jrnl was NOT upgraded",
+        ja="",
+        )
 
-    AbortingUpgrade = "Aborting upgrade..."
+    AbortingUpgrade = T(
+        en="Aborting upgrade...",
+        ja="",
+        )
 
-    ImportAborted = "Entries were NOT imported"
+    ImportAborted = T(
+        en="Entries were NOT imported",
+        ja="",
+        )
 
-    JournalsToUpgrade = """
+    JournalsToUpgrade = T(
+        en="""
         The following journals will be upgraded to jrnl {version}:
 
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    JournalsToIgnore = """
+    JournalsToIgnore = T(
+        en="""
         The following journals will not be touched:
 
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    UpgradingJournal = """
+    UpgradingJournal = T(
+        en="""
         Upgrading '{journal_name}' journal stored in {path}...
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    UpgradingConfig = "Upgrading config..."
+    UpgradingConfig = T(
+        en="Upgrading config...",
+        ja="",
+        )
 
     PaddedJournalName = "{journal_name:{pad}} -> {path}"
 
     # -- Config --- #
-    AltConfigNotFound = """
+    AltConfigNotFound = T(
+        en="""
         Alternate configuration file not found at the given path:
             {config_file}
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    ConfigUpdated = """
+    ConfigUpdated = T(
+        en="""
         Configuration updated to newest version at {config_path}
-        """
+        """,
+        ja="""
+        """,
+        )
 
-    ConfigDoubleKeys = """
+    ConfigDoubleKeys = T(
+        en="""
         There is at least one duplicate key in your configuration file.
 
         Details:
         {error_message}
-        """
-
+        """,
+        ja="""
+        """,
+        )
     # --- Password --- #
-    Password = "Password:"
-    PasswordFirstEntry = "Enter password for journal '{journal_name}': "
-    PasswordConfirmEntry = "Enter password again: "
-    PasswordMaxTriesExceeded = "Too many attempts with wrong password"
-    PasswordCanNotBeEmpty = "Password can't be empty!"
-    PasswordDidNotMatch = "Passwords did not match, please try again"
-    WrongPasswordTryAgain = "Wrong password, try again"
-    PasswordStoreInKeychain = "Do you want to store the password in your keychain?"
+    Password = T(
+        en="Password:",
+        ja="",
+        )
+    PasswordFirstEntry = T(
+        en="Enter password for journal '{journal_name}': ",
+        ja="",
+        )
+    PasswordConfirmEntry = T(
+        en="Enter password again: ",
+        ja="",
+        )
+    PasswordMaxTriesExceeded = T(
+        en="Too many attempts with wrong password",
+        ja="",
+        )
+    PasswordCanNotBeEmpty = T(
+        en="Password can't be empty!",
+        ja="",
+        )
+    PasswordDidNotMatch = T(
+        en="Passwords did not match, please try again",
+        ja="",
+        )
+    WrongPasswordTryAgain = T(
+        en="Wrong password, try again",
+        ja="",
+        )
+    PasswordStoreInKeychain = T(
+        en="Do you want to store the password in your keychain?",
+        ja="",
+        )
 
     # --- Search --- #
-    NothingToDelete = """
+    NothingToDelete = T(
+        en="""
         No entries to delete, because the search returned no results
-        """
-
-    NothingToModify = """
+        """,
+        ja="""
+        """,
+        )
+    NothingToModify = T(
+        en="""
         No entries to modify, because the search returned no results
-        """
-
-    NoEntriesFound = "no entries found"
-    EntryFoundCountSingular = "{num} entry found"
-    EntryFoundCountPlural = "{num} entries found"
+        """,
+        ja="""
+        """,
+        )
+    NoEntriesFound = T(
+        en="no entries found",
+        ja="",
+        )
+    EntryFoundCountSingular = T(
+        en="{num} entry found",
+        ja="",
+        )
+    EntryFoundCountPlural = T(
+        en="{num} entries found",
+        ja="",
+        )
 
     # --- Formats --- #
-    HeadingsPastH6 = """
+    HeadingsPastH6 = T(
+        en="""
         Headings increased past H6 on export - {date} {title}
-        """
-
-    YamlMustBeDirectory = """
+        """,
+        ja="""
+        """,
+        )
+    YamlMustBeDirectory = T(
+        en="""
         YAML export must be to a directory, not a single file
-        """
-
-    JournalExportedTo = "Journal exported to {path}"
+        """,
+        ja="""
+        """,
+        )
+    JournalExportedTo = T(
+        en="Journal exported to {path}",
+        ja="",
+        )
 
     # --- Import --- #
-    ImportSummary = """
+    ImportSummary = T(
+        en="""
         {count} imported to {journal_name} journal
-        """
-
+        """,
+        ja="""
+        """,
+        )
     # --- Color --- #
-    InvalidColor = "{key} set to invalid color: {color}"
+    InvalidColor = T(
+        en="{key} set to invalid color: {color}",
+        ja="",
+        )
 
     # --- Keyring --- #
-    KeyringBackendNotFound = """
+    KeyringBackendNotFound = T(
+        en="""
         Keyring backend not found.
 
         Please install one of the supported backends by visiting:
           https://pypi.org/project/keyring/
-        """
-
-    KeyringRetrievalFailure = "Failed to retrieve keyring"
+        """,
+        ja="""
+        """,
+        )
+    KeyringRetrievalFailure = T(
+        en="Failed to retrieve keyring",
+        ja="",
+        )
 
     # --- Deprecation --- #
-    DeprecatedCommand = """
+    DeprecatedCommand = T(
+        en="""
         The command {old_cmd} is deprecated and will be removed from jrnl soon.
         Please use {new_cmd} instead.
-        """
+        """,
+        ja="""
+        """,
+        )

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -258,71 +258,71 @@ class MsgText(Enum):
     # --- Journal status ---#
     JournalNotSaved = T(
         en="Entry NOT saved to journal",
-        ja="",
+        ja="エントリがジャーナルに保存されませんでした",
         )
     JournalEntryAdded = T(
         en="Entry added to {journal_name} journal",
-        ja="",
+        ja="エントリが {journal_name} ジャーナルに追加されました",
         )
 
     JournalCountAddedSingular = T(
         en="{num} entry added",
-        ja="",
+        ja="{num} 個のエントリが追加されました",
         )
 
     JournalCountModifiedSingular = T(
         en="{num} entry modified",
-        ja="",
+        ja="{num} 個のエントリが変更されました",
         )
     
     JournalCountDeletedSingular = T(
         en="{num} entry deleted",
-        ja="",
+        ja="{num} 個のエントリが削除されました",
         )
 
     JournalCountAddedPlural = T(
         en="{num} entries added",
-        ja="",
+        ja="{num} 個のエントリが追加されました",
         )
 
     JournalCountModifiedPlural = T(
         en="{num} entries modified",
-        ja="",
+        ja="{num} 個のエントリが変更されました",
         )
 
     JournalCountDeletedPlural = T(
         en="{num} entries deleted",
-        ja="",
+        ja="{num} 個のエントリが削除されました",
         )
 
     JournalCreated = T(
         en="Journal '{journal_name}' created at {filename}",
-        ja="",
+        ja="ジャーナル '{journal_name}' が {filename} に作成されました",
         )
 
     DirectoryCreated = T(
         en="Directory {directory_name} created",
-        ja="",
+        ja="ディレクトリ {directory_name} が作成されました",
         )
 
     JournalEncrypted = T(
         en="Journal will be encrypted",
-        ja="",
+        ja="ジャーナルは暗号化されます",
         )
 
     JournalEncryptedTo = T(
         en="Journal encrypted to {path}",
-        ja="",
+        ja="ジャーナルが {path} に暗号化されました",
         )
 
     JournalDecryptedTo = T(
         en="Journal decrypted to {path}",
-        ja="",
+        ja="ジャーナルが {path} に復号されました",
         )
 
     BackupCreated = T(
         en="Created a backup at {filename}",
-        ja="",
+        ja="{filename} にバックアップが作成されました",
         )
 
     # --- Editor ---#

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -1,7 +1,7 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
-# format example, delete later
+# localization format example
 # OneLineMessage = T(
 #     en="something",
 #     ja="何か",
@@ -56,12 +56,10 @@ class MsgText(Enum):
         続行する場合は、古いバージョンの jrnl ではジャーナルを使用できなくなります。
         """,
         )
-
     AllDoneUpgrade = T(
         en="We're all done here and you can start enjoying jrnl 2",
         ja="これですべて完了です、jrnl 2 をお楽しみください",
         )
-    
     InstallComplete = T(
         en="""
         jrnl configuration created at {config_path}
@@ -139,7 +137,6 @@ class MsgText(Enum):
         https://github.com/jrnl-org/jrnl/issues/new/choose
         """,
         )
-
     ConfigDirectoryIsFile = T(
         en="""
         Problem with config file!
@@ -159,7 +156,6 @@ class MsgText(Enum):
         
         """,
         )
-
     CantParseConfigFile = T(
         en="""
         Unable to parse config file at:
@@ -170,7 +166,6 @@ class MsgText(Enum):
         {config_path}
         """,
         )
-
     LineWrapTooSmallForDateFormat = T(
         en="""
         The provided linewrap value of {config_linewrap} is too small by
@@ -189,7 +184,6 @@ class MsgText(Enum):
         指定するか、コマンド ラインで --config-override を使用してください。
         """,
         )
-
     CannotEncryptJournalType = T(
         en="""
         The journal {journal_name} can't be encrypted because it is a
@@ -205,7 +199,6 @@ class MsgText(Enum):
         ジャーナルにエクスポートしてから、新しいジャーナルを暗号化してください。
         """,
         )
-
     ConfigEncryptedForUnencryptableJournalType = T(
         en="""
         The config for journal "{journal_name}" has 'encrypt' set to true, but this type
@@ -216,17 +209,14 @@ class MsgText(Enum):
         このタイプのジャーナルは暗号化できません。構成ファイルを修正してください。
         """,
         )
-
     DecryptionFailedGeneric = T(
         en="The decryption of journal data failed.",
         ja="ジャーナル データの復号化に失敗しました。",
         )
-
     KeyboardInterruptMsg = T(
         en="Aborted by user",
         ja="ユーザーによって中止しました",
         )
-
     CantReadTemplate = T(
         en="""
         Unable to find a template file {template_path}.
@@ -243,13 +233,11 @@ class MsgText(Enum):
         * {actual_template_path}
         """,
         )
-
     NoNamedJournal = T(
         en="No '{journal_name}' journal configured\n{journals}",
         ja="'{journal_name}' ジャーナルが設定されていません\n{journals}",
         )
     # is that \n{journals} supposed to be there?
-
     DoesNotExist = T(
         en="{name} does not exist",
         ja="{name} が存在しません",
@@ -264,62 +252,50 @@ class MsgText(Enum):
         en="Entry added to {journal_name} journal",
         ja="エントリが {journal_name} ジャーナルに追加されました",
         )
-
     JournalCountAddedSingular = T(
         en="{num} entry added",
         ja="{num} 個のエントリが追加されました",
         )
-
     JournalCountModifiedSingular = T(
         en="{num} entry modified",
         ja="{num} 個のエントリが変更されました",
         )
-    
     JournalCountDeletedSingular = T(
         en="{num} entry deleted",
         ja="{num} 個のエントリが削除されました",
         )
-
     JournalCountAddedPlural = T(
         en="{num} entries added",
         ja="{num} 個のエントリが追加されました",
         )
-
     JournalCountModifiedPlural = T(
         en="{num} entries modified",
         ja="{num} 個のエントリが変更されました",
         )
-
     JournalCountDeletedPlural = T(
         en="{num} entries deleted",
         ja="{num} 個のエントリが削除されました",
         )
-
     JournalCreated = T(
         en="Journal '{journal_name}' created at {filename}",
         ja="ジャーナル '{journal_name}' が {filename} に作成されました",
         )
-
     DirectoryCreated = T(
         en="Directory {directory_name} created",
         ja="ディレクトリ {directory_name} が作成されました",
         )
-
     JournalEncrypted = T(
         en="Journal will be encrypted",
         ja="ジャーナルは暗号化されます",
         )
-
     JournalEncryptedTo = T(
         en="Journal encrypted to {path}",
         ja="ジャーナルが {path} に暗号化されました",
         )
-
     JournalDecryptedTo = T(
         en="Journal decrypted to {path}",
         ja="ジャーナルが {path} に復号されました",
         )
-
     BackupCreated = T(
         en="Created a backup at {filename}",
         ja="{filename} にバックアップが作成されました",
@@ -341,12 +317,10 @@ class MsgText(Enum):
         en="Ctrl+z and then Enter",
         ja="Ctrl+z を押してから Enter を押してください",
         )
-    
     HowToQuitLinux = T(
         en="Ctrl+d",
         ja="Ctrl+d",
         )
-
     EditorMisconfigured = T(
         en="""
         No such file or directory: '{editor_key}'
@@ -361,7 +335,6 @@ class MsgText(Enum):
             エディター: '{editor_key}'
         """,
         )
-
     EditorNotConfigured = T(
         en="""
         There is no editor configured
@@ -382,7 +355,6 @@ class MsgText(Enum):
             https://jrnl.sh/en/stable/external-editors/
         """,
         )
-
     NoEditsReceivedJournalNotDeleted = T(
         en="""
         No text received from editor. Were you trying to delete all the entries?
@@ -399,12 +371,10 @@ class MsgText(Enum):
         すべてのエントリを削除するには、--delete オプションを使用してください。
         """,
         )
-
     NoEditsReceived = T(
         en="No edits to save, because nothing was changed",
         ja="変更がなかったため、保存する編集はありません",
         )
-
     NoTextReceived = T(
         en="""
         No entry to save, because no text was received
@@ -413,7 +383,6 @@ class MsgText(Enum):
         テキストが受信されてないため、保存するエントリがありません
         """,
         )
-
     NoChangesToTemplate = T(
         en="""
         No entry to save, because the template was not changed
@@ -440,22 +409,18 @@ class MsgText(Enum):
         https://github.com/jrnl-org/jrnl/issues/new?title=JournalFailedUpgrade
         """,
         )
-
     UpgradeAborted = T(
         en="jrnl was NOT upgraded",
         ja="jrnl はアップグレードされませんでした",
         )
-
     AbortingUpgrade = T(
         en="Aborting upgrade...",
         ja="アップグレードを中止しています...",
         )
-
     ImportAborted = T(
         en="Entries were NOT imported",
         ja="エントリがインポートされませんでした",
         )
-
     JournalsToUpgrade = T(
         en="""
         The following journals will be upgraded to jrnl {version}:
@@ -466,7 +431,6 @@ class MsgText(Enum):
 
         """,
         )
-
     JournalsToIgnore = T(
         en="""
         The following journals will not be touched:
@@ -477,7 +441,6 @@ class MsgText(Enum):
 
         """,
         )
-
     UpgradingJournal = T(
         en="""
         Upgrading '{journal_name}' journal stored in {path}...
@@ -486,12 +449,10 @@ class MsgText(Enum):
         {path} に保存されている '{journal_name}' ジャーナルをアップグレードしています...
         """,
         )
-
     UpgradingConfig = T(
         en="Upgrading config...",
         ja="構成をアップグレードしています...",
         )
-
     PaddedJournalName = "{journal_name:{pad}} -> {path}"
 
     # -- Config --- #
@@ -505,7 +466,6 @@ class MsgText(Enum):
             {config_file}
         """,
         )
-
     ConfigUpdated = T(
         en="""
         Configuration updated to newest version at {config_path}
@@ -514,7 +474,6 @@ class MsgText(Enum):
         {config_path} で構成が最新バージョンに更新されました
         """,
         )
-
     ConfigDoubleKeys = T(
         en="""
         There is at least one duplicate key in your configuration file.
@@ -625,6 +584,7 @@ class MsgText(Enum):
         {count} 個が {journal_name} ジャーナルにインポートされました
         """,
         )
+    
     # --- Color --- #
     InvalidColor = T(
         en="{key} set to invalid color: {color}",

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -570,6 +570,7 @@ class MsgText(Enum):
         No entries to delete, because the search returned no results
         """,
         ja="""
+        検索で結果が返されなかったため、削除するエントリはありません
         """,
         )
     NothingToModify = T(
@@ -577,19 +578,20 @@ class MsgText(Enum):
         No entries to modify, because the search returned no results
         """,
         ja="""
+        検索で結果が返されなかったため、変更するエントリはありません
         """,
         )
     NoEntriesFound = T(
         en="no entries found",
-        ja="",
+        ja="エントリが見つかりません",
         )
     EntryFoundCountSingular = T(
         en="{num} entry found",
-        ja="",
+        ja="{num} 個のエントリが見つかりました",
         )
     EntryFoundCountPlural = T(
         en="{num} entries found",
-        ja="",
+        ja="{num} 個のエントリが見つかりました",
         )
 
     # --- Formats --- #
@@ -598,6 +600,7 @@ class MsgText(Enum):
         Headings increased past H6 on export - {date} {title}
         """,
         ja="""
+        エクスポート時に見出しが増えて H6 を超えました - {date} {title}
         """,
         )
     YamlMustBeDirectory = T(
@@ -605,11 +608,12 @@ class MsgText(Enum):
         YAML export must be to a directory, not a single file
         """,
         ja="""
+        YAML エクスポートは、単一のファイルではなく、ディレクトリに行う必要があります
         """,
         )
     JournalExportedTo = T(
         en="Journal exported to {path}",
-        ja="",
+        ja="ジャーナルが {path} にエプスポートされました",
         )
 
     # --- Import --- #
@@ -618,12 +622,13 @@ class MsgText(Enum):
         {count} imported to {journal_name} journal
         """,
         ja="""
+        {count} 個が {journal_name} ジャーナルにインポートされました
         """,
         )
     # --- Color --- #
     InvalidColor = T(
         en="{key} set to invalid color: {color}",
-        ja="",
+        ja="{key} が無効な色に設定されています: {color}",
         )
 
     # --- Keyring --- #
@@ -635,11 +640,15 @@ class MsgText(Enum):
           https://pypi.org/project/keyring/
         """,
         ja="""
+        キーリングのバックエンドが見つかりません。
+
+        サポートされているバックエンドのいずれかをここからインストールしてください:
+          https://pypi.org/project/keyring/
         """,
         )
     KeyringRetrievalFailure = T(
         en="Failed to retrieve keyring",
-        ja="",
+        ja="キーリングの取得に失敗しました",
         )
 
     # --- Deprecation --- #
@@ -649,5 +658,7 @@ class MsgText(Enum):
         Please use {new_cmd} instead.
         """,
         ja="""
+        コマンド {old_cmd} は非推奨であり、まもなく jrnl から削除されます。
+        代わりに {new_cmd} を使用してください。
         """,
         )

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -186,7 +186,7 @@ class MsgText(Enum):
         設定された時間形式でタイムスタンプを表示するには、{columns} 列分小さすぎます。
 
         このエラーを回避するには、構成ファイルで行折り返し値を少なくとも {columns} 大きく
-        指定するか、コマンド ラインで --config-override を使用して下さい。
+        指定するか、コマンド ラインで --config-override を使用してください。
         """,
         )
 
@@ -202,7 +202,7 @@ class MsgText(Enum):
         ジャーナル {journal_name} は {journal_type} ジャーナルであるため暗号化できません。
 
         暗号化するには、ファイルを参照する新しいジャーナルを作成し、このジャーナルを新しい
-        ジャーナルにエクスポートしてから、新しいジャーナルを暗号化して下さい。
+        ジャーナルにエクスポートしてから、新しいジャーナルを暗号化してください。
         """,
         )
 
@@ -333,13 +333,13 @@ class MsgText(Enum):
         """,
         ja="""
         エントリ書き込み中
-        書き込みを終了するには、空白行で {how_to_quit} を押して下さい。
+        書き込みを終了するには、空白行で {how_to_quit} を押してください。
         """,
         )
 
     HowToQuitWindows = T(
         en="Ctrl+z and then Enter",
-        ja="Ctrl+z を押してから Enter を押して下さい",
+        ja="Ctrl+z を押してから Enter を押してください",
         )
     
     HowToQuitLinux = T(
@@ -396,7 +396,7 @@ class MsgText(Enum):
 
         これは少し極端なため、操作はキャンセルされました。
 
-        すべてのエントリを削除するには、--delete オプションを使用して下さい。
+        すべてのエントリを削除するには、--delete オプションを使用してください。
         """,
         )
 
@@ -433,22 +433,27 @@ class MsgText(Enum):
         https://github.com/jrnl-org/jrnl/issues/new?title=JournalFailedUpgrade
         """,
         ja="""
+        次のジャーナルはアップグレードに失敗しました:
+        {failed_journals}
+
+        この問題について、次の　URL　でお知らせください:
+        https://github.com/jrnl-org/jrnl/issues/new?title=JournalFailedUpgrade
         """,
         )
 
     UpgradeAborted = T(
         en="jrnl was NOT upgraded",
-        ja="",
+        ja="jrnl はアップグレードされませんでした",
         )
 
     AbortingUpgrade = T(
         en="Aborting upgrade...",
-        ja="",
+        ja="アップグレードを中止しています...",
         )
 
     ImportAborted = T(
         en="Entries were NOT imported",
-        ja="",
+        ja="エントリがインポートされませんでした",
         )
 
     JournalsToUpgrade = T(
@@ -457,6 +462,8 @@ class MsgText(Enum):
 
         """,
         ja="""
+        次のジャーナルは jrnl {バージョン} にアップグレードされます:
+
         """,
         )
 
@@ -466,6 +473,8 @@ class MsgText(Enum):
 
         """,
         ja="""
+        次のジャーナルは変更されません:
+
         """,
         )
 
@@ -474,12 +483,13 @@ class MsgText(Enum):
         Upgrading '{journal_name}' journal stored in {path}...
         """,
         ja="""
+        {path} に保存されている '{journal_name}' ジャーナルをアップグレードしています...
         """,
         )
 
     UpgradingConfig = T(
         en="Upgrading config...",
-        ja="",
+        ja="構成をアップグレードしています...",
         )
 
     PaddedJournalName = "{journal_name:{pad}} -> {path}"
@@ -491,6 +501,8 @@ class MsgText(Enum):
             {config_file}
         """,
         ja="""
+        指定されたパスに代替構成ファイルが見つかりません:
+            {config_file}
         """,
         )
 
@@ -499,6 +511,7 @@ class MsgText(Enum):
         Configuration updated to newest version at {config_path}
         """,
         ja="""
+        {config_path} で構成が最新バージョンに更新されました
         """,
         )
 
@@ -510,40 +523,45 @@ class MsgText(Enum):
         {error_message}
         """,
         ja="""
+        構成ファイル内に重複するキーが少なくとも 1 つあります。
+
+        詳細:
+        {error_message}
         """,
         )
+
     # --- Password --- #
     Password = T(
         en="Password:",
-        ja="",
+        ja="パスワード:",
         )
     PasswordFirstEntry = T(
         en="Enter password for journal '{journal_name}': ",
-        ja="",
+        ja="ジャーナル '{journal_name}' のパスワードを入力してください: ",
         )
     PasswordConfirmEntry = T(
         en="Enter password again: ",
-        ja="",
+        ja="パスワードをもう一度入力してくださいください: ",
         )
     PasswordMaxTriesExceeded = T(
         en="Too many attempts with wrong password",
-        ja="",
+        ja="間違ったパスワードで試行回数が多すぎます",
         )
     PasswordCanNotBeEmpty = T(
         en="Password can't be empty!",
-        ja="",
+        ja="パスワードを空にすることはできません！",
         )
     PasswordDidNotMatch = T(
         en="Passwords did not match, please try again",
-        ja="",
+        ja="パスワードが一致しませんでした、もう一度お試しください",
         )
     WrongPasswordTryAgain = T(
         en="Wrong password, try again",
-        ja="",
+        ja="パスワードが間違っています、やり直してください",
         )
     PasswordStoreInKeychain = T(
         en="Do you want to store the password in your keychain?",
-        ja="",
+        ja="パスワードをキーチェーンに保存しますか？",
         )
 
     # --- Search --- #

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -182,7 +182,11 @@ class MsgText(Enum):
         --config-override at the command line
         """,
         ja="""
-        
+        指定された {config_linewrap} の行折り返し値は、ジャーナル {journal} に
+        設定された時間形式でタイムスタンプを表示するには、{columns} 列分小さすぎます。
+
+        このエラーを回避するには、構成ファイルで行折り返し値を少なくとも {columns} 大きく
+        指定するか、コマンド ラインで --config-override を使用して下さい。
         """,
         )
 
@@ -195,6 +199,10 @@ class MsgText(Enum):
         this journal to the new journal, then encrypt the new journal.
         """,
         ja="""
+        ジャーナル {journal_name} は {journal_type} ジャーナルであるため暗号化できません。
+
+        暗号化するには、ファイルを参照する新しいジャーナルを作成し、このジャーナルを新しい
+        ジャーナルにエクスポートしてから、新しいジャーナルを暗号化して下さい。
         """,
         )
 
@@ -204,17 +212,19 @@ class MsgText(Enum):
         of journal can't be encrypted. Please fix your config file.
         """,
         ja="""
+        ジャーナル "{journal_name}" の構成では 'encrypt' が true に設定されていますが、
+        このタイプのジャーナルは暗号化できません。構成ファイルを修正してください。
         """,
         )
 
     DecryptionFailedGeneric = T(
         en="The decryption of journal data failed.",
-        ja="",
+        ja="ジャーナル データの復号化に失敗しました。",
         )
 
     KeyboardInterruptMsg = T(
         en="Aborted by user",
-        ja="",
+        ja="ユーザーによって中止しました",
         )
 
     CantReadTemplate = T(
@@ -226,17 +236,23 @@ class MsgText(Enum):
          * {actual_template_path}
         """,
         ja="""
+        テンプレート ファイル {template_path} が見つかりません。
+
+        次のパスがチェックされました:
+        * {jrnl_template_dir}{template_path}
+        * {actual_template_path}
         """,
         )
 
     NoNamedJournal = T(
         en="No '{journal_name}' journal configured\n{journals}",
-        ja="",
+        ja="'{journal_name}' ジャーナルが設定されていません\n{journals}",
         )
+    # is that \n{journals} supposed to be there?
 
     DoesNotExist = T(
         en="{name} does not exist",
-        ja="",
+        ja="{name} が存在しません",
         )
 
     # --- Journal status ---#
@@ -253,10 +269,12 @@ class MsgText(Enum):
         en="{num} entry added",
         ja="",
         )
+
     JournalCountModifiedSingular = T(
         en="{num} entry modified",
         ja="",
         )
+    
     JournalCountDeletedSingular = T(
         en="{num} entry deleted",
         ja="",
@@ -266,10 +284,12 @@ class MsgText(Enum):
         en="{num} entries added",
         ja="",
         )
+
     JournalCountModifiedPlural = T(
         en="{num} entries modified",
         ja="",
         )
+
     JournalCountDeletedPlural = T(
         en="{num} entries deleted",
         ja="",
@@ -279,22 +299,27 @@ class MsgText(Enum):
         en="Journal '{journal_name}' created at {filename}",
         ja="",
         )
+
     DirectoryCreated = T(
         en="Directory {directory_name} created",
         ja="",
         )
+
     JournalEncrypted = T(
         en="Journal will be encrypted",
         ja="",
         )
+
     JournalEncryptedTo = T(
         en="Journal encrypted to {path}",
         ja="",
         )
+
     JournalDecryptedTo = T(
         en="Journal decrypted to {path}",
         ja="",
         )
+
     BackupCreated = T(
         en="Created a backup at {filename}",
         ja="",


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Japanese localization

This code is intended to (1) implement a format for each message to strings for multiple languages, and (2) provide a set of Japanese translated strings.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
