### PR TITLE
Fix KeyError crash when colors.tags is missing from config

### DIFF
--- a/jrnl/color.py
+++ b/jrnl/color.py
@@ -53,7 +53,9 @@ def highlight_tags_with_background_color(
             if part and part[0] not in config["tagsymbols"]:
                 yield colorize(part, color, bold=is_title), part
             elif part:
-                yield colorize(part, config["colors"]["tags"], bold=True), part
+                yield colorize(
+                    part, config.get("colors", {}).get("tags", "none"), bold=True
+                ), part
 
     config = entry.journal.config
     if config["highlight"]:  # highlight tags

--- a/jrnl/install.py
+++ b/jrnl/install.py
@@ -43,11 +43,20 @@ def upgrade_config(config_data: dict, alt_config_path: str | None = None) -> Non
         for key in missing_keys:
             config_data[key] = default_config[key]
 
+    # Fill in any missing color sub-keys (e.g. "tags") that were added
+    # in newer versions, since the top-level check above won't catch them.
+    missing_color_keys = set()
+    if "colors" in config_data and isinstance(config_data["colors"], dict):
+        for color_key, color_val in default_config["colors"].items():
+            if color_key not in config_data["colors"]:
+                config_data["colors"][color_key] = color_val
+                missing_color_keys.add(color_key)
+
     different_version = config_data["version"] != __version__
     if different_version:
         config_data["version"] = __version__
 
-    if missing_keys or different_version:
+    if missing_keys or missing_color_keys or different_version:
         save_config(config_data, alt_config_path)
         config_path = alt_config_path if alt_config_path else get_config_path()
         print_msg(

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -15,3 +15,26 @@ def test_initialize_autocomplete_runs_without_readline():
 
     with mock.patch.dict(sys.modules, {"readline": None}):
         install._initialize_autocomplete()  # should not throw exception
+
+
+def test_upgrade_config_fills_missing_color_subkeys(tmp_path):
+    """Regression test for https://github.com/jrnl-org/jrnl/issues/2021.
+
+    If a user's config has a 'colors' dict but is missing sub-keys
+    (e.g. 'tags'), upgrade_config should fill them in from defaults.
+    """
+    from jrnl.config import get_default_config
+    from jrnl.install import upgrade_config
+
+    config = get_default_config()
+    # Simulate a config that has colors but is missing the 'tags' key
+    del config["colors"]["tags"]
+    assert "tags" not in config["colors"]
+
+    config_path = tmp_path / "jrnl.yaml"
+    config_path.write_text("")
+
+    upgrade_config(config, alt_config_path=str(config_path))
+
+    assert "tags" in config["colors"]
+    assert config["colors"]["tags"] == "none"


### PR DESCRIPTION
## Problem

Fixes #2021.

When a user's config file has a `colors` section but is missing the `tags` sub-key (e.g. from an older jrnl version or manual editing), displaying an entry with tags crashes with:

```
KeyError: 'tags'
```

at `jrnl/color.py:56` in `colorized_text_generator`.

## Root cause

`upgrade_config()` only fills in missing **top-level** config keys. If `colors` exists but is missing nested keys like `tags`, they are not backfilled from defaults.

## Fix

1. **`install.py`**: `upgrade_config()` now also fills in missing sub-keys under `colors` from the default config, and persists the update.
2. **`color.py`**: Uses defensive `.get()` access as a safety net so a missing key falls back to `"none"` instead of crashing.
3. **Regression test** added to verify `upgrade_config` fills missing color sub-keys.

## Validation

All 155 unit tests pass (`python -m pytest tests/unit/ -v`).