### PR TITLE
fix typed.js URL

### DIFF
--- a/docs_theme/index.html
+++ b/docs_theme/index.html
@@ -103,7 +103,7 @@ License: https://www.gnu.org/licenses/gpl-3.0.html
     <footer>
         jrnl is made with love by <a href="https://github.com/jrnl-org/jrnl/graphs/contributors" title="Contributors">many fabulous people</a>. If you need help, <a href="https://github.com/jrnl-org/jrnl/issues/new/choose" title="Open a new issue on Github">submit an issue</a> on Github.
     </footer>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/typed.js/2.1.0/typed.min.js"></script>
+    <script src="https://unpkg.com/typed.js@2.1.0/dist/typed.umd.js"></script>
     <script>
     new Typed("#typed", {
         strings: [


### PR DESCRIPTION
<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->
## Fix
Replaces the link to the `typed.js` script with a new one because the current one is broken and so the typing animation in the landing page does not start.

Fixes #1969 

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
