### PR TITLE
Add llms.txt for LLM/agent-readable project summary

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,31 @@
+# jrnl
+
+> A simple, plain-text journal application for the command line. Create, search, tag, and view journal entries; supports multiple journals, external editors, AES encryption, and import/export in several formats.
+
+## Getting Started
+
+- [Installation](https://github.com/jrnl-org/jrnl/blob/main/docs/installation.md): Install via `pipx install jrnl` (Python 3.11+), quickstart example.
+- [Overview](https://github.com/jrnl-org/jrnl/blob/main/docs/overview.md): Core concepts — plain text storage, tags, multiple journals, external editors, encryption, import/export.
+- [Basic Usage](https://github.com/jrnl-org/jrnl/blob/main/docs/usage.md): Composing vs. viewing modes, timestamp parsing, tagging, starring entries.
+
+## Configuration
+
+- [Command Line Reference](https://github.com/jrnl-org/jrnl/blob/main/docs/reference-command-line.md): Full flag synopsis (`--encrypt`, `--decrypt`, `--import`, `--format`, filters like `-on`, `-from`, `-to`, `-contains`, `-starred`).
+- [Config File Reference](https://github.com/jrnl-org/jrnl/blob/main/docs/reference-config-file.md): All `jrnl.yaml` settings (default hour/minute, tag symbols, editor, etc.).
+- [Advanced](https://github.com/jrnl-org/jrnl/blob/main/docs/advanced.md) / [External Editors](https://github.com/jrnl-org/jrnl/blob/main/docs/external-editors.md): Editor integration and advanced configuration.
+
+## Data
+
+- [Formats](https://github.com/jrnl-org/jrnl/blob/main/docs/formats.md): Display, data, and report output formats (JSON, YAML, Markdown, etc.) for viewing and export.
+- [Encryption](https://github.com/jrnl-org/jrnl/blob/main/docs/encryption.md): AES encryption behavior, v3 file format, related security advisory.
+- [Journal Types](https://github.com/jrnl-org/jrnl/blob/main/docs/journal-types.md): Single-file vs. folder-based journals.
+- [Privacy and Security](https://github.com/jrnl-org/jrnl/blob/main/docs/privacy-and-security.md): Threat model and data-handling notes.
+
+## Development
+
+- [Contributing](https://github.com/jrnl-org/jrnl/blob/main/docs/contributing.md): Code of conduct, bug reports, docs editing (`poe docs-run`), developing jrnl.
+
+## Optional
+
+- [Tips and Tricks](https://github.com/jrnl-org/jrnl/blob/main/docs/tips-and-tricks.md): Practical usage patterns.
+- [License](https://github.com/jrnl-org/jrnl/blob/main/LICENSE.md): GPL-3.0.


### PR DESCRIPTION
This repo doesn't have an [`llms.txt`](https://llmstxt.org) file yet — a small, curated markdown index (title, one-line summary, and grouped links to the docs that matter) that AI coding agents can read to understand a project quickly, instead of having to crawl and guess through the full README and `docs/` tree.

jrnl's docs are already well-organized into separate `docs/*.md` files (overview, usage, formats, encryption, config reference, command-line reference, etc.) but there's no single entry point that tells an agent which file answers which question — it has to open all of them to find out. That's exactly the gap llms.txt is meant to fill, and it's a good fit here specifically because jrnl has a lot of surface area (multiple journals, tag symbols, timestamp parsing, encryption versions, format plugins) that's easy for an agent to get wrong by guessing instead of reading the right doc.

Content is derived entirely from your existing docs (README, and `docs/overview.md`, `docs/installation.md`, `docs/usage.md`, `docs/reference-command-line.md`, `docs/reference-config-file.md`, `docs/formats.md`, `docs/encryption.md`, `docs/contributing.md`) — no new claims, just pointers. Validated against the [llms.txt spec](https://llmstxt.org) with [llms-txt-lint](https://github.com/abyworkings-coder/llms-txt-lint) (disclosure: a small validator tool I maintain — happy to drop that line from the PR if you'd rather not have it).

Totally understand if this isn't something you want to maintain — no worries either way, feel free to close.