### PR TITLE
fix: search DayOne tags with any configured tag symbol

### DIFF
--- a/jrnl/journals/DayOneJournal.py
+++ b/jrnl/journals/DayOneJournal.py
@@ -180,6 +180,16 @@ class DayOne(Journal):
                 entry.modified = True
                 setattr(entry, attr, new_attr)
 
+    def _normalize_tag(self, tag: str) -> str:
+        """DayOne stores tags without a symbol, so they are always read back with
+        the first configured tag symbol. Rewrite a searched tag to use that same
+        symbol so any configured tag symbol can be used to search."""
+        tag = super()._normalize_tag(tag)
+        tagsymbols = self.config["tagsymbols"]
+        if tag[:1] in tagsymbols:
+            return tagsymbols[0] + tag[1:]
+        return tag
+
     def _get_and_remove_uuid_from_entry(self, entry: Entry) -> Entry:
         uuid_regex = "^ *?# ([a-zA-Z0-9]+) *?$"
         m = re.search(uuid_regex, entry.body, re.MULTILINE)

--- a/jrnl/journals/Journal.py
+++ b/jrnl/journals/Journal.py
@@ -325,6 +325,10 @@ class Journal:
         tag_counts = {(tags.count(tag), tag) for tag in tags}
         return [Tag(tag, count=count) for count, tag in sorted(tag_counts)]
 
+    def _normalize_tag(self, tag: str) -> str:
+        """Normalizes a searched tag so it can be compared to an entry's tags."""
+        return tag.lower()
+
     def filter(
         self,
         tags=[],
@@ -354,8 +358,8 @@ class Journal:
 
         exclude is a list of the tags which should not appear in the results.
         entry is kept if any tag is present, unless they appear in exclude."""
-        self.search_tags = {tag.lower() for tag in tags}
-        excluded_tags = {tag.lower() for tag in exclude}
+        self.search_tags = {self._normalize_tag(tag) for tag in tags}
+        excluded_tags = {self._normalize_tag(tag) for tag in exclude}
         end_date = time.parse(end_date, inclusive=True)
         start_date = time.parse(start_date)
 

--- a/tests/unit/test_journals_dayone_journal.py
+++ b/tests/unit/test_journals_dayone_journal.py
@@ -1,0 +1,19 @@
+# Copyright © 2012-2023 jrnl contributors
+# License: https://www.gnu.org/licenses/gpl-3.0.html
+
+import pytest
+
+from jrnl.journals.DayOneJournal import DayOne
+
+
+@pytest.mark.parametrize("tagsymbol", ["#", "@"])
+def test_filter_matches_any_configured_tagsymbol(tagsymbol):
+    journal = DayOne(
+        name="dayone",
+        journal="tests/data/journals/dayone.dayone",
+        tagsymbols="#@",
+    )
+    journal.open()
+    journal.filter(tags=[tagsymbol + "work"])
+
+    assert len(journal.entries) == 1


### PR DESCRIPTION
Closes #1658

DayOne stores tags without a symbol, so entries always read them back prefixed with the *first* configured tag symbol. `Journal.filter` compared searched tags verbatim, so with `tagsymbols: "#@"` only `jrnl dayone #work` matched and `jrnl dayone @work` found nothing. Tag normalization for search is now a `Journal._normalize_tag` hook that `DayOneJournal` overrides to rewrite a leading tag symbol to the journal's canonical one, so any configured symbol matches.

### Checklist

- [x] I have read the [contributing doc](https://github.com/jrnl-org/jrnl/blob/main/docs/contributing.md).
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open [pull requests](../pulls)
  for the same issue.
- [x] I have written new tests for these changes, as needed.
