### PR TITLE
docs: clarify that --import only supports 'jrnl' format

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -21,6 +21,12 @@ more formats through plugins, you may have more available on your system. Please
 Any of these formats can be used interchangeably, and are only grouped into "display",
 "data", and "report" formats below for convenience.
 
+!!! note
+    The formats listed on this page are **export formats** — they are used for
+    displaying or exporting journal entries. When importing entries with
+    `--import`, the only supported format is `jrnl` (the default). See the
+    [--import documentation](reference-command-line.md#-import) for more information.
+
 ## Display Formats
 These formats are mainly intended for displaying your journal in the terminal. Even so,
 they can still be used in the same way as any other format (like written to a file, if

--- a/docs/reference-command-line.md
+++ b/docs/reference-command-line.md
@@ -50,8 +50,11 @@ Specify a file to import. If not provided, `jrnl` will use STDIN as the data sou
 ```sh
 --format TYPE
 ```
-Specify the format of the file that is being imported. Defaults to the same data
-storage method that jrnl uses. See [formats](formats.md) for more information.
+Specify the format of the file that is being imported. Currently, the only
+supported import format is `jrnl` (the default), which is the same data storage
+method that jrnl uses. The `--format` argument used with `--import` is separate
+from the `--format` argument used for [exporting](#-format-type); export-only
+formats such as `json`, `markdown`, or `text` cannot be used with `--import`.
 
 ## Writing new entries
 See [Basic Usage](usage.md).


### PR DESCRIPTION
## Summary

The command-line reference documentation incorrectly suggested that all formats listed on the [formats page](https://jrnl.sh/en/stable/formats/) could be used with `--import`. In reality, only the `jrnl` format is supported for importing entries. Export-only formats (such as `json`, `markdown`, `text`, etc.) cannot be used with `--import`.

This was confusing for users because:
1. The `--import` help text mentioned `--format` with a link to the formats page, which only lists export formats
2. The `--format` argument in argparse accepts all export format choices, so `jrnl --import --format text` would not be rejected by argparse but would fail at runtime with an unclear error (see #1990)

## Changes

- **`docs/reference-command-line.md`**: Updated the `--format` note under the `--import` section to clearly state that only `jrnl` format is supported for import, and to distinguish it from the `--format` argument used for exporting.
- **`docs/formats.md`**: Added a note clarifying that the formats listed on this page are export formats, and that `--import` only supports the `jrnl` format.

## Related issues

Addresses #1485 ("Document import formats (or lack thereof)") and #1990 ("jrnl should display an error message when using `--import` and `--format`").

## AI Usage Disclosure

An AI assistant was used to help locate the relevant code and draft this change. I have reviewed and understand every line of the diff, and I am the sole author of this contribution.

## Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/develop/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls) for the same issue.
- [x] I have written new tests for these changes, as needed (docs-only change, no tests needed).