### PR TITLE
fix: don't crash on missing or invalid color config values

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,15 @@ YAML-based config with per-journal overrides. Journals can be a string (path) or
 - OS-specific markers: `@skip_win`, `@skip_posix`, `@on_win`, `@on_posix`
 - CI tests across Python 3.11–3.14 on Linux, macOS, and Windows
 
+## Never Touch Real User Config/Journals
+
+`jrnl.config.save_config()` (and anything that calls it, e.g. `install.upgrade_config()`) writes to the real `~/.config/jrnl/jrnl.yaml` by default when no `alt_config_path` is given. Do not run ad-hoc reproduction snippets (`python -c "..."`, scratch scripts) against functions in this codebase that touch config/journal paths — they can silently overwrite the user's actual jrnl config or journal files. Always reproduce bugs through the existing test infrastructure instead:
+
+- BDD: add/run a scenario in `tests/bdd/features/*.feature` against a fixture config in `tests/data/configs/`
+- Unit: use `tmp_path` / existing fixtures in `tests/unit/`, never a bare path that resolves to `get_config_path()`
+
+If a one-off script is unavoidable, pass an explicit `alt_config_path` pointed at a file under the scratchpad/tmp directory, never leave it to default.
+
 ## Code Style
 
 - Formatter: black (line length 88)

--- a/jrnl/color.py
+++ b/jrnl/color.py
@@ -17,6 +17,18 @@ if on_windows():
     colorama.init()
 
 
+def get_color(config: dict, key: str) -> str:
+    """Safely looks up config["colors"][key], falling back to "NONE" if the
+    key is missing or its value isn't a valid colorama.Fore color name.
+    Configs created before a given color key existed, hand-edited configs,
+    or configs with a typo'd/wrong-typed color value should mean "don't
+    colorize", not crash."""
+    color = config["colors"].get(key, "NONE")
+    if isinstance(color, str) and hasattr(colorama.Fore, color.upper()):
+        return color
+    return "NONE"
+
+
 def colorize(string: str, color: str, bold: bool = False) -> str:
     """Returns the string colored with colorama.Fore.color. If the color set by
     the user is "NONE" or the color doesn't exist in the colorama.Fore attributes,
@@ -53,7 +65,7 @@ def highlight_tags_with_background_color(
             if part and part[0] not in config["tagsymbols"]:
                 yield colorize(part, color, bold=is_title), part
             elif part:
-                yield colorize(part, config["colors"]["tags"], bold=True), part
+                yield colorize(part, get_color(config, "tags"), bold=True), part
 
     config = entry.journal.config
     if config["highlight"]:  # highlight tags

--- a/jrnl/color.py
+++ b/jrnl/color.py
@@ -17,26 +17,31 @@ if on_windows():
     colorama.init()
 
 
+def is_valid_color(color: object) -> bool:
+    """True if `color` is a string naming a real colorama.Fore attribute
+    (e.g. "red"). Used to guard against missing, typo'd, or wrong-typed
+    color config values before handing them to colorama."""
+    return isinstance(color, str) and hasattr(colorama.Fore, color.upper())
+
+
 def get_color(config: dict, key: str) -> str:
     """Safely looks up config["colors"][key], falling back to "NONE" if the
     key is missing or its value isn't a valid colorama.Fore color name.
     Configs created before a given color key existed, hand-edited configs,
     or configs with a typo'd/wrong-typed color value should mean "don't
     colorize", not crash."""
-    color = config["colors"].get(key, "NONE")
-    if isinstance(color, str) and hasattr(colorama.Fore, color.upper()):
-        return color
-    return "NONE"
+    color = config.get("colors", {}).get(key, "NONE")
+    return color if is_valid_color(color) else "NONE"
 
 
 def colorize(string: str, color: str, bold: bool = False) -> str:
     """Returns the string colored with colorama.Fore.color. If the color set by
     the user is "NONE" or the color doesn't exist in the colorama.Fore attributes,
     it returns the string without any modification."""
-    color_escape = getattr(colorama.Fore, color.upper(), None)
-    if not color_escape:
+    if not is_valid_color(color):
         return string
-    elif not bold:
+    color_escape = getattr(colorama.Fore, color.upper())
+    if not bold:
         return color_escape + string + colorama.Fore.RESET
     else:
         return colorama.Style.BRIGHT + color_escape + string + colorama.Style.RESET_ALL

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -8,12 +8,12 @@ from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 
-import colorama
 from rich.pretty import pretty_repr
 from ruamel.yaml import YAML
 from ruamel.yaml import constructor
 
 from jrnl import __version__
+from jrnl.color import is_valid_color
 from jrnl.exception import JrnlException
 from jrnl.messages import Message
 from jrnl.messages import MsgStyle
@@ -132,10 +132,9 @@ def verify_config_colors(config: dict) -> bool:
     """
     all_valid_colors = True
     for key, color in config["colors"].items():
-        upper_color = color.upper() if isinstance(color, str) else ""
-        if upper_color == "NONE":
+        if isinstance(color, str) and color.upper() == "NONE":
             continue
-        if not getattr(colorama.Fore, upper_color, None):
+        if not is_valid_color(color):
             print_msg(
                 Message(
                     MsgText.InvalidColor,

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -132,7 +132,7 @@ def verify_config_colors(config: dict) -> bool:
     """
     all_valid_colors = True
     for key, color in config["colors"].items():
-        upper_color = color.upper()
+        upper_color = color.upper() if isinstance(color, str) else ""
         if upper_color == "NONE":
             continue
         if not getattr(colorama.Fore, upper_color, None):

--- a/jrnl/journals/Entry.py
+++ b/jrnl/journals/Entry.py
@@ -8,6 +8,7 @@ import re
 from typing import TYPE_CHECKING
 
 from jrnl.color import colorize
+from jrnl.color import get_color
 from jrnl.color import highlight_tags_with_background_color
 from jrnl.output import wrap_with_ansi_colors
 
@@ -110,7 +111,7 @@ class Entry:
 
         date_str = colorize(
             self.date.strftime(self.journal.config["timeformat"]),
-            self.journal.config["colors"]["date"],
+            get_color(self.journal.config, "date"),
             bold=True,
         )
 
@@ -134,13 +135,13 @@ class Entry:
                 + highlight_tags_with_background_color(
                     self,
                     self.title,
-                    self.journal.config["colors"]["title"],
+                    get_color(self.journal.config, "title"),
                     is_title=True,
                 ),
                 columns,
             )
             body = highlight_tags_with_background_color(
-                self, self.body.rstrip(" \n"), self.journal.config["colors"]["body"]
+                self, self.body.rstrip(" \n"), get_color(self.journal.config, "body")
             )
 
             body = wrap_with_ansi_colors(body, columns - len(indent))
@@ -148,11 +149,11 @@ class Entry:
                 # Without explicitly colorizing the indent character, it will lose its
                 # color after a tag appears.
                 body = "\n".join(
-                    colorize(indent, self.journal.config["colors"]["body"]) + line
+                    colorize(indent, get_color(self.journal.config, "body")) + line
                     for line in body.splitlines()
                 )
 
-            body = colorize(body, self.journal.config["colors"]["body"])
+            body = colorize(body, get_color(self.journal.config, "body"))
         else:
             title = (
                 date_str
@@ -160,12 +161,12 @@ class Entry:
                 + highlight_tags_with_background_color(
                     self,
                     self.title.rstrip("\n"),
-                    self.journal.config["colors"]["title"],
+                    get_color(self.journal.config, "title"),
                     is_title=True,
                 )
             )
             body = highlight_tags_with_background_color(
-                self, self.body.rstrip("\n "), self.journal.config["colors"]["body"]
+                self, self.body.rstrip("\n "), get_color(self.journal.config, "body")
             )
 
         # Suppress bodies that are just blanks and new lines.

--- a/tests/bdd/features/upgrade.feature
+++ b/tests/bdd/features/upgrade.feature
@@ -80,6 +80,12 @@ Feature: Upgrading Journals from 1.x.x to 2.x.x
                 tags: none
             """
 
+    Scenario: Displaying a tagged entry should not crash when the colors config is missing the tags key
+        Given we use the config "missing_tags_color.yaml"
+        When we run "jrnl -n 1"
+        Then we should get no error
+        And the output should contain "I met with @dan"
+
     Scenario: Upgrade and parse journals with little endian date format
         Given we use the config "upgrade_from_195_little_endian_dates.json"
         When we run "jrnl -9 --short" and enter "Y"

--- a/tests/data/configs/missing_tags_color.yaml
+++ b/tests/data/configs/missing_tags_color.yaml
@@ -1,0 +1,16 @@
+default_hour: 9
+default_minute: 0
+editor: ''
+encrypt: false
+highlight: true
+template: false
+journals:
+  default: features/journals/tags.journal
+linewrap: 80
+tagsymbols: '@'
+timeformat: '%Y-%m-%d %H:%M'
+indent_character: "|"
+colors:
+  date: none
+  title: none
+  body: none


### PR DESCRIPTION
## Summary
- Fixes #2021 — jrnl crashed with `KeyError: 'tags'` when a config's `colors` dict was missing a sub-key (e.g. an older or hand-edited config without `colors.tags`).
- Added `get_color()` in `jrnl/color.py` as the single lookup point for color config values: falls back to `"NONE"` (no colorization) when a key is missing, or when the value isn't a valid `colorama.Fore` color name (covers typos and wrong-typed values like `tags: true`).
- Routed all direct `config["colors"][...]` lookups in `jrnl/journals/Entry.py` (date, title, body) and `jrnl/color.py` (tags) through `get_color()`, since they all had the same crash risk.
- Hardened `verify_config_colors()` in `jrnl/config.py` against the same `.upper()`-on-non-string crash, while still surfacing a warning for invalid values (unlike `get_color()`, which silently degrades — this function's job is to report bad config).

## Test plan
- [x] New BDD scenario in `tests/bdd/features/upgrade.feature` ("Displaying a tagged entry should not crash when the colors config is missing the tags key") using a new fixture `tests/data/configs/missing_tags_color.yaml`
- [x] `poetry run poe test` (lint + full suite) passes locally