### PR TITLE
Fix CJK wide character cursor misalignment in interactive input

### DIFF
--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -66,7 +66,7 @@ def get_text_from_stdin() -> str:
     )
 
     try:
-        raw = sys.stdin.read()
+        raw = _read_multiline()
     except KeyboardInterrupt:
         logging.error("Append mode: keyboard interrupt")
         raise JrnlException(
@@ -75,6 +75,24 @@ def get_text_from_stdin() -> str:
         )
 
     return raw
+
+
+def _read_multiline() -> str:
+    """Read multiline input using prompt_toolkit for correct CJK wide character
+    cursor handling. Ctrl+D on a blank line submits (matching original behavior)."""
+    from prompt_toolkit import prompt as pt_prompt
+    from prompt_toolkit.key_binding import KeyBindings
+
+    kb = KeyBindings()
+
+    @kb.add("c-d")
+    def handle_ctrl_d(event):
+        event.current_buffer.validate_and_handle()
+
+    try:
+        return pt_prompt("", multiline=True, key_bindings=kb)
+    except EOFError:
+        return ""
 
 
 def get_template_path(template_path: str, jrnl_template_dir: str) -> str:

--- a/jrnl/output.py
+++ b/jrnl/output.py
@@ -110,8 +110,29 @@ def print_msgs(
     console = _get_console(stderr=True)
 
     if get_input:
-        return str(console.input(prompt=decorated_text, password=hide_input))
+        return _prompt_user(decorated_text, hide_input)
     console.print(decorated_text, new_line_start=style.prepend_newline)
+
+
+def _prompt_user(rich_prompt, hide_input: bool = False) -> str:
+    """Get user input using prompt_toolkit for correct CJK wide character support.
+
+    Python's built-in input() relies on readline, which uses the system's wcswidth()
+    to calculate cursor positions. Many systems incorrectly report CJK characters as
+    1 column wide instead of 2, causing cursor misalignment during editing.
+    prompt_toolkit reimplements terminal width calculations in Python using the wcwidth
+    library, which correctly handles east-asian wide characters.
+    """
+    from prompt_toolkit import prompt as pt_prompt
+    from prompt_toolkit.formatted_text import ANSI
+
+    # Render the Rich renderable to an ANSI string to use as the visible prompt
+    render_console = Console(force_terminal=True, highlight=False)
+    with render_console.capture() as capture:
+        render_console.print(rich_prompt, end="")
+    ansi_prompt = capture.get()
+
+    return pt_prompt(ANSI(ansi_prompt), is_password=hide_input)
 
 
 def _get_console(stderr: bool = True) -> Console:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   'pyxdg (>=0.27.0)',
   'ruamel.yaml (>=0.17.22)',
   'ruamel.yaml.clib (>=0.2.12)', # https://sourceforge.net/p/ruamel-yaml-clib/tickets/36/
+  'prompt_toolkit (>=3.0)',
   'rich (>=14.3.2,<14.4.0)',
   'tzlocal (>=4.0)' # https://github.com/regebro/tzlocal/blob/master/CHANGES.txt
 ]


### PR DESCRIPTION
Replace readline-based input with prompt_toolkit, which correctly calculates east-asian character display widths (2 columns instead of 1), fixing cursor position drift when editing CJK text.

- What is this new code intended to do: Fix the CJK issue
- Are there any related issue: https://github.com/jrnl-org/jrnl/issues/2067
- What is the motivation for this change? For CJK users.
- What is an example of usage, or changes to config files? nah

### Checklist

- [X] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [X] I have included a link to the relevant issue number.
- [X] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.

The patch has been tested on my device.

https://github.com/user-attachments/assets/34962235-0401-410c-ac76-e7f6dd0ffefa

