### PR TITLE
fix: don't crash on invalid UTF-8 from stdin when writing an entry

### DIFF
--- a/jrnl/controller.py
+++ b/jrnl/controller.py
@@ -15,6 +15,7 @@ from jrnl.config import get_journal_name
 from jrnl.config import scope_config
 from jrnl.editor import get_text_from_editor
 from jrnl.editor import get_text_from_stdin
+from jrnl.editor import read_stdin_text
 from jrnl.editor import read_template_file
 from jrnl.exception import JrnlException
 from jrnl.journals import open_journal
@@ -158,7 +159,7 @@ def append_mode(args: "Namespace", config: dict, journal: "Journal", **kwargs) -
             raw = _write_in_editor(config, raw)
     elif not sys.stdin.isatty():
         logging.debug("Append mode: receiving piped text")
-        raw = sys.stdin.read()
+        raw = read_stdin_text()
     else:
         raw = _write_in_editor(config, template_text)
 

--- a/jrnl/editor.py
+++ b/jrnl/editor.py
@@ -52,6 +52,16 @@ def get_text_from_editor(config: dict, template: str = "") -> str:
     return raw
 
 
+def read_stdin_text() -> str:
+    # It's possible to get invalid UTF-8 here, so we replace on error to
+    # avoid crashing and losing the whole journal entry.
+    try:
+        sys.stdin.reconfigure(errors="replace")
+    except AttributeError:
+        pass
+    return sys.stdin.read()
+
+
 def get_text_from_stdin() -> str:
     print_msg(
         Message(
@@ -66,7 +76,7 @@ def get_text_from_stdin() -> str:
     )
 
     try:
-        raw = sys.stdin.read()
+        raw = read_stdin_text()
     except KeyboardInterrupt:
         logging.error("Append mode: keyboard interrupt")
         raise JrnlException(

--- a/tests/unit/test_editor.py
+++ b/tests/unit/test_editor.py
@@ -1,13 +1,16 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import io
 import os
+from unittest.mock import Mock
 from unittest.mock import mock_open
 from unittest.mock import patch
 
 import pytest
 
 from jrnl.editor import get_template_path
+from jrnl.editor import read_stdin_text
 from jrnl.editor import read_template_file
 from jrnl.exception import JrnlException
 
@@ -43,3 +46,36 @@ def test_get_template_path_when_doesnt_exist_returns_correct_path(mock_absolute_
         output = get_template_path("template", "templatepath")
 
     assert output == mock_absolute_paths.return_value
+
+
+def test_read_stdin_text_with_invalid_utf8_does_not_raise():
+    # Regression test for https://github.com/jrnl-org/jrnl/issues/2082
+    # A backspace over a multi-byte character (e.g. ß) in a canonical-mode
+    # terminal only erases one byte, leaving stray invalid UTF-8 like this.
+    raw_bytes = b"I saw Elvis. " + bytes([0xC3]) + b"ss"
+    stdin = io.TextIOWrapper(io.BytesIO(raw_bytes), encoding="utf-8")
+
+    with patch("sys.stdin", stdin):
+        read_stdin_text()  # should not raise UnicodeDecodeError
+
+
+def test_read_stdin_text_replaces_invalid_utf8_with_replacement_character():
+    raw_bytes = b"I saw Elvis. " + bytes([0xC3]) + b"ss"
+    stdin = io.TextIOWrapper(io.BytesIO(raw_bytes), encoding="utf-8")
+
+    with patch("sys.stdin", stdin):
+        result = read_stdin_text()
+
+    assert result == "I saw Elvis. \ufffdss"
+
+
+def test_read_stdin_text_when_stdin_does_not_support_reconfigure():
+    # Some stdin replacements (e.g. pytest-xdist's captured stdin) don't
+    # support reconfigure(); reading should still work in that case.
+    stdin = Mock(spec=["read"])
+    stdin.read.return_value = "I saw Elvis."
+
+    with patch("sys.stdin", stdin):
+        result = read_stdin_text()
+
+    assert result == "I saw Elvis."


### PR DESCRIPTION
## Summary
- Fixes #2082 — jrnl crashed with an uncaught `UnicodeDecodeError` and lost the entire entry when stdin contained invalid UTF-8.
- Root cause: backspacing over a multi-byte character (e.g. `ß`) in a canonical-mode terminal only erases one byte, leaving a stray invalid byte in the input stream. `sys.stdin.read()` in strict mode raised on that, and the exception propagated all the way to the top-level handler, discarding everything the user typed.
- Fix: extracted a `read_stdin_text()` helper in `jrnl/editor.py` that reconfigures stdin to replace invalid bytes (`U+FFFD`) instead of raising, so the entry is saved (mostly) intact instead of lost outright. Applied to both places jrnl reads a raw entry from stdin: the interactive no-editor prompt and piped input. Guarded with `except AttributeError` for stdin-like objects that don't support `.reconfigure()` (e.g. pytest-xdist's captured stdin).

## Test plan
- [x] Added `tests/unit/test_editor.py::test_read_stdin_text_with_invalid_utf8_does_not_raise` — reproduces the exact crash scenario from the issue and confirms it no longer raises.
- [x] Added `tests/unit/test_editor.py::test_read_stdin_text_replaces_invalid_utf8_with_replacement_character` — confirms the invalid byte is replaced with `U+FFFD` and the rest of the entry is preserved.
- [x] Added `tests/unit/test_editor.py::test_read_stdin_text_when_stdin_does_not_support_reconfigure` — confirms the fallback path works when `.reconfigure()` isn't available.
- [x] `poetry run poe test` (full lint + test suite) passes locally.