### PR TITLE
feat: Add Google Doc journal type

### DIFF
--- a/docs/journal-types.md
+++ b/docs/journal-types.md
@@ -63,3 +63,78 @@ for your `new` journal:
 ```
 jrnl projects --format txt | jrnl new --import
 ```
+
+## Google Doc Journal (`googledoc`)
+
+The `googledoc` journal type allows you to keep your journal entries synchronized between a local text file and a Google Document. Writes are sent to both locations, while reads are performed from the local text file for speed and offline access.
+
+### Configuration
+
+To use the Google Doc journal type, add a new journal configuration to your `jrnl.yaml` file (or your main configuration file).
+
+Example configuration:
+
+```yaml
+journals:
+  gdoc_journal: # Your preferred journal name
+    type: googledoc
+    # Path to the local text file for your journal
+    journal: /path/to/your/local_gdoc_journal.txt 
+    # The ID of the Google Document you want to sync with
+    google_doc_id: "your_google_document_id_here"
+    # Path to your Google API credentials file (credentials.json)
+    # If not specified, jrnl will look for 'google_credentials.json' 
+    # in your jrnl configuration directory (e.g., ~/.jrnl/google_credentials.json)
+    google_credentials_path: /path/to/your/google_credentials.json 
+    # Optional: Allow writing an empty journal to Google Docs (defaults to false)
+    # allow_empty_gdoc_write: false 
+    # Other standard journal options (encrypt, default_hour, timeformat, etc.) can also be included
+    encrypt: false # Encryption is applied to the local file only.
+```
+
+**Key Configuration Options:**
+
+*   `type: googledoc`: **Required.** Specifies the journal type.
+*   `journal`: **Required.** The file path to the local copy of your journal.
+*   `google_doc_id`: **Required.** The ID of the Google Document. You can find this ID in the URL of your Google Doc: `https://docs.google.com/document/d/YOUR_DOCUMENT_ID_IS_HERE/edit`.
+*   `google_credentials_path`: **Required.** The full path to your `credentials.json` file obtained from the Google Cloud Console. Jrnl needs this to authenticate with the Google Docs API on your behalf.
+*   `encrypt`: (Optional) If set to `true`, encryption will be applied *only* to the local text file. The content in the Google Doc will remain unencrypted by `jrnl`.
+
+### Setting Up Google API Credentials
+
+To use this feature, you need to:
+
+1.  **Create or use an existing project in the [Google Cloud Console](https://console.cloud.google.com/).**
+2.  **Enable the Google Docs API** for your project.
+    *   In the Google Cloud Console, navigate to "APIs & Services" > "Library".
+    *   Search for "Google Docs API" and enable it.
+3.  **Create OAuth 2.0 Credentials for a Desktop Application.**
+    *   Navigate to "APIs & Services" > "Credentials".
+    *   Click "Create Credentials" > "OAuth client ID".
+    *   Select "Desktop app" as the application type.
+    *   Give it a name (e.g., "jrnl-googledoc-access").
+    *   After creation, a dialog will show your Client ID and Client Secret. Click **"DOWNLOAD JSON"** to save the `credentials.json` file.
+    *   Store this `credentials.json` file in a secure location on your computer and provide the path to it in the `google_credentials_path` configuration.
+    *   For detailed instructions, refer to Google's guide on [Authorizing credentials for a desktop application](https://developers.google.com/docs/api/quickstart/python#authorize_credentials_for_a_desktop_application) (follow steps related to creating credentials).
+
+### First-Time Authentication
+
+The first time you use `jrnl` with a `googledoc` journal (or when your authorization expires), `jrnl` will attempt to open a web browser. You will be asked to log in to your Google account and authorize `jrnl` to access your Google Docs.
+
+*   Follow the prompts in your browser.
+*   Once authorized, `jrnl` will store an access token (typically in a file named `google_token.json` within your `jrnl` configuration directory). This token allows `jrnl` to access your Google Doc without requiring you to log in each time.
+*   Keep your `credentials.json` file safe, but the `google_token.json` is what `jrnl` uses for day-to-day operations. If `google_token.json` is deleted or becomes invalid, `jrnl` will re-initiate the browser authentication flow using your `credentials.json`.
+
+### How it Works
+
+*   **Writing Entries:** When you write a new entry or modify your journal, `jrnl` will:
+    1.  Save the changes to your local text file (specified by the `journal` path).
+    2.  Update the content of the specified Google Document, replacing its entire content with your journal's current full text.
+*   **Reading Entries:** When `jrnl` reads entries (e.g., for display, export), it reads from the local text file. This ensures fast access and offline capability.
+*   **Synchronization Strategy:** The Google Doc is treated as a mirror of the local file's content. The entire content of the Google Doc is overwritten on each write to ensure consistency. This means any manual changes made directly in the Google Doc (not through `jrnl`) will be lost the next time `jrnl` writes to it.
+
+### Important Notes
+
+*   **Internet Connection:** An internet connection is required for the initial authentication and for writing entries to the Google Doc. If you are offline, writes will still go to your local file, but the Google Doc will not be updated until `jrnl` is run again with an internet connection and a write operation occurs.
+*   **API Usage & Rate Limits:** For most users, Google's API rate limits should not be an issue. However, extremely frequent writes to large journals could potentially hit these limits.
+*   **Security:** The `credentials.json` file grants significant access. Protect it appropriately. The content in the Google Doc itself is subject to your Google account's security and sharing settings.

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -72,7 +72,24 @@ def save_config(config: dict, alt_config_path: str | None = None) -> None:
 def get_default_config() -> dict[str, Any]:
     return {
         "version": __version__,
-        "journals": {"default": {"journal": get_default_journal_path()}},
+        "journals": {
+            "default": {"journal": get_default_journal_path()},
+            # Example of how a googledoc journal could be configured.
+            # Users would typically define this in their config file for a specific journal.
+            # "my_gdoc_journal": {
+            #     "type": "googledoc",
+            #     "journal": "my_local_gdoc_backup.txt", # Local backup file
+            #     "google_doc_id": "YOUR_GOOGLE_DOC_ID_HERE",
+            #     "encrypt": False, # Encryption for googledoc might need specific handling
+            #     "default_hour": 9,
+            #     "default_minute": 0,
+            #     "timeformat": "%Y-%m-%d %H:%M",
+            #     "tagsymbols": "@",
+            #     "highlight": True,
+            #     "linewrap": 80,
+            #     "indent_character": "|",
+            # }
+        },
         "editor": os.getenv("VISUAL") or os.getenv("EDITOR") or "",
         "encrypt": False,
         "template": False,
@@ -104,20 +121,38 @@ def get_default_colors() -> dict[str, Any]:
 def scope_config(config: dict, journal_name: str) -> dict:
     if journal_name not in config["journals"]:
         return config
-    config = config.copy()
-    journal_conf = config["journals"].get(journal_name)
-    if isinstance(journal_conf, dict):
-        # We can override the default config on a by-journal basis
-        logging.debug(
-            "Updating configuration with specific journal overrides:\n%s",
-            pretty_repr(journal_conf),
-        )
-        config.update(journal_conf)
-    else:
-        # But also just give them a string to point to the journal file
-        config["journal"] = journal_conf
+    
+    # Start with a copy of the global config
+    scoped_config = config.copy()
+    
+    journal_conf_entry = config["journals"].get(journal_name)
 
-    logging.debug("Scoped config:\n%s", pretty_repr(config))
+    if isinstance(journal_conf_entry, dict):
+        # This is a journal configured with specific options
+        # Merge these specific options into the copied global config
+        logging.debug(
+            "Updating configuration with specific journal overrides for '%s':\n%s",
+            journal_name,
+            pretty_repr(journal_conf_entry),
+        )
+        scoped_config.update(journal_conf_entry)
+    elif isinstance(journal_conf_entry, str):
+        # This is a simple string pointing to a journal file
+        scoped_config["journal"] = journal_conf_entry
+    else:
+        # Should not happen if config is well-formed, but handle gracefully
+        logging.warning(
+            "Journal configuration for '%s' is neither a dict nor a string. Using global defaults.",
+            journal_name
+        )
+        # In this case, scoped_config remains a copy of the global config,
+        # with 'journal' potentially not set or set to a global default if any.
+        # If 'default' journal has a simple path, that might be used, or it might need explicit handling.
+        # For now, we ensure 'journal' key exists if it's a simple string config.
+        # If it's a new journal type like 'googledoc', its 'type' field in journal_conf_entry
+        # would have been handled by the dict branch.
+
+    logging.debug("Scoped config for journal '%s':\n%s", journal_name, pretty_repr(scoped_config))
     return config
 
 

--- a/jrnl/journals/GoogleDocJournal.py
+++ b/jrnl/journals/GoogleDocJournal.py
@@ -1,0 +1,286 @@
+# Copyright © 2023-2024 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+import logging
+import os
+import traceback # Added for detailed error logging
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+from jrnl.path import get_config_path # For determining jrnl's config directory
+from .Journal import Journal # Ensure Journal base class is imported
+
+
+class GoogleDocJournal(Journal):
+    _logger = logging.getLogger(__name__)
+    SCOPES = ["https://www.googleapis.com/auth/documents"] # Class constant for scopes
+
+    def __init__(self, name="default", **kwargs):
+        super().__init__(name, **kwargs)
+        self._logger.debug(f"Initializing GoogleDocJournal '{name}' with config: {kwargs}")
+        self.google_doc_id = self.config.get("google_doc_id")
+        self.creds = None
+        self.docs_service = None
+
+        try:
+            # config_file_path is the path to the jrnl.yaml or equivalent
+            config_file_path = get_config_path() 
+            jrnl_base_dir = os.path.dirname(config_file_path)
+            if not jrnl_base_dir: # Fallback if dirname is empty
+                self._logger.warning("Could not determine jrnl base directory from get_config_path(). Falling back to ~/.jrnl.")
+                jrnl_base_dir = os.path.join(os.path.expanduser("~"), ".jrnl")
+        except Exception as e: 
+            self._logger.error(f"Error getting jrnl config path: {e}. Falling back to ~/.jrnl for token/credentials.")
+            jrnl_base_dir = os.path.join(os.path.expanduser("~"), ".jrnl")
+        
+        if not os.path.exists(jrnl_base_dir):
+            try:
+                os.makedirs(jrnl_base_dir)
+                self._logger.info(f"Created jrnl configuration directory at {jrnl_base_dir}")
+            except OSError as e:
+                self._logger.error(f"Failed to create jrnl configuration directory at {jrnl_base_dir}: {e}. Using current directory as fallback.")
+                jrnl_base_dir = "." # Fallback to current directory
+
+        self.token_path = self.config.get("google_token_path", os.path.join(jrnl_base_dir, "google_token.json"))
+        self.credentials_path = self.config.get("google_credentials_path", os.path.join(jrnl_base_dir, "google_credentials.json"))
+        
+        self._logger.info(f"Google Docs Token path: {self.token_path}")
+        self._logger.info(f"Google Docs Credentials path (user-provided 'credentials.json'): {self.credentials_path}")
+
+        if self.google_doc_id:
+            self._logger.info(f"Google Doc ID '{self.google_doc_id}' is configured. Initializing Google Docs service.")
+            self._initialize_docs_service()
+        else:
+            self._logger.info("No Google Doc ID configured. Google Docs service will not be initialized at startup.")
+
+    def _initialize_docs_service(self):
+        self._logger.debug("Attempting to initialize Google Docs service...")
+        if os.path.exists(self.token_path):
+            try:
+                self.creds = Credentials.from_authorized_user_file(self.token_path, self.SCOPES)
+                self._logger.info(f"Loaded existing Google credentials from {self.token_path}")
+            except Exception as e:
+                self._logger.error(f"Error loading token file '{self.token_path}': {e}. Credentials may be invalid or require re-authentication.")
+                self.creds = None
+
+        if not self.creds or not self.creds.valid:
+            if self.creds and self.creds.expired and self.creds.refresh_token:
+                try:
+                    self._logger.info("Refreshing expired Google access token...")
+                    self.creds.refresh(Request())
+                    self._logger.info("Google access token refreshed successfully.")
+                except Exception as e:
+                    self._logger.error(f"Error refreshing Google access token: {e}. Re-authentication will be attempted.")
+                    self._run_auth_flow() 
+            else:
+                self._logger.info("No valid Google credentials found, running authentication flow.")
+                self._run_auth_flow()
+            
+            if self.creds and self.creds.valid: # After potential auth flow or refresh
+                try:
+                    with open(self.token_path, "w") as token_file:
+                        token_file.write(self.creds.to_json())
+                    self._logger.info(f"Google credentials saved to {self.token_path}")
+                except Exception as e:
+                    self._logger.error(f"Error saving Google token file '{self.token_path}': {e}")
+        
+        if self.creds and self.creds.valid:
+            try:
+                self.docs_service = build("docs", "v1", credentials=self.creds, cache_discovery=False) # cache_discovery=False for dynamic environments
+                self._logger.info("Google Docs service initialized successfully.")
+            except Exception as e:
+                self._logger.error(f"Error building Google Docs service: {e}")
+                self.docs_service = None
+        else:
+            self._logger.warning("Could not initialize Google Docs service due to invalid or missing credentials after auth attempt.")
+
+    def _run_auth_flow(self):
+        self._logger.info("Starting Google OAuth authentication flow...")
+        if not os.path.exists(self.credentials_path):
+            self._logger.error(f"Google API Credentials file ('{os.path.basename(self.credentials_path)}') not found at expected path: '{self.credentials_path}'.")
+            self._logger.error("Please download your OAuth 2.0 client ID and secret from the Google Cloud Console ( τύπος \"Desktop app\" ) and save it as 'google_credentials.json' (or configure 'google_credentials_path' in jrnl config) and place it at the specified path.")
+            self._logger.error("Instructions: https://developers.google.com/docs/api/quickstart/python#authorize_credentials_for_a_desktop_application")
+            # Consider using print_msg for more direct user feedback if available and appropriate
+            # from jrnl.output import print_msg
+            # from jrnl.messages import Message, MsgText, MsgStyle
+            # print_msg(Message(MsgText.PLAIN_TEXT_MESSAGE_TEMPLATE, MsgStyle.ERROR, {"text": "Google API Credentials file not found..."}))
+            self.creds = None 
+            return
+
+        try:
+            flow = InstalledAppFlow.from_client_secrets_file(self.credentials_path, self.SCOPES)
+            self._logger.info("Attempting to launch browser for Google OAuth authentication. Please follow the prompts in your browser.")
+            # Make sure user is informed that a browser will open.
+            # Consider print_msg here for direct feedback.
+            print("Attempting to launch browser for Google OAuth authentication. Please follow the prompts in your browser. If the browser does not open, please check your system's default browser settings.")
+            
+            self.creds = flow.run_local_server(port=0,
+                                               authorization_prompt_message="Please authorize jrnl to access your Google Docs in the web browser that has just opened. Waiting for authorization...",
+                                               success_message="OAuth2 authorization successful! You can close the browser tab/window.",
+                                               open_browser=True) # Explicitly true, though it's default
+            
+            if self.creds:
+                self._logger.info("OAuth flow completed successfully. Credentials obtained.")
+            else:
+                # This case might not be hit if run_local_server raises an exception on failure,
+                # but good for robustness.
+                self._logger.error("OAuth flow did not result in valid credentials.")
+                self.creds = None
+
+        except FileNotFoundError: # Should be caught by the initial os.path.exists, but good practice.
+            self._logger.error(f"Credentials file not found at '{self.credentials_path}' during OAuth flow initiation.")
+            self.creds = None
+        except Exception as e:
+            self._logger.error(f"An error occurred during the Google OAuth flow: {e}")
+            self._logger.error("Possible issues: Incorrectly formatted credentials.json, network problems, or browser interaction issues.")
+            self.creds = None
+        
+        # The obtained self.creds will be saved by the calling method _initialize_docs_service
+        # if they are valid.
+
+    def open(self, filename: str | None = None) -> "GoogleDocJournal":
+        # For now, this will behave like the standard journal's open
+        # It will be modified later to handle Google Docs specifics
+        return super().open(filename)
+
+    def write(self, filename: str | None = None) -> None:
+        super().write(filename) # Write to local file first
+        self._logger.debug(f"Local journal file '{filename if filename else self.config['journal']}' written.")
+
+        if self.google_doc_id:
+            if not self.docs_service: # If service wasn't initialized at startup (e.g. no doc_id then, but added later)
+                self._logger.warning("Google Docs service not initialized. Attempting to initialize for write operation.")
+                self._initialize_docs_service() 
+
+            if self.docs_service:
+                self._logger.info(f"Preparing to write to Google Doc ID: {self.google_doc_id}")
+                # Determine what content to write. For now, the full journal text.
+                # This could be optimized later to only send new/modified entries.
+                full_journal_text = self._to_text() 
+                
+                # allow_empty_gdoc_write can be a config option if needed, default to False
+                allow_empty = self.config.get("allow_empty_gdoc_write", False) 
+                if full_journal_text or allow_empty:
+                    self._write_to_google_doc(full_journal_text)
+                else:
+                    self._logger.info("Journal is empty and 'allow_empty_gdoc_write' is false. Nothing to write to Google Doc.")
+            else:
+                self._logger.error("Google Docs service could not be initialized. Cannot write to Google Doc.")
+        else:
+            self._logger.debug("No Google Doc ID configured. Skipping write to Google Docs.")
+
+    def _write_to_google_doc(self, content: str):
+        if not self.docs_service: # Should be checked by caller, but good for safety
+            self._logger.error("Google Docs service not available. Cannot write to Google Doc.")
+            return
+        
+        # Ensure content is not None, though _to_text() should return "" for empty.
+        content_to_write = content if content is not None else ""
+
+        if not self.docs_service:
+            self._logger.error("Google Docs service not available. Cannot write to Google Doc.")
+            return
+        if not self.google_doc_id:
+            self._logger.error("Google Doc ID not configured. Cannot write to Google Doc.")
+            return
+        
+        content_to_write = content if content is not None else ""
+
+        self._logger.info(f"Preparing to write to Google Doc ID '{self.google_doc_id}'. Strategy: Overwrite/Replace.")
+
+        requests = []
+        try:
+            # 1. Get the current document's structure to find the end of content for deletion.
+            # Fetching the full document is more reliable for complex documents.
+            document = self.docs_service.documents().get(documentId=self.google_doc_id).execute()
+            
+            current_doc_end_index = 1 # Default for an empty document (has one implicit paragraph).
+            body_content_list = document.get('body', {}).get('content', [])
+            if body_content_list:
+                # The document's content is a list of StructuralElements.
+                # The last element's endIndex is the effective length of the document's content.
+                # Ensure we only access endIndex if the element is not None and has the key.
+                last_element = body_content_list[-1]
+                if last_element and 'endIndex' in last_element:
+                    current_doc_end_index = last_element['endIndex']
+
+            self._logger.debug(f"Current document's perceived end index: {current_doc_end_index}")
+
+            # 2. Create a request to delete all existing content.
+            # The Google Docs API uses 1-based indexing. The range for deletion is [startIndex, endIndex).
+            # To delete all content, we delete from index 1 up to the document's current total length (current_doc_end_index).
+            if current_doc_end_index > 1:  # If there's content beyond the initial empty paragraph.
+                requests.append({
+                    'deleteContentRange': {
+                        'range': {
+                            'startIndex': 1, # Deletion starts after the very first position.
+                            'endIndex': current_doc_end_index, # Deletes up to (but not including) this index.
+                        }
+                    }
+                })
+                self._logger.debug(f"Added request to delete content from range [1, {current_doc_end_index}).")
+
+            # 3. Create a request to insert the new content at the beginning (index 1).
+            if content_to_write:
+                requests.append({
+                    'insertText': {
+                        'location': {
+                            'index': 1  # Insert at the beginning of the document body.
+                        },
+                        'text': content_to_write
+                    }
+                })
+                self._logger.debug(f"Added request to insert new content (length {len(content_to_write)}) at index 1.")
+            elif not requests: 
+                # This means current_doc_end_index <= 1 (doc was empty) AND content_to_write is empty.
+                self._logger.info("Document is already empty and new content is empty. No API call needed.")
+                return 
+
+            # 4. Execute the batchUpdate if there are any requests
+            if requests:
+                self._logger.info(f"Executing batchUpdate with {len(requests)} requests for Google Doc '{self.google_doc_id}'.")
+                self.docs_service.documents().batchUpdate(
+                    documentId=self.google_doc_id, body={'requests': requests}
+                ).execute()
+                self._logger.info(f"Successfully updated content in Google Doc '{self.google_doc_id}'.")
+            # No 'else' needed here as the "already empty and new content is empty" case is handled above.
+            
+        except HttpError as error:
+            self._logger.error(f"An HttpError occurred while writing to Google Doc '{self.google_doc_id}': {error.resp.status} - {error._get_reason()}")
+            error_details = "No additional details."
+            if error.content:
+                try:
+                    error_details = error.content.decode('utf-8') # Try to decode as utf-8
+                except Exception: 
+                    error_details = str(error.content) # Fallback to string representation
+            self._logger.error(f"Details: {error_details}")
+                if error.resp.status == 400:
+                    self._logger.error("HTTP 400 Bad Request: The request sent by jrnl was malformed. This could be due to an unexpected document structure or a bug in jrnl. Please report this issue if it persists.")
+                elif error.resp.status == 401:
+                    self._logger.error("HTTP 401 Unauthorized: Your authentication credentials may be invalid or expired. jrnl will attempt to re-authenticate on the next run. If this persists, your Google token might be corrupted or scopes insufficient.")
+                    # Forcing re-authentication by clearing current credentials
+                    self.creds = None
+                    self.docs_service = None 
+                    try:
+                        if os.path.exists(self.token_path):
+                            os.remove(self.token_path)
+                            self._logger.info(f"Removed potentially corrupted token file at {self.token_path} to force re-authentication.")
+                    except Exception as ex_remove:
+                        self._logger.error(f"Error removing token file {self.token_path}: {ex_remove}")
+                elif error.resp.status == 403:
+                    self._logger.error("HTTP 403 Forbidden: Permission denied. Ensure 'jrnl' has write access to the Google Doc and that the Google Docs API is enabled in your Google Cloud project. Check the sharing settings for the document.")
+            elif error.resp.status == 404:
+                    self._logger.error(f"HTTP 404 Not Found: The Google Doc with ID '{self.google_doc_id}' was not found. Please verify the 'google_doc_id' in your journal's configuration.")
+                elif error.resp.status == 429:
+                    self._logger.error("HTTP 429 Resource Exhausted (Rate Limit): You've made too many requests to Google Docs API in a short period. Please wait a while and try again.")
+                elif error.resp.status >= 500 and error.resp.status < 600:
+                    self._logger.error(f"HTTP {error.resp.status} Server Error: A server-side error occurred with Google's services. This is likely a temporary issue. Please try again later.")
+                # else:
+                #    self._logger.error(f"Unhandled HTTP Error {error.resp.status}: {error._get_reason()}. Details: {error_details}")
+        except Exception as e:
+            self._logger.error(f"A general error occurred while writing to Google Doc '{self.google_doc_id}': {e}")
+            # It's good to have traceback for unexpected errors during development/debugging.
+            # Import traceback at the top of the file: import traceback
+            self._logger.debug(f"Traceback: {traceback.format_exc()}")

--- a/jrnl/journals/Journal.py
+++ b/jrnl/journals/Journal.py
@@ -17,6 +17,7 @@ from jrnl.path import expand_path
 from jrnl.prompt import yesno
 
 from .Entry import Entry
+from jrnl.journals.GoogleDocJournal import GoogleDocJournal
 
 
 class Tag:
@@ -475,7 +476,21 @@ def open_journal(journal_name: str, config: dict, legacy: bool = False) -> Journ
     config = config.copy()
     config["journal"] = expand_path(config["journal"])
 
-    if os.path.isdir(config["journal"]):
+    if config.get("type") == "googledoc":
+        # Potentially check for encryption conflicts if GoogleDocJournal doesn't support it
+        if config["encrypt"]:
+            print_msg(
+                Message(
+                    MsgText.ConfigEncryptedForUnencryptableJournalType, # Or a new specific message
+                    MsgStyle.WARNING,
+                    {
+                        "journal_name": journal_name,
+                    },
+                )
+            )
+            # Decide if to proceed or raise error, for now, let's assume it might proceed or be handled by GoogleDocJournal's own encryption logic later
+        return GoogleDocJournal(journal_name, **config).open()
+    elif os.path.isdir(config["journal"]):
         if config["encrypt"]:
             print_msg(
                 Message(

--- a/jrnl/journals/__init__.py
+++ b/jrnl/journals/__init__.py
@@ -3,3 +3,4 @@ from .Entry import Entry
 from .FolderJournal import Folder
 from .Journal import Journal
 from .Journal import open_journal
+from .GoogleDocJournal import GoogleDocJournal

--- a/tests/unit/test_google_doc_journal.py
+++ b/tests/unit/test_google_doc_journal.py
@@ -1,0 +1,268 @@
+# tests/unit/test_google_doc_journal.py
+import unittest
+from unittest.mock import patch, MagicMock, mock_open
+import os # For path manipulations if needed in tests
+import logging
+
+# Assuming jrnl.journals.GoogleDocJournal can be imported
+# This might require PYTHONPATH adjustments if running standalone,
+# but pytest/unittest discovery should handle it in a project structure.
+from jrnl.journals.GoogleDocJournal import GoogleDocJournal 
+# We will mock jrnl.path.get_config_path used in GoogleDocJournal.__init__
+
+# Mock HttpError if not easily importable or to simplify
+# Based on googleapiclient.errors.HttpError
+class MockHttpError(Exception):
+    def __init__(self, resp_status, reason_phrase, content=b""):
+        super().__init__(f"<{resp_status}> {reason_phrase}")
+        self.resp = MagicMock()
+        self.resp.status = resp_status
+        self.resp.reason = reason_phrase # HttpError uses resp.reason
+        self.content = content
+
+    def _get_reason(self): # Match the method name in HttpError
+        return self.resp.reason
+
+# Suppress logging output during tests unless specifically testing for it
+logging.disable(logging.CRITICAL)
+
+class TestGoogleDocJournal(unittest.TestCase):
+
+    def setUp(self):
+        # Basic config for the journal
+        self.mock_journal_name = "gdoc_test"
+        self.base_config_dir = "/fake/config_dir" # Used by mock_get_config_path
+        
+        self.mock_config = {
+            "type": "googledoc",
+            "journal": "/fake/local_journal.txt", # Local backup file path
+            "google_doc_id": "fake_doc_id",
+            # Paths for token and credentials will be derived from base_config_dir
+            # or overridden by specific config values if provided.
+            "google_credentials_path": os.path.join(self.base_config_dir, "google_credentials.json"),
+            "google_token_path": os.path.join(self.base_config_dir, "google_token.json"),
+        }
+
+        # Patch get_config_path used in GoogleDocJournal.__init__
+        self.patch_get_config_path = patch('jrnl.journals.GoogleDocJournal.get_config_path')
+        self.mock_get_config_path = self.patch_get_config_path.start()
+        # Let get_config_path return the path to a dummy jrnl.yaml, so its dirname is base_config_dir
+        self.mock_get_config_path.return_value = os.path.join(self.base_config_dir, "jrnl.yaml")
+
+        # Patch external dependencies common to most tests
+        self.patch_os_path_exists = patch('os.path.exists')
+        self.mock_os_path_exists = self.patch_os_path_exists.start()
+
+        self.patch_makedirs = patch('os.makedirs')
+        self.mock_makedirs = self.patch_makedirs.start()
+        
+        self.patch_credentials_from_file = patch('jrnl.journals.GoogleDocJournal.Credentials.from_authorized_user_file')
+        self.mock_credentials_from_file = self.patch_credentials_from_file.start()
+
+        self.patch_credentials_refresh = patch('jrnl.journals.GoogleDocJournal.Credentials.refresh')
+        # This needs to be attached to a mock Credentials instance, done in tests where creds are loaded
+
+        self.patch_installed_app_flow = patch('jrnl.journals.GoogleDocJournal.InstalledAppFlow.from_client_secrets_file')
+        self.mock_installed_app_flow = self.patch_installed_app_flow.start()
+        
+        self.patch_build = patch('jrnl.journals.GoogleDocJournal.build')
+        self.mock_build = self.patch_build.start()
+
+        self.patch_open = patch('builtins.open', new_callable=mock_open)
+        self.mock_open_file = self.patch_open.start()
+        
+        self.patch_os_remove = patch('os.remove')
+        self.mock_os_remove = self.patch_os_remove.start()
+
+        # Default mock behaviors
+        self.mock_os_path_exists.return_value = False # Default to no files existing
+        self.mock_credentials_from_file.return_value = None # Default to no existing credentials
+        
+        self.mock_flow_instance = MagicMock()
+        self.mock_installed_app_flow.return_value = self.mock_flow_instance
+        
+        self.mock_service_instance = MagicMock()
+        self.mock_build.return_value = self.mock_service_instance
+        
+        # Mock for credentials.refresh()
+        self.mock_creds_instance = MagicMock()
+
+
+    def tearDown(self):
+        self.patch_get_config_path.stop()
+        self.patch_os_path_exists.stop()
+        self.patch_makedirs.stop()
+        self.patch_credentials_from_file.stop()
+        # self.patch_credentials_refresh.stop() # Not started directly
+        self.patch_installed_app_flow.stop()
+        self.patch_build.stop()
+        self.patch_open.stop()
+        self.patch_os_remove.stop()
+        logging.disable(logging.NOTSET) # Re-enable logging
+
+    def _create_journal_instance(self, config_overrides=None):
+        # Ensure base_config_dir exists for __init__ logic
+        # In __init__, if jrnl_base_dir (derived from get_config_path) doesn't exist, it tries to create it.
+        # Let's simulate it exists to prevent makedirs call for the base dir itself.
+        def os_path_exists_side_effect(path):
+            if path == self.base_config_dir:
+                return True
+            # Fallback to default for other paths (usually False unless overridden in test)
+            return self.mock_os_path_exists.orig_return_value if hasattr(self.mock_os_path_exists, 'orig_return_value') else False
+        
+        # Store original return_value if needed, or use specific side_effects in tests.
+        # For this generic instance creation, assume it's okay if it's just False for token/creds paths.
+        # More specific side_effects for os.path.exists will be set in individual tests.
+
+        current_config = self.mock_config.copy()
+        if config_overrides:
+            current_config.update(config_overrides)
+        
+        # Ensure derived paths are correct if base_config_dir changed
+        if "google_credentials_path" not in (config_overrides or {}):
+            current_config["google_credentials_path"] = os.path.join(self.base_config_dir, "google_credentials.json")
+        if "google_token_path" not in (config_overrides or {}):
+            current_config["google_token_path"] = os.path.join(self.base_config_dir, "google_token.json")
+            
+        return GoogleDocJournal(name=self.mock_journal_name, **current_config)
+
+    def test_init_calls_initialize_service_if_doc_id_present(self):
+        with patch.object(GoogleDocJournal, '_initialize_docs_service') as mock_init_service:
+            self._create_journal_instance()
+            mock_init_service.assert_called_once()
+
+    def test_init_does_not_initialize_service_if_no_doc_id(self):
+        with patch.object(GoogleDocJournal, '_initialize_docs_service') as mock_init_service:
+            self._create_journal_instance(config_overrides={"google_doc_id": None})
+            mock_init_service.assert_not_called()
+            
+    def test_initialize_service_loads_valid_token(self):
+        token_path = self.mock_config["google_token_path"]
+        self.mock_os_path_exists.side_effect = lambda path: path == token_path
+        
+        self.mock_creds_instance.valid = True
+        self.mock_creds_instance.expired = False
+        self.mock_creds_instance.refresh_token = "dummy_refresh_token" # Has a refresh token
+        self.mock_credentials_from_file.return_value = self.mock_creds_instance
+        
+        journal = self._create_journal_instance()
+        
+        self.mock_credentials_from_file.assert_called_with(token_path, GoogleDocJournal.SCOPES)
+        self.mock_build.assert_called_with("docs", "v1", credentials=self.mock_creds_instance, cache_discovery=False)
+        self.assertIsNotNone(journal.docs_service)
+        self.mock_installed_app_flow.assert_not_called() # Auth flow should not run
+        self.mock_open_file.assert_not_called() # Token should not be re-saved
+
+    def test_initialize_service_runs_auth_flow_if_no_token(self):
+        # Simulate only credentials.json exists, token_path does not.
+        credentials_path = self.mock_config["google_credentials_path"]
+        self.mock_os_path_exists.side_effect = lambda path: path == credentials_path
+        
+        with patch.object(GoogleDocJournal, '_run_auth_flow') as mock_run_auth_method:
+            # Simulate _run_auth_flow does not successfully set creds by default for this isolated test
+            # (i.e., self.creds remains None after its call unless it's made to set it)
+            journal = self._create_journal_instance()
+            mock_run_auth_method.assert_called_once()
+            # self.creds would be None if _run_auth_flow didn't set it.
+            # So, build should not be called if _run_auth_flow (as mocked here) doesn't update self.creds
+            self.mock_build.assert_not_called()
+
+
+    def test_run_auth_flow_handles_missing_credentials_file(self):
+        # Ensure google_credentials_path does not exist
+        self.mock_os_path_exists.return_value = False 
+        
+        journal = self._create_journal_instance() # This calls _initialize_docs_service
+        # _initialize_docs_service will call _run_auth_flow because no token exists
+        
+        self.mock_installed_app_flow.assert_not_called() # Flow object should not be created
+        self.assertIsNone(journal.creds)
+        # Check logs (optional here, but good for real debugging)
+
+    def test_run_auth_flow_simulates_successful_interactive_auth(self):
+        # Simulate credentials.json exists
+        credentials_path = self.mock_config["google_credentials_path"]
+        self.mock_os_path_exists.side_effect = lambda path: path == credentials_path
+
+        mock_successful_creds = MagicMock()
+        mock_successful_creds.valid = True
+        self.mock_flow_instance.run_local_server.return_value = mock_successful_creds
+        
+        journal = self._create_journal_instance() # This calls _initialize_docs_service, which calls _run_auth_flow
+        
+        self.mock_installed_app_flow.assert_called_with(credentials_path, GoogleDocJournal.SCOPES)
+        self.mock_flow_instance.run_local_server.assert_called_once()
+        self.assertEqual(journal.creds, mock_successful_creds)
+        # Also check that token is saved
+        self.mock_open_file.assert_called_with(self.mock_config["google_token_path"], "w")
+        self.mock_open_file().write.assert_called_with(mock_successful_creds.to_json())
+        # And service is built
+        self.mock_build.assert_called_with("docs", "v1", credentials=mock_successful_creds, cache_discovery=False)
+
+
+    @patch('jrnl.journals.GoogleDocJournal.traceback.format_exc') # Mock traceback
+    def test_write_to_google_doc_overwrite_logic(self, mock_traceback_format_exc):
+        # Setup for a successful write to an existing document
+        # Assume service is initialized and journal instance is ready
+        self.mock_os_path_exists.side_effect = lambda path: path == self.mock_config["google_token_path"]
+        self.mock_creds_instance.valid = True
+        self.mock_credentials_from_file.return_value = self.mock_creds_instance
+        journal = self._create_journal_instance()
+        self.assertIsNotNone(journal.docs_service) # Ensure service was built
+
+        # Mock the .get().execute() call for current doc content
+        mock_get_result = {
+            'body': {
+                'content': [
+                    {'endIndex': 1}, 
+                    {'startIndex': 1, 'endIndex': 50, 'paragraph': {}}, 
+                ]
+            },
+            'documentId': 'fake_doc_id' # Added for completeness
+        }
+        self.mock_service_instance.documents().get().execute.return_value = mock_get_result
+        
+        # Mock the .batchUpdate().execute() call
+        self.mock_service_instance.documents().batchUpdate().execute.return_value = {} # Success
+
+        new_content = "This is the new journal content."
+        journal._write_to_google_doc(new_content) # Call the method under test
+
+        expected_requests = [
+            {'deleteContentRange': {'range': {'startIndex': 1, 'endIndex': 50}}},
+            {'insertText': {'location': {'index': 1}, 'text': new_content}}
+        ]
+        self.mock_service_instance.documents().batchUpdate.assert_called_once_with(
+            documentId="fake_doc_id",
+            body={'requests': expected_requests}
+        )
+
+    @patch('jrnl.journals.GoogleDocJournal.traceback.format_exc')
+    def test_write_to_google_doc_handles_httperror_403(self, mock_traceback_format_exc):
+        # Assume service is initialized
+        self.mock_os_path_exists.side_effect = lambda path: path == self.mock_config["google_token_path"]
+        self.mock_creds_instance.valid = True
+        self.mock_credentials_from_file.return_value = self.mock_creds_instance
+        journal = self._create_journal_instance()
+        self.assertIsNotNone(journal.docs_service)
+
+        # Simulate HttpError on batchUpdate
+        http_error = MockHttpError(resp_status=403, reason_phrase="Permission Denied", content=b'{"error": "permission_denied"}')
+        
+        # Doc is initially empty for this error test, simplifying .get()
+        self.mock_service_instance.documents().get().execute.return_value = {'body':{'content':[{'endIndex':1}]}, 'documentId': 'fake_doc_id'}
+        self.mock_service_instance.documents().batchUpdate().execute.side_effect = http_error
+        
+        with patch.object(GoogleDocJournal._logger, 'error') as mock_log_error:
+            journal._write_to_google_doc("some content")
+            
+            self.assertTrue(any("HttpError occurred" in call_args[0][0] for call_args in mock_log_error.call_args_list))
+            self.assertTrue(any("HTTP 403 Forbidden" in call_args[0][0] for call_args in mock_log_error.call_args_list))
+
+if __name__ == '__main__':
+    # To run this test file directly (e.g., python tests/unit/test_google_doc_journal.py)
+    # you might need to adjust sys.path if jrnl is not installed in the environment.
+    # Example:
+    # import sys
+    # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../../')))
+    unittest.main(verbosity=2)


### PR DESCRIPTION
This commit introduces a new journal type, `googledoc`, which allows journal entries to be written simultaneously to a local text file and a Google Document. Reads are performed from the local text file for efficiency.

Key features:
-   **Dual Writing:** Entries are saved to both the local file and the specified
    Google Doc. The Google Doc content is overwritten on each write to ensure
    it mirrors the local journal.
-   **OAuth2 Authentication:** Utilizes Google's OAuth2 flow for authorization.
    You will be prompted to authenticate via a web browser on the first use
    or when credentials expire. Tokens are stored locally for persistence.
    Requires your provided `credentials.json` from Google Cloud Console.
-   **Configuration:** You can configure the journal type, local file path,
    Google Doc ID, and path to your `credentials.json` via `jrnl.yaml`.
-   **Error Handling:** Includes mechanisms to handle API errors, authentication
    issues, and file operation problems, with logging for diagnostics.
-   **Documentation:** Updated `docs/journal-types.md` with instructions for
    configuration, obtaining Google API credentials, and usage.
-   **Unit Tests:** Added unit tests for `GoogleDocJournal`, mocking external
    Google API interactions to ensure test reliability.

This feature provides you with a cloud backup/mirror option for your journals while retaining the benefits of local access.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [ ] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
