### PR TITLE
[Documentation change] Update command line reference

### DIFF
--- a/docs/reference-command-line.md
+++ b/docs/reference-command-line.md
@@ -30,7 +30,7 @@ Print version and license information.
 ### --list
 List the config file location, all configured journals, and their locations.
 
-### ---encrypt
+### --encrypt
 Encrypt a journal. See [encryption](encryption.md) for more information.
 
 ### --decrypt
@@ -138,4 +138,5 @@ Read [advanced usage](./advanced.md) for examples.
 Prints information useful for troubleshooting while `jrnl` executes.
 
 ### --diagnostic
+
 Prints diagnostic information useful for [reporting issues](https://github.com/jrnl-org/jrnl/issues).


### PR DESCRIPTION
No code, just a documentation change (typo). Standalone `encrypt` command had three leading dashes instead of two. No issue is tied to this PR.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
