### PR TITLE
feat: add 1Password keyring backend support

### DIFF
--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -39,9 +39,35 @@ want to "store the password in your keychain." This keychain is accessed using
 the [Python keyring library](https://pypi.org/project/keyring/), which has different
 behavior depending on your operating system.
 
+If your password isn't found in the keychain and you're prompted to type it in
+manually — for example while just reading a journal, not only when first
+encrypting it — `jrnl` will also offer to save that password to the keychain
+once it's confirmed to work. To turn this off, set
+`prompt_to_add_to_keyring_on_successful_decrypt: false` in your config.
+
 In Windows, the keychain is the Windows Credential Manager (WCM), which can't be locked
 and can be accessed by any other application running under your username. If this is
 a concern for you, you may not want to store your password.
+
+### Using 1Password instead of your OS keychain
+
+Set `keyring_backend: onepassword` in your config (globally, or as a
+per-journal override) to store passwords as Login items in
+[1Password](https://1password.com) instead of your OS keychain. This requires
+the [1Password CLI](https://developer.1password.com/docs/cli/get-started/)
+(`op`) to be installed and signed in. Each journal's password is stored under
+its own item, titled `jrnl/<journal name>`, so multiple journals don't
+collide.
+
+If `keyring_backend` isn't already set and `jrnl` detects the `op` CLI on your
+system, it will ask whether you'd like to use 1Password the next time you
+create a new password; answering yes saves the choice to your config so
+you're not asked again.
+
+If `keyring_backend` is unset (the default), or if `op` isn't installed,
+`jrnl` uses your OS keychain as before. If a `keyring_backend` lookup or
+store fails for any reason, `jrnl` falls back to prompting for your password
+interactively.
 
 ## Shell history
 

--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -143,9 +143,8 @@ def postconfig_encrypt(
 
     # Update the config, if we encrypted in place
     if not args.filename:
-        update_config(
-            original_config, {"encrypt": True}, args.journal_name, force_local=True
-        )
+        updates = {"encrypt": True, **journal._pending_config_updates}
+        update_config(original_config, updates, args.journal_name, force_local=True)
         save_config(original_config)
 
     return 0
@@ -176,9 +175,8 @@ def postconfig_decrypt(
 
     # Update the config, if we decrypted in place
     if not args.filename:
-        update_config(
-            original_config, {"encrypt": False}, args.journal_name, force_local=True
-        )
+        updates = {"encrypt": False, **journal._pending_config_updates}
+        update_config(original_config, updates, args.journal_name, force_local=True)
         save_config(original_config)
 
     return 0

--- a/jrnl/encryption/BasePasswordEncryption.py
+++ b/jrnl/encryption/BasePasswordEncryption.py
@@ -10,7 +10,14 @@ from jrnl.messages import Message
 from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
 from jrnl.prompt import create_password
+from jrnl.prompt import offer_to_store_password_in_keyring
 from jrnl.prompt import prompt_password
+
+# Whether to offer to save a manually entered password to the keyring after
+# a successful decrypt, when no config value is set. Tests default this to
+# False (see tests/lib/fixtures.py) so existing scenarios that don't script
+# an answer to this prompt aren't affected by it.
+DEFAULT_PROMPT_TO_ADD_TO_KEYRING_ON_SUCCESSFUL_DECRYPT = True
 
 
 class BasePasswordEncryption(BaseEncryption):
@@ -46,28 +53,46 @@ class BasePasswordEncryption(BaseEncryption):
         logging.debug("encrypting")
         if not self.password:
             if self.check_keyring and (
-                keyring_pw := get_keyring_password(self._journal_name)
+                keyring_pw := get_keyring_password(self._journal_name, self._config)
             ):
                 self.password = keyring_pw
 
             if not self.password:
-                self.password = create_password(self._journal_name)
+                self.password = create_password(self._journal_name, self._config)
 
         return self._encrypt(text)
 
     def decrypt(self, text: bytes) -> str:
         logging.debug("decrypting")
+        password_from_keyring = False
         if not self.password:
             if self.check_keyring and (
-                keyring_pw := get_keyring_password(self._journal_name)
+                keyring_pw := get_keyring_password(self._journal_name, self._config)
             ):
                 self.password = keyring_pw
+                password_from_keyring = True
 
             if not self.password:
                 self._prompt_password()
 
         while (result := self._decrypt(text)) is None:
             self._prompt_password()
+
+        prompt_to_add_to_keyring_on_successful_decrypt = self._config.get(
+            "prompt_to_add_to_keyring_on_successful_decrypt",
+            DEFAULT_PROMPT_TO_ADD_TO_KEYRING_ON_SUCCESSFUL_DECRYPT,
+        )
+        if (
+            self.check_keyring
+            and not password_from_keyring
+            and prompt_to_add_to_keyring_on_successful_decrypt
+        ):
+            # The password wasn't already in the keyring (or check_keyring was
+            # freshly enabled), but we now have one confirmed to work -- offer
+            # to save it, same as when a new password is first created.
+            offer_to_store_password_in_keyring(
+                self.password, self._journal_name, self._config
+            )
 
         return result
 

--- a/jrnl/encryption/OnePasswordBackend.py
+++ b/jrnl/encryption/OnePasswordBackend.py
@@ -1,0 +1,135 @@
+# Copyright © 2012-2023 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+import json
+import shutil
+import subprocess
+
+from keyring import backend
+from keyring import errors
+
+OP_EXECUTABLE = "op"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [OP_EXECUTABLE, *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _item_title(service: str, username: str) -> str:
+    return f"{service}/{username}"
+
+
+def _ensure_authenticated() -> None:
+    if _run("whoami").returncode != 0:
+        msg = (
+            "1Password CLI is not signed in. Run 'op signin', or enable the "
+            "1Password desktop app's 'Integrate with 1Password CLI' setting, "
+            "then try again."
+        )
+        raise RuntimeError(msg)
+
+
+def _item_exists(title: str) -> bool:
+    return _run("item", "get", title, "--format", "json").returncode == 0
+
+
+class OnePasswordBackend(backend.KeyringBackend):
+    """A keyring backend that stores secrets as Login items in 1Password,
+    via the 'op' CLI. Each (service, username) pair maps to one item,
+    titled '{service}/{username}', so distinct callers never collide on a
+    single item. Only the password field is populated -- the item's
+    username field is left blank, since the (service, username) pair is
+    already captured in the title.
+
+    Unlike the OS-native backends, priority is not used for automatic
+    discovery here -- callers must opt in explicitly via
+    keyring.set_keyring(OnePasswordBackend()) rather than relying on
+    keyring's own priority-based backend selection. This avoids ties with
+    other backends (see jrnl's own commit history for why).
+    """
+
+    priority = 1
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return shutil.which(OP_EXECUTABLE) is not None
+
+    def item_exists(self, service: str, username: str) -> bool:
+        """Whether an item already exists for this (service, username) pair,
+        i.e. whether set_password() would edit an existing item rather than
+        create a new one."""
+        _ensure_authenticated()
+        return _item_exists(_item_title(service, username))
+
+    def get_password(self, service: str, username: str) -> str | None:
+        _ensure_authenticated()
+        title = _item_title(service, username)
+
+        result = _run(
+            "item",
+            "get",
+            title,
+            "--fields",
+            "label=password",
+            "--reveal",
+            "--format",
+            "json",
+        )
+        if result.returncode != 0:
+            return None
+
+        try:
+            parsed = json.loads(result.stdout)
+        except json.JSONDecodeError as e:
+            msg = f"Unexpected response from 1Password CLI for '{title}': {e}"
+            raise RuntimeError(msg) from e
+
+        # 'op item get' returns a single field object (not a list) when only
+        # one --fields value is requested, but a list of field objects when
+        # multiple are requested. Normalize to a list either way.
+        if isinstance(parsed, dict):
+            parsed = [parsed]
+
+        try:
+            return next(f["value"] for f in parsed if f.get("label") == "password")
+        except (KeyError, StopIteration, TypeError) as e:
+            msg = f"Unexpected response from 1Password CLI for '{title}': {e}"
+            raise RuntimeError(msg) from e
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        _ensure_authenticated()
+        title = _item_title(service, username)
+
+        if _item_exists(title):
+            result = _run("item", "edit", title, f"password={password}")
+        else:
+            result = _run(
+                "item",
+                "create",
+                "--category=login",
+                f"--title={title}",
+                f"password={password}",
+            )
+
+        if result.returncode != 0:
+            msg = (
+                f"1Password CLI failed to store password for '{title}': "
+                f"{result.stderr.strip()}"
+            )
+            raise RuntimeError(msg)
+
+    def delete_password(self, service: str, username: str) -> None:
+        _ensure_authenticated()
+        title = _item_title(service, username)
+
+        if not _item_exists(title):
+            raise errors.PasswordDeleteError(title)
+
+        result = _run("item", "delete", title)
+        if result.returncode != 0:
+            msg = f"1Password CLI failed to delete '{title}': {result.stderr.strip()}"
+            raise RuntimeError(msg)

--- a/jrnl/journals/Journal.py
+++ b/jrnl/journals/Journal.py
@@ -126,7 +126,16 @@ class Journal:
             decryptor = decryption_cls(self.name, self.config)
             self._upgrade_encryption_from_version = decryptor.version
 
+        keyring_backend_before = self.config.get("keyring_backend")
         result = decryptor.decrypt(text)
+
+        if self.config.get("keyring_backend") != keyring_backend_before:
+            # e.g. the user opted into a non-default keyring backend (such as
+            # 1Password) when offered while decrypting with a manually
+            # entered password.
+            self._pending_config_updates["keyring_backend"] = self.config[
+                "keyring_backend"
+            ]
 
         if self._is_upgrading_encryption():
             # Share the now-known password to the v3 write instance so it
@@ -160,7 +169,15 @@ class Journal:
                 )
             )
 
+        keyring_backend_before = self.config.get("keyring_backend")
         result = self.encryption_method.encrypt(text)
+
+        if self.config.get("keyring_backend") != keyring_backend_before:
+            # e.g. the user opted into a non-default keyring backend (such as
+            # 1Password) when prompted while creating a new password.
+            self._pending_config_updates["keyring_backend"] = self.config[
+                "keyring_backend"
+            ]
 
         if self._is_upgrading_encryption():
             from_version = self._upgrade_encryption_from_version

--- a/jrnl/keyring.py
+++ b/jrnl/keyring.py
@@ -1,6 +1,8 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import logging
+
 import keyring
 
 from jrnl.messages import Message
@@ -8,22 +10,193 @@ from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
 from jrnl.output import print_msg
 
+SERVICE_NAME = "jrnl"
 
-def get_keyring_password(journal_name: str = "default") -> str | None:
+
+def _backend_name() -> str:
     try:
-        return keyring.get_password("jrnl", journal_name)
-    except keyring.errors.KeyringError as e:
-        if not isinstance(e, keyring.errors.NoKeyringError):
-            print_msg(Message(MsgText.KeyringRetrievalFailure, MsgStyle.ERROR))
+        return type(keyring.get_keyring()).__name__
+    except Exception:
+        return "unknown"
+
+
+def _select_backend(config: dict | None) -> None:
+    """Explicitly pin the active keyring backend if the config requests one,
+    rather than relying on keyring's own priority-based auto-discovery.
+
+    This is only ever opt-in: with no keyring_backend set, jrnl behaves
+    exactly as before, deferring entirely to keyring's own backend
+    selection.
+    """
+    backend_name = (config or {}).get("keyring_backend")
+    if not backend_name:
+        return
+
+    if backend_name == "onepassword":
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+
+        if not OnePasswordBackend.is_available():
+            logging.debug(
+                "Keyring: keyring_backend='onepassword' but the 'op' CLI "
+                "was not found"
+            )
+            print_msg(Message(MsgText.OnePasswordCliNotFound, MsgStyle.WARNING))
+            return
+
+        keyring.set_keyring(OnePasswordBackend())
+        return
+
+    logging.debug("Keyring: unrecognized keyring_backend '%s'", backend_name)
+
+
+def _confirm_onepassword_overwrite(
+    config: dict | None, journal_name: str, keyring_key: str
+) -> bool:
+    """If storing to 1Password would overwrite an existing item, ask the
+    user to confirm first. Returns False if the caller should abort the
+    store instead."""
+    if (config or {}).get("keyring_backend") != "onepassword":
+        return True
+
+    from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+    from jrnl.prompt import yesno
+
+    try:
+        exists = OnePasswordBackend().item_exists(SERVICE_NAME, journal_name)
+    except Exception as e:
+        logging.debug(
+            "Keyring (%s): could not check for an existing 1Password item: %s",
+            keyring_key,
+            e,
+        )
+        return True
+
+    if not exists:
+        return True
+
+    return yesno(
+        Message(
+            MsgText.OnePasswordItemWillBeOverwritten,
+            params={"journal_name": journal_name, "keyring_key": keyring_key},
+        ),
+        default=False,
+    )
+
+
+def get_keyring_password(
+    journal_name: str = "default", config: dict | None = None
+) -> str | None:
+    _select_backend(config)
+    keyring_key = f"{SERVICE_NAME}/{journal_name}"
+    try:
+        password = keyring.get_password(SERVICE_NAME, journal_name)
+    except keyring.errors.NoKeyringError:
+        logging.debug("Keyring (%s): no backend available", keyring_key)
+        return None
+    except Exception as e:
+        # Some third-party backends don't raise keyring.errors.KeyringError
+        # on failure, so this is intentionally broad.
+        backend = _backend_name()
+        logging.debug(
+            "Keyring (%s) via %s: failed to retrieve password: %s",
+            keyring_key,
+            backend,
+            e,
+        )
+        print_msg(
+            Message(
+                MsgText.KeyringRetrievalFailure,
+                MsgStyle.ERROR,
+                params={
+                    "journal_name": journal_name,
+                    "backend": backend,
+                    "reason": str(e),
+                },
+            )
+        )
         return None
 
+    backend = _backend_name()
+    logging.debug(
+        "Keyring (%s) via %s: retrieval %s",
+        keyring_key,
+        backend,
+        "succeeded" if password else "returned no password",
+    )
+    if password:
+        print_msg(
+            Message(
+                MsgText.PasswordRetrievedFromKeyring,
+                MsgStyle.NORMAL,
+                params={
+                    "journal_name": journal_name,
+                    "backend": backend,
+                    "keyring_key": keyring_key,
+                },
+            )
+        )
+    return password
 
-def set_keyring_password(password: str, journal_name: str = "default") -> None:
+
+def set_keyring_password(
+    password: str, journal_name: str = "default", config: dict | None = None
+) -> None:
+    _select_backend(config)
+    keyring_key = f"{SERVICE_NAME}/{journal_name}"
+
+    if not _confirm_onepassword_overwrite(config, journal_name, keyring_key):
+        print_msg(
+            Message(
+                MsgText.KeyringStoreCancelled,
+                MsgStyle.WARNING,
+                params={"journal_name": journal_name},
+            )
+        )
+        return
+
     try:
-        return keyring.set_password("jrnl", journal_name, password)
-    except keyring.errors.KeyringError as e:
-        if isinstance(e, keyring.errors.NoKeyringError):
-            msg = Message(MsgText.KeyringBackendNotFound, MsgStyle.WARNING)
-        else:
-            msg = Message(MsgText.KeyringRetrievalFailure, MsgStyle.ERROR)
-        print_msg(msg)
+        keyring.set_password(SERVICE_NAME, journal_name, password)
+    except keyring.errors.NoKeyringError:
+        logging.debug("Keyring (%s): no backend available", keyring_key)
+        print_msg(Message(MsgText.KeyringBackendNotFound, MsgStyle.WARNING))
+        return
+    except Exception as e:
+        # Some third-party backends don't raise keyring.errors.KeyringError
+        # on failure, so this is intentionally broad.
+        backend = _backend_name()
+        logging.debug(
+            "Keyring (%s) via %s: failed to store password: %s",
+            keyring_key,
+            backend,
+            e,
+        )
+        print_msg(
+            Message(
+                MsgText.KeyringStorageFailure,
+                MsgStyle.ERROR,
+                params={
+                    "journal_name": journal_name,
+                    "backend": backend,
+                    "reason": str(e),
+                },
+            )
+        )
+        return
+
+    backend = _backend_name()
+    logging.debug(
+        "Keyring (%s) via %s: password stored successfully",
+        keyring_key,
+        backend,
+    )
+    print_msg(
+        Message(
+            MsgText.PasswordStoredInKeyring,
+            MsgStyle.NORMAL,
+            params={
+                "journal_name": journal_name,
+                "backend": backend,
+                "keyring_key": keyring_key,
+            },
+        )
+    )

--- a/jrnl/main.py
+++ b/jrnl/main.py
@@ -28,7 +28,6 @@ def configure_logger(debug: bool = False) -> None:
         handlers=[RichHandler()],
     )
     logging.getLogger("parsedatetime").setLevel(logging.INFO)
-    logging.getLogger("keyring.backend").setLevel(logging.ERROR)
     logging.debug("Logging start")
 
 

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -246,6 +246,10 @@ class MsgText(Enum):
     PasswordDidNotMatch = "Passwords did not match, please try again"
     WrongPasswordTryAgain = "Wrong password, try again"
     PasswordStoreInKeychain = "Do you want to store the password in your keychain?"
+    UseOnePasswordInstead = (
+        "1Password CLI (op) detected. Use 1Password instead of your OS "
+        "keychain to store this password?"
+    )
 
     # --- Search --- #
     NothingToDelete = """
@@ -292,7 +296,33 @@ class MsgText(Enum):
           https://pypi.org/project/keyring/
         """
 
-    KeyringRetrievalFailure = "Failed to retrieve keyring"
+    OnePasswordCliNotFound = """
+        keyring_backend is set to 'onepassword', but the 1Password CLI ('op')
+        was not found. Install it from:
+          https://developer.1password.com/docs/cli/get-started/
+        """
+
+    KeyringRetrievalFailure = (
+        "Failed to retrieve keyring password for '{journal_name}' from {backend}:"
+        " {reason}"
+    )
+    KeyringStorageFailure = (
+        "Failed to store keyring password for '{journal_name}' in {backend}:"
+        " {reason}"
+    )
+    PasswordStoredInKeyring = (
+        "Password for '{journal_name}' stored in keyring via {backend}"
+        " under entry {keyring_key}"
+    )
+    PasswordRetrievedFromKeyring = (
+        "Password for '{journal_name}' retrieved from keyring via {backend}"
+        " under entry {keyring_key}"
+    )
+    OnePasswordItemWillBeOverwritten = (
+        "An existing 1Password item '{keyring_key}' will be overwritten with"
+        " the new password for '{journal_name}'. Continue?"
+    )
+    KeyringStoreCancelled = "Password for '{journal_name}' was not stored in keyring"
 
     # --- Deprecation --- #
     DeprecatedCommand = """

--- a/jrnl/prompt.py
+++ b/jrnl/prompt.py
@@ -8,7 +8,26 @@ from jrnl.output import print_msg
 from jrnl.output import print_msgs
 
 
-def create_password(journal_name: str) -> str:
+def offer_to_store_password_in_keyring(
+    password: str, journal_name: str, config: dict | None = None
+) -> None:
+    if not yesno(Message(MsgText.PasswordStoreInKeychain), default=True):
+        return
+
+    from jrnl.keyring import set_keyring_password
+
+    if config is not None and not config.get("keyring_backend"):
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+
+        if OnePasswordBackend.is_available() and yesno(
+            Message(MsgText.UseOnePasswordInstead), default=False
+        ):
+            config["keyring_backend"] = "onepassword"
+
+    set_keyring_password(password, journal_name, config)
+
+
+def create_password(journal_name: str, config: dict | None = None) -> str:
     kwargs = {
         "get_input": True,
         "hide_input": True,
@@ -34,10 +53,7 @@ def create_password(journal_name: str) -> str:
 
         print_msg(Message(MsgText.PasswordDidNotMatch, MsgStyle.ERROR))
 
-    if yesno(Message(MsgText.PasswordStoreInKeychain), default=True):
-        from jrnl.keyring import set_keyring_password
-
-        set_keyring_password(pw, journal_name)
+    offer_to_store_password_in_keyring(pw, journal_name, config)
 
     return pw
 

--- a/tests/bdd/features/password.feature
+++ b/tests/bdd/features/password.feature
@@ -66,7 +66,7 @@ Feature: Using the installed keyring
             this password will not be saved in keyring
             y
             """
-        Then the output should contain "Failed to retrieve keyring"
+        Then the output should contain "Failed to store keyring password"
         And we should get no error
         And we should be prompted for a password
         And the config for journal "default" should contain "encrypt: true"
@@ -101,6 +101,46 @@ Feature: Using the installed keyring
         And we should be prompted for a password
         And the output should contain "Failed to retrieve keyring"
         And the output should contain "2013-06-10 15:40 Life is good"
+
+
+    Scenario: Offering to save a manually entered password to keyring after decrypt
+        Given we use the config "encrypted.yaml"
+        And we have a keyring
+        And we are offered to save the password after decrypt
+        And we use the password "bad doggie no biscuit" if prompted
+        When we run "jrnl --short" and enter
+            """
+            y
+            """
+        Then we should get no error
+        And we should be prompted for a password
+        And the output should contain "stored in keyring"
+        When we run "jrnl --short"
+        Then we should not be prompted for a password
+        And the output should be
+            """
+            2013-06-09 15:39 My first entry.
+            2013-06-10 15:40 Life is good.
+            """
+
+
+    Scenario: Declining to save a manually entered password to keyring after decrypt
+        Given we use the config "encrypted.yaml"
+        And we have a keyring
+        And we are offered to save the password after decrypt
+        And we use the password "bad doggie no biscuit" if prompted
+        When we run "jrnl --short" and enter
+            """
+            n
+            """
+        Then we should get no error
+        And we should be prompted for a password
+        And the output should not contain "stored in keyring"
+        When we run "jrnl --short" and enter
+            """
+            n
+            """
+        Then we should be prompted for a password
 
 
     Scenario: Mistyping your password

--- a/tests/lib/fixtures.py
+++ b/tests/lib/fixtures.py
@@ -89,6 +89,8 @@ def cli_run(
     mock_overrides,
     mock_default_journal_path,
     mock_default_templates_path,
+    mock_onepassword_available,
+    mock_prompt_to_add_to_keyring_on_successful_decrypt,
 ):
     # Check if we need more mocks
     mock_factories.update(mock_args)
@@ -99,6 +101,8 @@ def cli_run(
     mock_factories.update(mock_user_input)
     mock_factories.update(mock_default_journal_path)
     mock_factories.update(mock_default_templates_path)
+    mock_factories.update(mock_onepassword_available)
+    mock_factories.update(mock_prompt_to_add_to_keyring_on_successful_decrypt)
 
     return {
         "status": 0,
@@ -186,6 +190,44 @@ def mock_default_templates_path(temp_dir):
     return {
         "get_templates_path": lambda: patch(
             "jrnl.editor.get_templates_path", return_value=templates_path
+        ),
+    }
+
+
+@fixture
+def onepassword_available():
+    # Whether the 1Password CLI is detected must not depend on whatever
+    # happens to be on the test-runner's PATH.
+    return False
+
+
+@fixture
+def mock_onepassword_available(onepassword_available):
+    return {
+        "onepassword_available": lambda: patch(
+            "jrnl.encryption.OnePasswordBackend.OnePasswordBackend.is_available",
+            return_value=onepassword_available,
+        ),
+    }
+
+
+@fixture
+def prompt_to_add_to_keyring_on_successful_decrypt():
+    # Whether jrnl offers to save a manually entered password to the keyring
+    # after a successful decrypt defaults to off in tests, since most
+    # existing scenarios don't script an answer to that prompt.
+    return False
+
+
+@fixture
+def mock_prompt_to_add_to_keyring_on_successful_decrypt(
+    prompt_to_add_to_keyring_on_successful_decrypt,
+):
+    return {
+        "prompt_to_add_to_keyring_on_successful_decrypt": lambda: patch(
+            "jrnl.encryption.BasePasswordEncryption"
+            ".DEFAULT_PROMPT_TO_ADD_TO_KEYRING_ON_SUCCESSFUL_DECRYPT",
+            prompt_to_add_to_keyring_on_successful_decrypt,
         ),
     }
 

--- a/tests/lib/given_steps.py
+++ b/tests/lib/given_steps.py
@@ -88,6 +88,14 @@ def we_have_type_of_keyring(keyring_type):
             return TestKeyring()
 
 
+@given(
+    "we are offered to save the password after decrypt",
+    target_fixture="prompt_to_add_to_keyring_on_successful_decrypt",
+)
+def we_are_offered_to_save_password_after_decrypt():
+    return True
+
+
 @given(parse("we use no config"), target_fixture="config_path")
 def we_use_no_config(temp_dir):
     os.chdir(temp_dir.name)  # @todo move this step to a more universal place

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,0 +1,89 @@
+# Copyright © 2012-2023 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+import argparse
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from jrnl.commands import postconfig_encrypt
+
+
+def make_journal_stub(pending_updates=None):
+    journal = MagicMock()
+    journal.config = {"encrypt": False, "journal": "/tmp/journal.txt"}
+    journal.can_be_encrypted = True
+    journal._pending_config_updates = {}
+    journal.name = "default"
+
+    def write(filename, force_new_password=False):
+        # Simulate a config change accumulated during the password prompt
+        # (e.g. the user opted into a non-default keyring backend).
+        journal._pending_config_updates.update(pending_updates or {})
+
+    journal.write.side_effect = write
+    return journal
+
+
+class TestPostconfigEncryptPersistsPendingConfigUpdates:
+    def test_persists_keyring_backend_choice_made_during_encrypt(self):
+        journal = make_journal_stub(pending_updates={"keyring_backend": "onepassword"})
+        args = argparse.Namespace(journal_name="default", filename=None)
+        original_config = {"journals": {"default": "/tmp/journal.txt"}}
+        config = {"journals": {"default": "/tmp/journal.txt"}}
+
+        with (
+            patch("jrnl.journals.open_journal", return_value=journal),
+            patch("jrnl.config.update_config") as update_config,
+            patch("jrnl.install.save_config") as save_config,
+            patch("jrnl.output.print_msg"),
+        ):
+            postconfig_encrypt(
+                args=args, config=config, original_config=original_config
+            )
+
+        update_config.assert_called_once_with(
+            original_config,
+            {"encrypt": True, "keyring_backend": "onepassword"},
+            "default",
+            force_local=True,
+        )
+        save_config.assert_called_once_with(original_config)
+
+    def test_persists_just_encrypt_when_no_pending_updates(self):
+        journal = make_journal_stub()
+        args = argparse.Namespace(journal_name="default", filename=None)
+        original_config = {"journals": {"default": "/tmp/journal.txt"}}
+        config = {"journals": {"default": "/tmp/journal.txt"}}
+
+        with (
+            patch("jrnl.journals.open_journal", return_value=journal),
+            patch("jrnl.config.update_config") as update_config,
+            patch("jrnl.install.save_config"),
+            patch("jrnl.output.print_msg"),
+        ):
+            postconfig_encrypt(
+                args=args, config=config, original_config=original_config
+            )
+
+        update_config.assert_called_once_with(
+            original_config, {"encrypt": True}, "default", force_local=True
+        )
+
+    def test_does_not_persist_when_writing_to_a_separate_file(self):
+        journal = make_journal_stub(pending_updates={"keyring_backend": "onepassword"})
+        args = argparse.Namespace(journal_name="default", filename="out.txt")
+        original_config = {"journals": {"default": "/tmp/journal.txt"}}
+        config = {"journals": {"default": "/tmp/journal.txt"}}
+
+        with (
+            patch("jrnl.journals.open_journal", return_value=journal),
+            patch("jrnl.config.update_config") as update_config,
+            patch("jrnl.install.save_config") as save_config,
+            patch("jrnl.output.print_msg"),
+        ):
+            postconfig_encrypt(
+                args=args, config=config, original_config=original_config
+            )
+
+        update_config.assert_not_called()
+        save_config.assert_not_called()

--- a/tests/unit/test_decrypt_keyring_offer.py
+++ b/tests/unit/test_decrypt_keyring_offer.py
@@ -1,0 +1,103 @@
+# Copyright © 2012-2023 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+from unittest.mock import patch
+
+from jrnl.encryption.Jrnlv3Encryption import Jrnlv3Encryption
+
+
+def _encrypted_blob(password: str, plaintext: str = "hello") -> bytes:
+    enc = Jrnlv3Encryption("test", {})
+    enc.password = password
+    return enc._encrypt(plaintext)
+
+
+class TestDecryptKeyringOffer:
+    def test_offers_by_default_when_password_not_in_keyring(self):
+        config = {}
+        blob = _encrypted_blob("hunter2")
+        enc = Jrnlv3Encryption("test", config)
+
+        with (
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.get_keyring_password",
+                return_value=None,
+            ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.prompt_password",
+                return_value="hunter2",
+            ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption"
+                ".offer_to_store_password_in_keyring"
+            ) as offer,
+        ):
+            result = enc.decrypt(blob)
+
+        assert result == "hello"
+        offer.assert_called_once_with("hunter2", "test", config)
+
+    def test_does_not_offer_when_password_came_from_keyring(self):
+        config = {}
+        blob = _encrypted_blob("hunter2")
+        enc = Jrnlv3Encryption("test", config)
+
+        with (
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.get_keyring_password",
+                return_value="hunter2",
+            ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption"
+                ".offer_to_store_password_in_keyring"
+            ) as offer,
+        ):
+            result = enc.decrypt(blob)
+
+        assert result == "hello"
+        offer.assert_not_called()
+
+    def test_does_not_offer_when_disabled_via_config(self):
+        config = {"prompt_to_add_to_keyring_on_successful_decrypt": False}
+        blob = _encrypted_blob("hunter2")
+        enc = Jrnlv3Encryption("test", config)
+
+        with (
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.get_keyring_password",
+                return_value=None,
+            ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.prompt_password",
+                return_value="hunter2",
+            ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption"
+                ".offer_to_store_password_in_keyring"
+            ) as offer,
+        ):
+            result = enc.decrypt(blob)
+
+        assert result == "hello"
+        offer.assert_not_called()
+
+    def test_does_not_offer_when_check_keyring_is_false(self):
+        config = {}
+        blob = _encrypted_blob("hunter2")
+        enc = Jrnlv3Encryption("test", config)
+        enc.check_keyring = False
+
+        with (
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.prompt_password",
+                return_value="hunter2",
+            ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption"
+                ".offer_to_store_password_in_keyring"
+            ) as offer,
+        ):
+            result = enc.decrypt(blob)
+
+        assert result == "hello"
+        offer.assert_not_called()

--- a/tests/unit/test_journal_keyring_backend_persistence.py
+++ b/tests/unit/test_journal_keyring_backend_persistence.py
@@ -1,0 +1,48 @@
+# Copyright © 2012-2023 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+from unittest.mock import MagicMock
+
+from jrnl.journals.Journal import Journal
+
+
+def _journal_with_stub_encryption_method(mutate_config=None):
+    journal = Journal("test", encrypt=False)
+
+    def encrypt(text):
+        if mutate_config:
+            mutate_config(journal.config)
+        return text.encode()
+
+    journal.encryption_method = MagicMock()
+    journal.encryption_method.encrypt.side_effect = encrypt
+    return journal
+
+
+class TestKeyringBackendPendingConfigUpdate:
+    def test_queues_update_when_encrypt_sets_keyring_backend(self):
+        journal = _journal_with_stub_encryption_method(
+            mutate_config=lambda config: config.__setitem__(
+                "keyring_backend", "onepassword"
+            )
+        )
+
+        journal._encrypt("some text")
+
+        assert journal.config["keyring_backend"] == "onepassword"
+        assert journal._pending_config_updates == {"keyring_backend": "onepassword"}
+
+    def test_does_not_queue_update_when_keyring_backend_unchanged(self):
+        journal = _journal_with_stub_encryption_method()
+
+        journal._encrypt("some text")
+
+        assert "keyring_backend" not in journal._pending_config_updates
+
+    def test_does_not_queue_update_when_keyring_backend_already_set(self):
+        journal = _journal_with_stub_encryption_method()
+        journal.config["keyring_backend"] = "onepassword"
+
+        journal._encrypt("some text")
+
+        assert "keyring_backend" not in journal._pending_config_updates

--- a/tests/unit/test_jrnlv1_encryption.py
+++ b/tests/unit/test_jrnlv1_encryption.py
@@ -133,6 +133,10 @@ class TestJrnlv1JournalUpgrade:
                 "jrnl.encryption.BasePasswordEncryption.prompt_password",
                 return_value=password,
             ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.DEFAULT_PROMPT_TO_ADD_TO_KEYRING_ON_SUCCESSFUL_DECRYPT",
+                False,
+            ),
         ):
             result = journal._decrypt(ciphertext)
 
@@ -154,6 +158,10 @@ class TestJrnlv1JournalUpgrade:
                 "jrnl.encryption.BasePasswordEncryption.prompt_password",
                 return_value=password,
             ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.DEFAULT_PROMPT_TO_ADD_TO_KEYRING_ON_SUCCESSFUL_DECRYPT",
+                False,
+            ),
         ):
             journal._decrypt(ciphertext)
             v3_ciphertext = journal._encrypt(plaintext)
@@ -174,6 +182,10 @@ class TestJrnlv1JournalUpgrade:
             patch(
                 "jrnl.encryption.BasePasswordEncryption.prompt_password",
                 return_value=password,
+            ),
+            patch(
+                "jrnl.encryption.BasePasswordEncryption.DEFAULT_PROMPT_TO_ADD_TO_KEYRING_ON_SUCCESSFUL_DECRYPT",
+                False,
             ),
         ):
             journal._decrypt(ciphertext)

--- a/tests/unit/test_keyring.py
+++ b/tests/unit/test_keyring.py
@@ -1,0 +1,306 @@
+# Copyright © 2012-2023 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import keyring.errors
+
+from jrnl.keyring import get_keyring_password
+from jrnl.keyring import set_keyring_password
+
+
+class FakeBackend:
+    """Stand-in so backend-name logging doesn't depend on the real,
+    environment-specific keyring backend during tests."""
+
+
+def patch_get_keyring():
+    return patch("keyring.get_keyring", return_value=FakeBackend())
+
+
+class TestGetKeyringPassword:
+    def test_returns_password_on_success(self):
+        with (
+            patch("keyring.get_password", return_value="hunter2"),
+            patch_get_keyring(),
+            patch("jrnl.keyring.print_msg") as print_msg,
+        ):
+            assert get_keyring_password("default") == "hunter2"
+            print_msg.assert_called_once()
+            msg = print_msg.call_args.args[0]
+            assert "retrieved" in str(msg.text).lower()
+            assert msg.params["backend"] == "FakeBackend"
+            assert msg.params["keyring_key"] == "jrnl/default"
+
+    def test_silent_when_no_password_found(self):
+        with (
+            patch("keyring.get_password", return_value=None),
+            patch_get_keyring(),
+            patch("jrnl.keyring.print_msg") as print_msg,
+        ):
+            assert get_keyring_password("default") is None
+            print_msg.assert_not_called()
+
+    def test_returns_none_when_no_backend_available(self):
+        with (
+            patch(
+                "keyring.get_password",
+                side_effect=keyring.errors.NoKeyringError(),
+            ),
+            patch("jrnl.keyring.print_msg") as print_msg,
+        ):
+            assert get_keyring_password("default") is None
+            print_msg.assert_not_called()
+
+    def test_returns_none_on_standard_keyring_error(self):
+        with (
+            patch(
+                "keyring.get_password",
+                side_effect=keyring.errors.KeyringError("boom"),
+            ),
+            patch("jrnl.keyring.print_msg") as print_msg,
+            patch_get_keyring(),
+        ):
+            assert get_keyring_password("default") is None
+            print_msg.assert_called_once()
+            msg = print_msg.call_args.args[0]
+            assert "retrieve" in str(msg.text).lower()
+            assert msg.params["backend"] == "FakeBackend"
+            assert msg.params["reason"] == "boom"
+
+    def test_returns_none_when_backend_raises_non_conforming_error(self):
+        """Some third-party backends (e.g. onepassword-keyring) raise a bare
+        exception instead of a keyring.errors.KeyringError, or instead of
+        returning None, when no matching secret is found. jrnl should
+        degrade gracefully rather than crash."""
+        with (
+            patch("keyring.get_password", side_effect=RuntimeError("not found")),
+            patch("jrnl.keyring.print_msg") as print_msg,
+            patch_get_keyring(),
+        ):
+            assert get_keyring_password("default") is None
+            print_msg.assert_called_once()
+
+    def test_logs_backend_name_and_exception_on_failure(self):
+        with (
+            patch("keyring.get_password", side_effect=RuntimeError("not found")),
+            patch("jrnl.keyring.print_msg"),
+            patch_get_keyring(),
+            patch("logging.debug") as log_debug,
+        ):
+            get_keyring_password("default")
+            logged = " ".join(str(a) for a in log_debug.call_args.args)
+            assert "FakeBackend" in logged
+            assert "not found" in logged
+
+
+class TestSetKeyringPassword:
+    def test_sets_password_and_confirms_on_success(self):
+        with (
+            patch("keyring.set_password") as set_password,
+            patch("jrnl.keyring.print_msg") as print_msg,
+            patch_get_keyring(),
+        ):
+            set_keyring_password("hunter2", "default")
+            set_password.assert_called_once_with("jrnl", "default", "hunter2")
+            print_msg.assert_called_once()
+            msg = print_msg.call_args.args[0]
+            assert "stored" in str(msg.text).lower()
+            assert msg.params["backend"] == "FakeBackend"
+            assert msg.params["keyring_key"] == "jrnl/default"
+
+    def test_warns_when_no_backend_available(self):
+        with (
+            patch(
+                "keyring.set_password",
+                side_effect=keyring.errors.NoKeyringError(),
+            ),
+            patch("jrnl.keyring.print_msg") as print_msg,
+        ):
+            set_keyring_password("hunter2", "default")
+            print_msg.assert_called_once()
+
+    def test_does_not_raise_when_backend_raises_non_conforming_error(self):
+        with (
+            patch("keyring.set_password", side_effect=RuntimeError("boom")),
+            patch("jrnl.keyring.print_msg") as print_msg,
+            patch_get_keyring(),
+        ):
+            set_keyring_password("hunter2", "default")
+            print_msg.assert_called_once()
+            msg = print_msg.call_args.args[0]
+            assert "store" in str(msg.text).lower()
+            assert msg.params["backend"] == "FakeBackend"
+            assert msg.params["reason"] == "boom"
+
+    def test_logs_backend_name_and_exception_on_failure(self):
+        with (
+            patch("keyring.set_password", side_effect=RuntimeError("boom")),
+            patch("jrnl.keyring.print_msg"),
+            patch_get_keyring(),
+            patch("logging.debug") as log_debug,
+        ):
+            set_keyring_password("hunter2", "default")
+            logged = " ".join(str(a) for a in log_debug.call_args.args)
+            assert "FakeBackend" in logged
+            assert "boom" in logged
+
+
+def test_backend_name_falls_back_to_unknown_when_get_keyring_fails():
+    from jrnl.keyring import _backend_name
+
+    with patch("keyring.get_keyring", side_effect=RuntimeError("no backend")):
+        assert _backend_name() == "unknown"
+
+
+def test_backend_name_uses_active_backend_class_name():
+    from jrnl.keyring import _backend_name
+
+    with patch("keyring.get_keyring", return_value=MagicMock(spec=FakeBackend)):
+        assert "FakeBackend" in _backend_name() or _backend_name() != ""
+
+
+class TestSelectBackend:
+    def test_noop_when_no_config(self):
+        with patch("keyring.set_keyring") as set_keyring:
+            from jrnl.keyring import _select_backend
+
+            _select_backend(None)
+            set_keyring.assert_not_called()
+
+    def test_noop_when_keyring_backend_not_set(self):
+        with patch("keyring.set_keyring") as set_keyring:
+            from jrnl.keyring import _select_backend
+
+            _select_backend({"encrypt": True})
+            set_keyring.assert_not_called()
+
+    def test_pins_onepassword_backend_when_requested_and_available(self):
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+        from jrnl.keyring import _select_backend
+
+        with (
+            patch.object(OnePasswordBackend, "is_available", return_value=True),
+            patch("keyring.set_keyring") as set_keyring,
+        ):
+            _select_backend({"keyring_backend": "onepassword"})
+            set_keyring.assert_called_once()
+            assert isinstance(set_keyring.call_args.args[0], OnePasswordBackend)
+
+    def test_warns_and_does_not_pin_when_op_cli_missing(self):
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+        from jrnl.keyring import _select_backend
+
+        with (
+            patch.object(OnePasswordBackend, "is_available", return_value=False),
+            patch("keyring.set_keyring") as set_keyring,
+            patch("jrnl.keyring.print_msg") as print_msg,
+        ):
+            _select_backend({"keyring_backend": "onepassword"})
+            set_keyring.assert_not_called()
+            print_msg.assert_called_once()
+
+    def test_noop_for_unrecognized_backend_name(self):
+        with patch("keyring.set_keyring") as set_keyring:
+            from jrnl.keyring import _select_backend
+
+            _select_backend({"keyring_backend": "bitwarden"})
+            set_keyring.assert_not_called()
+
+    def test_get_keyring_password_selects_backend_from_config(self):
+        with (
+            patch("keyring.get_password", return_value="hunter2"),
+            patch_get_keyring(),
+            patch("jrnl.keyring._select_backend") as select_backend,
+        ):
+            config = {"keyring_backend": "onepassword"}
+            get_keyring_password("default", config)
+            select_backend.assert_called_once_with(config)
+
+    def test_set_keyring_password_selects_backend_from_config(self):
+        with (
+            patch("keyring.set_password"),
+            patch("jrnl.keyring.print_msg"),
+            patch_get_keyring(),
+            patch("jrnl.keyring._select_backend") as select_backend,
+            patch("jrnl.keyring._confirm_onepassword_overwrite", return_value=True),
+        ):
+            config = {"keyring_backend": "onepassword"}
+            set_keyring_password("hunter2", "default", config)
+            select_backend.assert_called_once_with(config)
+
+
+class TestConfirmOnePasswordOverwrite:
+    def test_true_when_backend_is_not_onepassword(self):
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+        from jrnl.keyring import _confirm_onepassword_overwrite
+
+        with patch.object(OnePasswordBackend, "item_exists") as item_exists:
+            assert _confirm_onepassword_overwrite(None, "default", "jrnl/default")
+            assert _confirm_onepassword_overwrite(
+                {"keyring_backend": None}, "default", "jrnl/default"
+            )
+            item_exists.assert_not_called()
+
+    def test_true_when_no_existing_item(self):
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+        from jrnl.keyring import _confirm_onepassword_overwrite
+
+        with patch.object(OnePasswordBackend, "item_exists", return_value=False):
+            assert _confirm_onepassword_overwrite(
+                {"keyring_backend": "onepassword"}, "default", "jrnl/default"
+            )
+
+    def test_true_when_existing_item_check_fails(self):
+        """If we can't tell whether an item exists (e.g. not authenticated),
+        don't block the store on that -- the store call itself will
+        surface a clear error if something's actually wrong."""
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+        from jrnl.keyring import _confirm_onepassword_overwrite
+
+        with patch.object(
+            OnePasswordBackend, "item_exists", side_effect=RuntimeError("boom")
+        ):
+            assert _confirm_onepassword_overwrite(
+                {"keyring_backend": "onepassword"}, "default", "jrnl/default"
+            )
+
+    def test_asks_and_returns_true_when_confirmed(self):
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+        from jrnl.keyring import _confirm_onepassword_overwrite
+
+        with (
+            patch.object(OnePasswordBackend, "item_exists", return_value=True),
+            patch("jrnl.prompt.yesno", return_value=True) as yesno,
+        ):
+            assert _confirm_onepassword_overwrite(
+                {"keyring_backend": "onepassword"}, "default", "jrnl/default"
+            )
+            yesno.assert_called_once()
+
+    def test_asks_and_returns_false_when_declined(self):
+        from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+        from jrnl.keyring import _confirm_onepassword_overwrite
+
+        with (
+            patch.object(OnePasswordBackend, "item_exists", return_value=True),
+            patch("jrnl.prompt.yesno", return_value=False),
+        ):
+            assert not _confirm_onepassword_overwrite(
+                {"keyring_backend": "onepassword"}, "default", "jrnl/default"
+            )
+
+    def test_set_keyring_password_aborts_when_overwrite_declined(self):
+        with (
+            patch("keyring.set_password") as set_password,
+            patch("jrnl.keyring.print_msg") as print_msg,
+            patch_get_keyring(),
+            patch("jrnl.keyring._confirm_onepassword_overwrite", return_value=False),
+        ):
+            config = {"keyring_backend": "onepassword"}
+            set_keyring_password("hunter2", "default", config)
+            set_password.assert_not_called()
+            print_msg.assert_called_once()
+            msg = print_msg.call_args.args[0]
+            assert "not stored" in str(msg.text).lower()

--- a/tests/unit/test_onepassword_backend.py
+++ b/tests/unit/test_onepassword_backend.py
@@ -1,0 +1,232 @@
+# Copyright © 2012-2023 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+from keyring.errors import PasswordDeleteError
+
+from jrnl.encryption.OnePasswordBackend import OnePasswordBackend
+
+SERVICE = "jrnl"
+USERNAME = "default"
+TITLE = "jrnl/default"
+
+
+def completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def patch_run(side_effect):
+    return patch(
+        "jrnl.encryption.OnePasswordBackend.subprocess.run", side_effect=side_effect
+    )
+
+
+class TestIsAvailable:
+    def test_true_when_op_on_path(self):
+        with patch("shutil.which", return_value="/usr/bin/op"):
+            assert OnePasswordBackend.is_available() is True
+
+    def test_false_when_op_missing(self):
+        with patch("shutil.which", return_value=None):
+            assert OnePasswordBackend.is_available() is False
+
+
+class TestItemExists:
+    def test_raises_when_not_authenticated(self):
+        with patch_run([completed(returncode=1, stderr="not signed in")]):
+            with pytest.raises(RuntimeError, match="not signed in"):
+                OnePasswordBackend().item_exists(SERVICE, USERNAME)
+
+    def test_true_when_item_exists(self):
+        with patch_run([completed(returncode=0), completed(returncode=0)]) as run:
+            assert OnePasswordBackend().item_exists(SERVICE, USERNAME) is True
+            item_get_args = run.call_args_list[1].args[0]
+            assert TITLE in item_get_args
+
+    def test_false_when_item_missing(self):
+        with patch_run([completed(returncode=0), completed(returncode=1)]):
+            assert OnePasswordBackend().item_exists(SERVICE, USERNAME) is False
+
+
+class TestGetPassword:
+    def test_raises_when_not_authenticated(self):
+        with patch_run([completed(returncode=1, stderr="not signed in")]):
+            with pytest.raises(RuntimeError, match="not signed in"):
+                OnePasswordBackend().get_password(SERVICE, USERNAME)
+
+    def test_returns_none_when_item_not_found(self):
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=1, stderr="isn't an item"),  # item get
+            ]
+        ):
+            assert OnePasswordBackend().get_password(SERVICE, USERNAME) is None
+
+    def test_returns_password_when_response_is_a_bare_field_object(self):
+        # 'op item get --fields label=password --format json' returns a
+        # single field object (not a list) when only one field is requested.
+        # This is the shape jrnl's single-field request actually receives.
+        field = json.dumps(
+            {
+                "id": "password",
+                "type": "CONCEALED",
+                "purpose": "PASSWORD",
+                "label": "password",
+                "value": "hunter2",
+                "reference": "op://Private/jrnl-default/password",
+            }
+        )
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=0, stdout=field),  # item get
+            ]
+        ):
+            assert OnePasswordBackend().get_password(SERVICE, USERNAME) == "hunter2"
+
+    def test_returns_password_when_response_is_a_list_of_fields(self):
+        # When multiple --fields values are requested, 'op' returns a list
+        # of field objects instead. jrnl only ever requests one field, but
+        # the parser should tolerate this shape too.
+        fields = json.dumps([{"label": "password", "value": "hunter2"}])
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=0, stdout=fields),  # item get
+            ]
+        ):
+            assert OnePasswordBackend().get_password(SERVICE, USERNAME) == "hunter2"
+
+    def test_raises_on_malformed_response(self):
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=0, stdout="not json"),  # item get
+            ]
+        ):
+            with pytest.raises(RuntimeError, match="Unexpected response"):
+                OnePasswordBackend().get_password(SERVICE, USERNAME)
+
+    def test_raises_when_password_field_missing_from_bare_object(self):
+        field = json.dumps({"label": "username", "value": "someone"})
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=0, stdout=field),  # item get
+            ]
+        ):
+            with pytest.raises(RuntimeError, match="Unexpected response"):
+                OnePasswordBackend().get_password(SERVICE, USERNAME)
+
+    def test_raises_when_password_field_missing_from_list(self):
+        fields = json.dumps([{"label": "username", "value": "someone"}])
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=0, stdout=fields),  # item get
+            ]
+        ):
+            with pytest.raises(RuntimeError, match="Unexpected response"):
+                OnePasswordBackend().get_password(SERVICE, USERNAME)
+
+    def test_uses_service_slash_username_as_item_title(self):
+        fields = json.dumps({"label": "password", "value": "hunter2"})
+        with patch_run(
+            [completed(returncode=0), completed(returncode=0, stdout=fields)]
+        ) as run:
+            OnePasswordBackend().get_password(SERVICE, USERNAME)
+            item_get_args = run.call_args_list[1].args[0]
+            assert TITLE in item_get_args
+
+
+class TestSetPassword:
+    def test_raises_when_not_authenticated(self):
+        with patch_run([completed(returncode=1, stderr="not signed in")]):
+            with pytest.raises(RuntimeError, match="not signed in"):
+                OnePasswordBackend().set_password(SERVICE, USERNAME, "hunter2")
+
+    def test_creates_item_when_it_does_not_exist(self):
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=1),  # item get (existence check) -> not found
+                completed(returncode=0),  # item create
+            ]
+        ) as run:
+            OnePasswordBackend().set_password(SERVICE, USERNAME, "hunter2")
+            create_args = run.call_args_list[2].args[0]
+            assert "create" in create_args
+            assert "password=hunter2" in create_args
+            assert not any(arg.startswith("username=") for arg in create_args)
+
+    def test_edits_item_when_it_already_exists(self):
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=0),  # item get (existence check) -> found
+                completed(returncode=0),  # item edit
+            ]
+        ) as run:
+            OnePasswordBackend().set_password(SERVICE, USERNAME, "hunter2")
+            edit_args = run.call_args_list[2].args[0]
+            assert "edit" in edit_args
+            assert "password=hunter2" in edit_args
+            assert not any(arg.startswith("username=") for arg in edit_args)
+
+    def test_raises_when_create_fails(self):
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=1),  # item get -> not found
+                completed(returncode=1, stderr="boom"),  # item create fails
+            ]
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                OnePasswordBackend().set_password(SERVICE, USERNAME, "hunter2")
+
+
+class TestDeletePassword:
+    def test_raises_when_not_authenticated(self):
+        with patch_run([completed(returncode=1, stderr="not signed in")]):
+            with pytest.raises(RuntimeError, match="not signed in"):
+                OnePasswordBackend().delete_password(SERVICE, USERNAME)
+
+    def test_raises_password_delete_error_when_item_missing(self):
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=1),  # item get -> not found
+            ]
+        ):
+            with pytest.raises(PasswordDeleteError):
+                OnePasswordBackend().delete_password(SERVICE, USERNAME)
+
+    def test_deletes_existing_item(self):
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=0),  # item get -> found
+                completed(returncode=0),  # item delete
+            ]
+        ) as run:
+            OnePasswordBackend().delete_password(SERVICE, USERNAME)
+            delete_args = run.call_args_list[2].args[0]
+            assert "delete" in delete_args
+
+    def test_raises_when_delete_command_fails(self):
+        with patch_run(
+            [
+                completed(returncode=0),  # whoami
+                completed(returncode=0),  # item get -> found
+                completed(returncode=1, stderr="boom"),  # item delete fails
+            ]
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                OnePasswordBackend().delete_password(SERVICE, USERNAME)

--- a/tests/unit/test_prompt.py
+++ b/tests/unit/test_prompt.py
@@ -1,0 +1,92 @@
+# Copyright © 2012-2023 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+from unittest.mock import patch
+
+from jrnl.prompt import create_password
+
+PASSWORD_ENTRY = ["hunter2", "hunter2"]
+
+
+class TestCreatePasswordOnePasswordOffer:
+    def test_offers_onepassword_when_available_and_unconfigured(self):
+        config = {}
+        with (
+            patch("jrnl.prompt.print_msg", side_effect=PASSWORD_ENTRY),
+            patch("jrnl.prompt.yesno", side_effect=[True, True]),
+            patch(
+                "jrnl.encryption.OnePasswordBackend.OnePasswordBackend.is_available",
+                return_value=True,
+            ),
+            patch("jrnl.keyring.set_keyring_password") as set_keyring_password,
+        ):
+            create_password("default", config)
+
+        assert config["keyring_backend"] == "onepassword"
+        set_keyring_password.assert_called_once_with("hunter2", "default", config)
+
+    def test_keeps_os_keychain_when_user_declines_onepassword(self):
+        config = {}
+        with (
+            patch("jrnl.prompt.print_msg", side_effect=PASSWORD_ENTRY),
+            patch("jrnl.prompt.yesno", side_effect=[True, False]),
+            patch(
+                "jrnl.encryption.OnePasswordBackend.OnePasswordBackend.is_available",
+                return_value=True,
+            ),
+            patch("jrnl.keyring.set_keyring_password") as set_keyring_password,
+        ):
+            create_password("default", config)
+
+        assert "keyring_backend" not in config
+        set_keyring_password.assert_called_once_with("hunter2", "default", config)
+
+    def test_does_not_offer_when_op_cli_unavailable(self):
+        config = {}
+        with (
+            patch("jrnl.prompt.print_msg", side_effect=PASSWORD_ENTRY),
+            patch("jrnl.prompt.yesno", side_effect=[True]) as yesno,
+            patch(
+                "jrnl.encryption.OnePasswordBackend.OnePasswordBackend.is_available",
+                return_value=False,
+            ),
+            patch("jrnl.keyring.set_keyring_password") as set_keyring_password,
+        ):
+            create_password("default", config)
+
+        assert "keyring_backend" not in config
+        assert yesno.call_count == 1
+        set_keyring_password.assert_called_once_with("hunter2", "default", config)
+
+    def test_does_not_offer_when_keyring_backend_already_configured(self):
+        config = {"keyring_backend": "onepassword"}
+        with (
+            patch("jrnl.prompt.print_msg", side_effect=PASSWORD_ENTRY),
+            patch("jrnl.prompt.yesno", side_effect=[True]) as yesno,
+            patch(
+                "jrnl.encryption.OnePasswordBackend.OnePasswordBackend.is_available",
+                return_value=True,
+            ),
+            patch("jrnl.keyring.set_keyring_password") as set_keyring_password,
+        ):
+            create_password("default", config)
+
+        assert yesno.call_count == 1
+        set_keyring_password.assert_called_once_with("hunter2", "default", config)
+
+    def test_does_not_offer_when_user_declines_keychain_storage(self):
+        config = {}
+        with (
+            patch("jrnl.prompt.print_msg", side_effect=PASSWORD_ENTRY),
+            patch("jrnl.prompt.yesno", side_effect=[False]) as yesno,
+            patch(
+                "jrnl.encryption.OnePasswordBackend.OnePasswordBackend.is_available",
+                return_value=True,
+            ),
+            patch("jrnl.keyring.set_keyring_password") as set_keyring_password,
+        ):
+            create_password("default", config)
+
+        assert "keyring_backend" not in config
+        assert yesno.call_count == 1
+        set_keyring_password.assert_not_called()


### PR DESCRIPTION
## Needs more cleanup and deeper review from me!

Adds an opt-in 1Password keyring backend, on top of several fixes to existing keyring handling that surfaced during development.

## 1Password backend

- New jrnl/encryption/OnePasswordBackend.py implements keyring.backend.KeyringBackend by shelling out to the `op` CLI directly (list-arg subprocess calls, no shell string building; exit-code checks instead of stderr text matching). Each (service, username) pair maps to its own item titled 'jrnl/<journal_name>', so journals never collide.
- Opt-in only, via `keyring_backend: onepassword` in config. The backend is never registered through keyring's own priority-based auto-discovery, so it can't tie with or shadow a user's OS keychain.
- jrnl/prompt.py offers to use 1Password instead of the OS keychain when `op` is detected and no keyring_backend is set yet; the choice is persisted so the question isn't asked again.
- Before overwriting an existing 1Password item, the user is asked to confirm.

## Keyring handling fixes

- jrnl/keyring.py: get/set failures now report the journal, backend, and underlying reason (previously a single generic "Failed to retrieve keyring" string covered both get and set failures). Successful get/set now also print a visible confirmation instead of being silent.
- jrnl/main.py: stop suppressing keyring.backend's own logger to ERROR, so `--debug` shows which backends keyring discovers and selects.
- BasePasswordEncryption.decrypt() now offers to save a manually entered password to the keyring after a successful decrypt, not only when a password is first created via --encrypt. Opt out with `prompt_to_add_to_keyring_on_successful_decrypt: false`.
- Fixed: postconfig_encrypt/postconfig_decrypt persisted only a hardcoded {"encrypt": ...} to config, ignoring Journal._pending_config_updates. This silently dropped any keyring_backend choice made during --encrypt/ --decrypt (it worked for the rest of that process, but never reached disk). Journal._encrypt()/_decrypt() now queue keyring_backend changes into _pending_config_updates, and both postconfig commands merge it in.

## Tests

- New: test_onepassword_backend.py, test_keyring.py, test_prompt.py, test_commands.py, test_journal_keyring_backend_persistence.py, test_decrypt_keyring_offer.py.
- New BDD scenarios for the decrypt-time save offer (accept/decline).
- tests/lib/fixtures.py: OnePasswordBackend.is_available() and the new decrypt-offer prompt default to off in BDD runs, so existing scenarios don't depend on the test machine's PATH or need to script answers to prompts they don't care about.

Addresses #1853

<!--
Thank you for wanting to contribute!

Please fill out this description, and the checklist below.

Here are some key points to include in your description:
- What is this new code intended to do?
- Are there any related issues?
- What is the motivation for this change?
- What is an example of usage, or changes to config files? (if applicable)
-->

### Checklist

- [ ] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [ ] I have included a link to the relevant issue number.
- [ ] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [ ] I have written new tests for these changes, as needed.
<!--
NOTE: Your PR may not be reviewed if there are any failing tests. You can run
tests locally with `poe test` (see the contributing doc if you need help with
`poe`), or use our automated tests after you submit your PR.
-->
