### PR TITLE
docs: add gedit to external editors

### DIFF
--- a/docs/external-editors.md
+++ b/docs/external-editors.md
@@ -132,6 +132,18 @@ editor: emacsclient -a "" -c
 
 When you're done editing the message, save and `C-x #` to close the buffer and stop the emacsclient process.
 
+## gedit
+
+To use [gedit](https://gedit-text-editor.org/) as your editor, edit the `jrnl` config
+file (`jrnl.yaml`) like this:
+
+```yaml
+editor: "gedit -w"
+```
+
+The `-w` (`--wait`) flag tells `gedit` to wait until the file is closed before
+passing control back to `jrnl`.
+
 ## Other editors
 
 If you're using another editor and would like to share, feel free to [contribute documentation](./contributing.md#editing-documentation) on it.


### PR DESCRIPTION
Adds a `gedit` section to the External Editors docs. Refs #1958.

`gedit` returns immediately by default, so without a wait flag jrnl exits before the entry is saved. The `-w` (`--wait`) flag makes it block until the file is closed, which is the same pattern already documented for Sublime Text (`-w`), VS Code (`--wait`), and MacVim (`-f`). Placed after `emacs`, immediately before "Other editors".

### Scope

Only `gedit` is included. The issue also asked for `nano -Scam`, but per @micahellison's review on the issue that was ruled out: `nano` already blocks, so it needs no arguments, and this page is scoped to making editors work with jrnl rather than to general editor preferences. I've left it out on that basis.

### The two other suggestions from the issue thread

Your review raised two broader ideas that I deliberately did **not** fold in here, to keep this diff reviewable:

1. **Listing all known blocking-by-default editors together.** The intro paragraph already names `micro`, and `vim`/`nvim` have their own section, so this is a restructure rather than an addition.
2. **Alphabetizing the sections.** Worth doing, but reordering every section in the same commit as new content makes the diff much harder to review.

Happy to do either or both — as follow-up commits here or as a separate PR, whichever you prefer.

### Verification

Built the docs locally with `mkdocs build --strict`: no warnings or errors, and the new section renders with a working link and correct anchor. The one INFO the build reports is pre-existing and in `tips-and-tricks.md`.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/main/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls) for the same issue.
- [ ] I have written new tests for these changes, as needed. — n/a, documentation only.
