### PR TITLE
fix: write journal files atomically to avoid corruption on crash

### DIFF
--- a/jrnl/journals/DayOneJournal.py
+++ b/jrnl/journals/DayOneJournal.py
@@ -4,6 +4,7 @@
 import contextlib
 import datetime
 import fnmatch
+import io
 import os
 import platform
 import plistlib
@@ -19,6 +20,7 @@ import tzlocal
 
 from jrnl import __title__
 from jrnl import __version__
+from jrnl.path import atomic_write
 
 from .Entry import Entry
 from .Journal import Journal
@@ -155,8 +157,9 @@ class DayOne(Journal):
                     entry_plist["Weather"] = entry.weather
 
                 # plistlib expects a binary object
-                with fn.open(mode="wb") as f:
-                    plistlib.dump(entry_plist, f, fmt=plistlib.FMT_XML, sort_keys=False)
+                buf = io.BytesIO()
+                plistlib.dump(entry_plist, buf, fmt=plistlib.FMT_XML, sort_keys=False)
+                atomic_write(str(fn), buf.getvalue())
 
         for entry in self._deleted_entries:
             filename = os.path.join(

--- a/jrnl/journals/FolderJournal.py
+++ b/jrnl/journals/FolderJournal.py
@@ -7,6 +7,7 @@ import pathlib
 from typing import TYPE_CHECKING
 
 from jrnl import time
+from jrnl.path import atomic_write
 
 from .Journal import Journal
 
@@ -77,8 +78,7 @@ class Folder(Journal):
                 ):
                     write_entries.append(e)
             journal = "\n".join([e.__str__() for e in write_entries])
-            with codecs.open(filename, "w", "utf-8") as journal_file:
-                journal_file.write(journal)
+            atomic_write(filename, journal.encode("utf-8"))
         # look for and delete empty files
         filenames = []
         filenames = Folder._get_files(self.config["journal"])

--- a/jrnl/journals/Journal.py
+++ b/jrnl/journals/Journal.py
@@ -13,6 +13,7 @@ from jrnl.messages import Message
 from jrnl.messages import MsgStyle
 from jrnl.messages import MsgText
 from jrnl.output import print_msg
+from jrnl.path import atomic_write
 from jrnl.path import expand_path
 from jrnl.prompt import yesno
 
@@ -252,8 +253,7 @@ class Journal:
             return f.read()
 
     def _store(self, filename: str, text: bytes) -> None:
-        with open(filename, "wb") as f:
-            f.write(text)
+        atomic_write(filename, text)
 
     def _parse(self, journal_txt: str) -> list[Entry]:
         """Parses a journal that's stored in a string and returns a list of entries"""

--- a/jrnl/path.py
+++ b/jrnl/path.py
@@ -1,7 +1,10 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import contextlib
+import os
 import os.path
+import tempfile
 from pathlib import Path
 
 import xdg.BaseDirectory
@@ -70,3 +73,19 @@ def get_config_path() -> str:
     except JrnlException:
         return os.path.join(home_dir(), DEFAULT_CONFIG_NAME)
     return os.path.join(config_directory_path, DEFAULT_CONFIG_NAME)
+
+
+def atomic_write(filename: str, data: bytes) -> None:
+    """Writes data to filename atomically, so a crash or kill mid-write can't
+    leave the file truncated or corrupted. Writes to a temp file in the same
+    directory, then replaces the target in a single filesystem operation."""
+    dirname = os.path.dirname(filename) or "."
+    fd, tmp_path = tempfile.mkstemp(dir=dirname, prefix=".jrnl-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp_path, filename)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.remove(tmp_path)
+        raise

--- a/tests/unit/test_path.py
+++ b/tests/unit/test_path.py
@@ -1,6 +1,7 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import os
 import random
 import string
 from os import getenv
@@ -9,6 +10,7 @@ from unittest.mock import patch
 import pytest
 
 from jrnl.path import absolute_path
+from jrnl.path import atomic_write
 from jrnl.path import expand_path
 from jrnl.path import home_dir
 
@@ -104,3 +106,46 @@ def test_absolute_path(mock_abspath, mock_expand_path):
     assert absolute_path(test_val) == mock_abspath.return_value
     mock_expand_path.assert_called_with(test_val)
     mock_abspath.assert_called_with(mock_expand_path.return_value)
+
+
+def test_atomic_write_creates_new_file(tmp_path):
+    filename = str(tmp_path / "journal.txt")
+
+    atomic_write(filename, b"hello world")
+
+    with open(filename, "rb") as f:
+        assert f.read() == b"hello world"
+    # no leftover temp file
+    assert os.listdir(tmp_path) == ["journal.txt"]
+
+
+def test_atomic_write_replaces_existing_file(tmp_path):
+    filename = str(tmp_path / "journal.txt")
+    with open(filename, "wb") as f:
+        f.write(b"old content")
+
+    atomic_write(filename, b"new content")
+
+    with open(filename, "rb") as f:
+        assert f.read() == b"new content"
+    assert os.listdir(tmp_path) == ["journal.txt"]
+
+
+def test_atomic_write_leaves_original_untouched_on_failure(tmp_path, monkeypatch):
+    filename = str(tmp_path / "journal.txt")
+    with open(filename, "wb") as f:
+        f.write(b"original content")
+
+    def broken_replace(*args, **kwargs):
+        msg = "simulated failure"
+        raise OSError(msg)
+
+    monkeypatch.setattr(os, "replace", broken_replace)
+
+    with pytest.raises(OSError):
+        atomic_write(filename, b"new content")
+
+    with open(filename, "rb") as f:
+        assert f.read() == b"original content"
+    # the temp file should have been cleaned up, leaving just the original
+    assert os.listdir(tmp_path) == ["journal.txt"]


### PR DESCRIPTION
## Summary
- `Journal._store()`, `Folder.write()`, and `DayOne.write()` previously truncated the target file and wrote directly into it, so a crash or kill mid-write (power loss, ctrl-C, OOM-kill) could leave a journal truncated or corrupted.
- Added `atomic_write()` in `jrnl/path.py`, which writes to a temp file in the same directory and `os.replace()`s it over the target — atomic on both POSIX and Windows.

## Test plan
- [x] `poetry run poe test` (lint + full unit/BDD suite) passes
- [x] New unit tests in `tests/unit/test_path.py` cover: creating a new file, replacing an existing file, and leaving the original untouched (with no leftover temp file) if the replace step fails