### PR TITLE
CI: Fix version-check test failures

### DIFF
--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -213,7 +213,10 @@ def toml_version(working_dir):
         import toml
 
         pyproject_contents = toml.load(pyproject_path)
-    return pyproject_contents["tool"]["poetry"]["version"]
+    version = pyproject_contents["tool"]["poetry"]["version"]
+    if not version.startswith("v"):
+        version = "v" + version
+    return version
 
 
 @fixture


### PR DESCRIPTION
## Summary

Fixes 6 test failures on `develop`.

The `toml_version` test fixture reads the version from `pyproject.toml` (`"4.3"`), but `__version__` in `jrnl/__version__.py` is `"v4.3"` (with the `v` prefix). The test compares them directly, so all 6 install/version tests fail:

- `test_install_jrnl_with_default_options`
- `test_install_jrnl_with_custom_relative_default_journal_path`
- `test_install_jrnl_with_custom_expanded_default_journal_path`
- `test_install_jrnl_with_encrypted_default_journal`
- `test_install_jrnl_with_encrypted_default_journal_with_no_entries`
- `test_update_version_number_in_config_file_when_running_newer_version`

**Fix:** Prepend `"v"` to the version in the `toml_version` fixture to match `__version__`.

## Test plan

- [x] All 6 version-check tests now pass
- [x] Full test suite passes: 645 passed, 40 skipped, 0 failed


🤖 Generated with [Claude Code](https://claude.com/claude-code)