### PR TITLE
fix: don't overwrite the default config when using --config-file

### DIFF
--- a/jrnl/commands.py
+++ b/jrnl/commands.py
@@ -93,7 +93,9 @@ def postconfig_import(
 
     # Persist any config changes that occurred during the import's journal.write()
     # (e.g. a v1/v2 upgrade to v3 triggered by the write).
-    flush_pending_config_updates(journal, original_config, args.journal_name)
+    flush_pending_config_updates(
+        journal, original_config, args.journal_name, args.config_file_path
+    )
 
     return 0
 
@@ -146,7 +148,7 @@ def postconfig_encrypt(
         update_config(
             original_config, {"encrypt": True}, args.journal_name, force_local=True
         )
-        save_config(original_config)
+        save_config(original_config, args.config_file_path)
 
     return 0
 
@@ -188,6 +190,6 @@ def postconfig_decrypt(
         update_config(
             original_config, {"encrypt": False}, args.journal_name, force_local=True
         )
-        save_config(original_config)
+        save_config(original_config, args.config_file_path)
 
     return 0

--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -211,10 +211,14 @@ def apply_config_updates_in_place(
 
 
 def flush_pending_config_updates(
-    journal: "Journal", original_config: dict, journal_name: str
+    journal: "Journal",
+    original_config: dict,
+    journal_name: str,
+    alt_config_path: str | None = None,
 ) -> None:
     """Persist any config changes accumulated on the journal (e.g. a legacy
-    encryption upgrade triggered by a write) back to the on-disk config."""
+    encryption upgrade triggered by a write) back to the on-disk config.
+    Supply alt_config_path if using an alternate config through --config-file."""
     if not journal._pending_config_updates:
         return
 
@@ -222,7 +226,7 @@ def flush_pending_config_updates(
         original_config, journal._pending_config_updates, journal_name
     )
     journal._pending_config_updates.clear()
-    save_config(original_config)
+    save_config(original_config, alt_config_path)
 
 
 def get_journal_name(args: argparse.Namespace, config: dict) -> argparse.Namespace:

--- a/jrnl/controller.py
+++ b/jrnl/controller.py
@@ -97,7 +97,9 @@ def run(args: "Namespace"):
 
     # Persist any config changes that occurred during journal.write() (e.g. a v1/v2
     # upgrade to v3 triggered by the write).
-    flush_pending_config_updates(journal, original_config, args.journal_name)
+    flush_pending_config_updates(
+        journal, original_config, args.journal_name, args.config_file_path
+    )
 
 
 def _perform_actions_on_search_results(**kwargs):

--- a/tests/bdd/features/config_file.feature
+++ b/tests/bdd/features/config_file.feature
@@ -91,6 +91,16 @@ Feature: Multiple journals
             """
         Then the output should contain "Journal encrypted to features/journals/basic_onefile.journal"
         And the config should contain "encrypt: false"
+        And the config should contain "editor: ''"
+
+    Scenario: Don't overwrite main config when a legacy encryption upgrade is triggered in an alternate config
+        Given the config "encrypted_v1_journal_legacy_config.yaml" exists
+        And we use the password "bad doggie no biscuit" if prompted
+        And we use the config "basic_onefile.yaml"
+        When we run "jrnl --config-file encrypted_v1_journal_legacy_config.yaml today I triggered the upgrade"
+        Then we should get no error
+        And the config should contain "encrypt: false"
+        And the config should contain "editor: noop"
 
     Scenario: Don't overwrite main config when decrypting a journal in an alternate config
         Given the config "editor_encrypted.yaml" exists
@@ -98,6 +108,7 @@ Feature: Multiple journals
         And we use the config "basic_encrypted.yaml"
         When we run "jrnl --cf editor_encrypted.yaml --decrypt"
         Then the config should contain "encrypt: true"
+        And the config should contain "editor: noop"
         And the output should not contain "Wrong password"
 
     Scenario: Show an error message when the config file is empty


### PR DESCRIPTION
## Context

`save_config()` writes to `get_config_path()` (`~/.config/jrnl/jrnl.yaml`) whenever it isn't given an explicit `alt_config_path`. Three call sites persisting config changes back to disk — `flush_pending_config_updates()` (config.py), and the in-place update branches of `postconfig_encrypt()` and `postconfig_decrypt()` (commands.py) — called `save_config()` without passing `alt_config_path` through, so any config write triggered while using `--config-file`/`--cf` (most commonly a v1/v2 to v3 encryption upgrade during `journal.write()`) silently clobbered the real config file instead of the one passed via `--config-file`.

`flush_pending_config_updates()` was introduced in 94c7763 ("Add v3 encryption with per-file random salt", GHSA-rhx6-37mm-5q9r), which is what made this regression user-visible. The same gap in `postconfig_encrypt()`/`postconfig_decrypt()` dates back to 631e08a (2020), when those commands were first split into commands.py.

## Fix

Thread `args.config_file_path` through all three call sites so writes stay scoped to whichever config file was actually loaded.

This bug slipped through every existing BDD test, including the ones added alongside 94c7763, and even the two scenarios that were already supposed to cover it ("Don't overwrite main config when encrypting/decrypting a journal in an alternate config") — both only asserted on the top-level `encrypt:` key, which the `force_local` update never touches (it lands on `journals.default.encrypt` instead), so they passed even against the buggy code.

To close that gap, this PR adds a new scenario covering the encrypt-upgrade path (`encrypted_v1_journal_legacy_config.yaml` loaded over `--config-file`), and strengthens the two existing `--encrypt`/`--decrypt` scenarios with an `editor:` assertion — a key that actually differs between the default and alternate config fixtures in each case, so an overwrite is caught rather than masked.

Fixes #2099
