### PR TITLE
Fix is_old_version to check version field before JSON format (#1908)

### DIFF
--- a/jrnl/upgrade.py
+++ b/jrnl/upgrade.py
@@ -190,6 +190,11 @@ def upgrade_jrnl(config_path: str) -> None:
 
 
 def is_old_version(config_path: str) -> bool:
+    config = load_config(config_path)
+    version = config.get("version")
+    if version is not None:
+        major_version = int(str(version).lstrip("v").split(".")[0])
+        return major_version < 2
     return is_config_json(config_path)
 
 

--- a/tests/bdd/features/upgrade.feature
+++ b/tests/bdd/features/upgrade.feature
@@ -69,3 +69,9 @@ Feature: Upgrading Journals from 1.x.x to 2.x.x
         Then the output should contain "features/journals/missing.journal does not exist"
         And the output should contain "We're all done"
         And we should get no error
+        
+        Scenario: Config that resembles JSON but has a current version is not flagged for upgrade
+        Given we use the config "json_style_with_version.json"
+        When we run "jrnl --short"
+        Then we should get no error
+        And the output should not contain "Welcome to jrnl"

--- a/tests/data/configs/json_style_with_version.json
+++ b/tests/data/configs/json_style_with_version.json
@@ -1,0 +1,1 @@
+{"default_hour": 9, "timeformat": "%Y-%m-%d %H:%M", "linewrap": 80, "encrypt": false, "editor": "", "default_minute": 0, "highlight": true, "journals": {"default": "features/journals/simple.journal"}, "tagsymbols": "@", "version": "v4.1"}


### PR DESCRIPTION
## Description

Fixes #1908

`is_old_version()` previously determined whether a config needed
upgrading based solely on whether the file looked like JSON:

    def is_old_version(config_path: str) -> bool:
        return is_config_json(config_path)

Since YAML is a superset of JSON, this incorrectly flagged any
JSON-style config as "old" even when it had a current `version`
field set, prompting users to upgrade unnecessarily.

This PR updates the function to check for a `version` field first:

- If `version` is present, the major version number is parsed and
  compared against 2. Versions below 2.0 are considered old;
  2.0 and above are not.
- If `version` is absent, the function falls back to the original
  JSON-detection check, preserving existing behavior for legacy
  configs that predate version tracking.

## Changes

- `jrnl/upgrade.py`: updated `is_old_version()` logic
- `tests/bdd/features/upgrade.feature`: added a scenario covering a
  JSON-style config with a current `version` field
- `tests/data/configs/json_style_with_version.json`: new fixture
  reproducing the exact scenario from the bug report

## Testing

Ran the full test suite locally (`poetry run pytest`). All tests
pass except for 6 pre-existing failures on `develop` unrelated to
this change (a version-string formatting mismatch between
`pyproject.toml` and `__version__.py`), confirmed present before
this change via `git stash`.