### PR TITLE
fix: prevent ValueError when upgrading with no journals configured

### DIFF
--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -83,7 +83,7 @@ def upgrade_jrnl(config_path: str) -> None:
 
     kwargs = {
         # longest journal name
-        "pad": max([len(journal) for journal in config["journals"]]),
+        "pad": max((len(journal) for journal in config["journals"]), default=0),
     }
 
     _print_journal_summary(


### PR DESCRIPTION
## Summary
`max()` on an empty sequence raises `ValueError: max() arg is an empty sequence`. When `config['journals']` is empty (no journals defined), running `jrnl --upgrade` would crash.

## Root Cause
In `jrnl/upgrade.py` line 86:
```python
"pad": max([len(journal) for journal in config["journals"]]),
```
`config['journals']` is a dict. Iterating over it gives the journal name strings, and `len(journal)` is the string length. But if no journals are configured, the list comprehension produces an empty list, and `max([])` raises `ValueError`.

## Fix
Use the `default` parameter of `max()` (Python 3.4+):
```python
"pad": max((len(journal) for journal in config["journals"]), default=0),
```
When there are no journals, `pad` will be `0` instead of crashing.

## Impact
- Severity: Low (edge case — only affects users running `jrnl --upgrade` with zero journals configured)
- No security implications
- Fix is backward-compatible
