### PR TITLE
docs: replace deprecated --export with --format in tips-and-tricks

### DIFF
--- a/docs/tips-and-tricks.md
+++ b/docs/tips-and-tricks.md
@@ -47,7 +47,7 @@ Will give you the number of words you wrote in 2013. How long is my
 average entry?
 
 ```sh
-expr $(jrnl --export text | wc -w) / $(jrnl --short | wc -l)
+expr $(jrnl --format text | wc -w) / $(jrnl --short | wc -l)
 ```
 
 This will first get the total number of words in the journal and divide
@@ -193,7 +193,7 @@ Out of the box, `jrnl` can output journal entries in Markdown. To visualize it, 
 
 The simplest way to visualize your Markdown output with `mdless` is as follows:
 ```sh
-jrnl --export md | mdless
+jrnl --format md | mdless
 ```
 
 This will render your Markdown output in the whole screen.
@@ -201,7 +201,7 @@ This will render your Markdown output in the whole screen.
 Fortunately, `mdless` has an option that allows you to adjust the screen width by using the `-w` option as follows:
 
 ```sh
-jrnl --export md | mdless -w 70
+jrnl --format md | mdless -w 70
 ```
 
 If you want Markdown to be your default display format, you can define this in your config file as follows:


### PR DESCRIPTION
## What

Updates three code examples in `docs/tips-and-tricks.md` that use the deprecated `--export` flag to use the current `--format` flag instead.

## Why

The `--export` flag is registered in `jrnl/args.py` with `help=argparse.SUPPRESS`, meaning it's a hidden, backwards-compatible alias that shouldn't appear in user-facing documentation. The rest of the jrnl docs consistently use `--format` (e.g., `docs/formats.md`, `docs/reference-command-line.md`, `docs/journal-types.md`). These three examples in `tips-and-tricks.md` were missed when the flag was deprecated.

## Changes

- Line 50: `jrnl --export text` → `jrnl --format text` (Statistics example)
- Line 196: `jrnl --export md | mdless` → `jrnl --format md | mdless` (Markdown visualization example)
- Line 204: `jrnl --export md | mdless -w 70` → `jrnl --format md | mdless -w 70` (Markdown visualization with width example)

## Verification

Checked `jrnl/args.py` to confirm `--format` and `--export` both map to `args.export` (same behavior), and that all other documentation files already use `--format`. No functional change — both flags work; this is purely a docs consistency fix.