### PR TITLE
Modify linewrap test to bypass minor inconsistency between Python versions

### DIFF
--- a/tests/bdd/features/override.feature
+++ b/tests/bdd/features/override.feature
@@ -28,18 +28,22 @@ Feature: Implementing Runtime Overrides for Select Configuration Keys
         Given we use the config "simple.yaml"
         And we use the password "test" if prompted
         When we run "jrnl  -2 --config-override linewrap 23 --format fancy"
-        Then the output should be
+        Then the standard output should contain
             """
             ┎─────╮2013-06-09 15:39
             ┃ My  ╘═══════════════╕
-            ┃ fir st  ent ry.     │
+            """
+        And the standard output should contain
+            """
             ┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
             ┃ Everything is       │
             ┃ alright             │
             ┖─────────────────────┘
             ┎─────╮2013-06-10 15:40
             ┃ Lif ╘═══════════════╕
-            ┃ e is  goo d.        │
+            """
+        And the standard output should contain
+            """
             ┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┤
             ┃ But I'm better.     │
             ┖─────────────────────┘


### PR DESCRIPTION
On Python 3.13.12, a test has started failing around linewrap formatting. The particular output lines that changed don't have great output in the old behavior or the new, so I'm bypassing checks on those lines. The important part of this test is that the fancy formatting box width is consistent, which is what we're still testing after this change.

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
