### PR TITLE
fix: fall back to literal string when override value is not valid YAML

### DIFF
--- a/jrnl/config.py
+++ b/jrnl/config.py
@@ -11,6 +11,7 @@ from typing import Callable
 from rich.pretty import pretty_repr
 from ruamel.yaml import YAML
 from ruamel.yaml import constructor
+from ruamel.yaml.error import YAMLError
 
 from jrnl import __version__
 from jrnl.color import is_valid_color
@@ -53,7 +54,13 @@ def make_yaml_valid_dict(input: list) -> dict:
     # yaml compatible strings are of the form Key:Value
     yamlstr = YAML_SEPARATOR.join(input)
 
-    runtime_modifications = YAML(typ="safe").load(yamlstr)
+    try:
+        runtime_modifications = YAML(typ="safe").load(yamlstr)
+    except YAMLError:
+        # Values that are not valid YAML on their own (e.g. a strftime format
+        # such as "%d", where "%" starts a YAML directive) are still valid
+        # configuration values, so fall back to the literal string.
+        runtime_modifications = {input[0]: input[1]}
 
     return runtime_modifications
 

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -300,6 +300,18 @@ class TestDeserialization:
         assert input_str[0] in runtime_config
         assert runtime_config[input_str[0]] == input_str[1]
 
+    @pytest.mark.parametrize(
+        "input_str",
+        [
+            ["timeformat", "%d"],
+            ["timeformat", "%Y-%m-%d %H:%M"],
+        ],
+    )
+    def test_deserialize_values_that_are_not_valid_yaml(self, input_str):
+        runtime_config = make_yaml_valid_dict(input_str)
+        assert runtime_config.__class__ is dict
+        assert runtime_config[input_str[0]] == input_str[1]
+
     def test_deserialize_multiple_datatypes(self):
         cfg = make_yaml_valid_dict(["linewrap", "23"])
         assert cfg["linewrap"] == 23


### PR DESCRIPTION
Closes #2011

`--config-override` joins the key and value into a `key: value` string and parses it with the YAML safe loader. A strftime format like `%d` is not valid YAML on its own (`%` begins a YAML directive), so `jrnl --config-override timeformat "%d"` raised a `ScannerError` and surfaced as an internal-error panel, forcing users to add a second layer of quoting.

Such values are still legitimate configuration values, so the loader error is now caught and the raw string is used as the override value. Valid YAML values (ints, bools, nested keys) are unaffected.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/main/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
