### PR TITLE
fix: emit error when running --decrypt on an unencrypted journal

### DIFF
--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -162,6 +162,15 @@ def postconfig_decrypt(
 
     journal = open_journal(args.journal_name, config)
 
+    if not journal.config["encrypt"]:
+        raise JrnlException(
+            Message(
+                MsgText.JournalNotEncrypted,
+                MsgStyle.ERROR,
+                {"journal_name": args.journal_name},
+            )
+        )
+
     journal.config["encrypt"] = False
     journal._reconfigure_encryption_method()
 

--- a/jrnl/messages/MsgText.py
+++ b/jrnl/messages/MsgText.py
@@ -101,6 +101,8 @@ class MsgText(Enum):
         of journal can't be encrypted. Please fix your config file.
         """
 
+    JournalNotEncrypted = 'Journal "{journal_name}" is not encrypted'
+
     DecryptionFailedGeneric = "The decryption of journal data failed."
 
     KeyboardInterruptMsg = "Aborted by user"

--- a/tests/bdd/features/encrypt.feature
+++ b/tests/bdd/features/encrypt.feature
@@ -17,12 +17,10 @@ Feature: Encrypting and decrypting journals
             """
 
 
-    @todo
     Scenario: Trying to decrypt an already unencrypted journal
-        # This should warn the user that the journal is already encrypted
         Given we use the config "simple.yaml"
         When we run "jrnl --decrypt"
-        Then the config for journal "default" should contain "encrypt: false"
+        Then the error output should contain "is not encrypted"
         When we run "jrnl -99 --short"
         Then the output should be
             """


### PR DESCRIPTION
Previously, `--decrypt` on an unencrypted journal declared success on decrypting a file that it didn't decrypt.

It now raises an error instead.

Test plan:

```
jrnl-upstream on  develop [$!] is 📦 v4.3 via  v24.12.0 via 🐍 v3.14.6 took 1s 04:37:50 AM ✗ poetry run jrnl --decrypt
Password:
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓ ┃  Journal decrypted to /home/alichtman/Documents/journals/journal.txt  ┃ ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

jrnl-upstream on  develop [$!] is 📦 v4.3 via  v24.12.0 via 🐍 v3.14.6 took 1s 04:37:53 AM ➜ poetry run jrnl --decrypt
┏━ Error ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  Journal "default" is not encrypted  ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛

jrnl-upstream on  develop [$!] is 📦 v4.3 via  v24.12.0 via 🐍 v3.14.6 took 0s 04:37:56 AM ✗ poetry run jrnl --decrypt
┏━ Error ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  Journal "default" is not encrypted  ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

Also ran `poetry run poe test` (lint, format, full suite): all passing.
