### PR TITLE
Remove deprecated command in Poetry >2.0 causing error in CI

### DIFF
--- a/.github/actions/run_tests/action.yaml
+++ b/.github/actions/run_tests/action.yaml
@@ -34,7 +34,7 @@ runs:
       echo '::endgroup::'
 
       echo '::group::Other dependencies'
-      poetry install --remove-untracked
+      poetry install
       echo '::endgroup::'
 
       echo 'DEPS_INSTALLED=true' >> $GITHUB_ENV

--- a/.github/actions/run_tests/action.yaml
+++ b/.github/actions/run_tests/action.yaml
@@ -34,7 +34,7 @@ runs:
       echo '::endgroup::'
 
       echo '::group::Other dependencies'
-      poetry install
+      poetry sync
       echo '::endgroup::'
 
       echo 'DEPS_INSTALLED=true' >> $GITHUB_ENV

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -65,7 +65,7 @@ jobs:
       run: |
         pip install poetry
         poetry config --local virtualenvs.in-project true
-        poetry install --no-root
+        poetry sync --no-root
         npm install
         echo "node_modules/.bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -65,7 +65,7 @@ jobs:
       run: |
         pip install poetry
         poetry config --local virtualenvs.in-project true
-        poetry install --no-root --remove-untracked
+        poetry install --no-root
         npm install
         echo "node_modules/.bin" >> "$GITHUB_PATH"
 


### PR DESCRIPTION
The `--remove-untracked` flag was recently deprecated in Poetry 2.0. It is now causing errors in the CI pipelines because we used the flag. This PR removes the flag to allow the CI to proceed.

Example of failing pipeline: https://github.com/jrnl-org/jrnl/actions/runs/13353056619/job/37373472281?pr=1970

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [ ] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
