### PR TITLE
Derive folder-journal entry dates from the folder path

### DIFF
--- a/jrnl/journals/FolderJournal.py
+++ b/jrnl/journals/FolderJournal.py
@@ -39,7 +39,20 @@ class Folder(Journal):
             for filename in filenames:
                 with codecs.open(filename, "r", "utf-8") as f:
                     journal = f.read()
-                    self.entries.extend(self._parse(journal))
+                # The folder layout (YYYY/MM/DD.txt) is authoritative for each
+                # entry's date. Parsing the date only from the entry header
+                # loses the day when the configured timeformat has no date
+                # component (e.g. "%H:%M"), which made same-day entries collide
+                # and overwrite each other on the next write (#2006).
+                file_path = pathlib.Path(filename)
+                year, month, day = (
+                    int(file_path.parts[-3]),
+                    int(file_path.parts[-2]),
+                    int(file_path.stem),
+                )
+                for entry in self._parse(journal):
+                    entry.date = entry.date.replace(year=year, month=month, day=day)
+                    self.entries.append(entry)
             self.sort()
 
         return self

--- a/tests/unit/test_journals_folder_journal.py
+++ b/tests/unit/test_journals_folder_journal.py
@@ -1,11 +1,13 @@
 # Copyright © 2012-2023 jrnl contributors
 # License: https://www.gnu.org/licenses/gpl-3.0.html
 
+import datetime
 import pathlib
 from unittest import mock
 
 import pytest
 
+from jrnl.journals.Entry import Entry
 from jrnl.journals.FolderJournal import Folder
 
 
@@ -57,3 +59,33 @@ def test_get_day_files_expected_filtering(inputs_and_outputs):
         expected_output.sort()
 
         assert actual_output == expected_output
+
+
+def test_dateless_timeformat_preserves_same_day_entries(tmp_path):
+    # Regression for #2006: with a timeformat that carries no date component
+    # (e.g. "%H:%M"), a second entry added on the same day must not overwrite
+    # the earlier one. The folder path (YYYY/MM/DD) is authoritative for the
+    # date, so entries must round-trip regardless of the timeformat.
+    kwargs = {"journal": str(tmp_path / "journal"), "timeformat": "%H:%M"}
+
+    journal = Folder("test", **kwargs)
+    morning = Entry(
+        journal, date=datetime.datetime(2020, 1, 15, 9, 0), text="Morning entry"
+    )
+    morning.modified = True
+    journal.entries = [morning]
+    journal.write()
+
+    journal = Folder("test", **kwargs).open()
+    evening = Entry(
+        journal, date=datetime.datetime(2020, 1, 15, 17, 0), text="Evening entry"
+    )
+    evening.modified = True
+    journal.entries.append(evening)
+    journal.write()
+
+    journal = Folder("test", **kwargs).open()
+    texts = " ".join(e.text for e in journal.entries)
+    assert len(journal.entries) == 2
+    assert "Morning entry" in texts
+    assert "Evening entry" in texts


### PR DESCRIPTION
### Description

Fixes #2006.

In a folder (directory) journal with a custom `timeformat` that has no date component (e.g. `timeformat: "%H:%M"`), adding a second entry on the same day silently destroyed the earlier one (data loss).

**Cause:** `Folder.open()` derived each entry's date only from the entry header. With a date-less timeformat the day cannot be recovered from the header (`time.parse("09:00")` defaults the month/day), so a re-read entry drifted off its real day. `Folder.write()` rewrites each `YYYY/MM/DD.txt` day file with only the entries whose `date` matches that day, so the earlier entry — whose in-memory date had drifted — was excluded and overwritten.

**Fix:** the folder layout (`YYYY/MM/DD.txt`) is authoritative for the date — that is where `write()` places each entry. On read, reconstruct each entry's year/month/day from the folder path (keeping the time from the header), so entries round-trip regardless of the configured timeformat. Journals whose timeformat already includes a date are unaffected (the path matches the header).

**Test:** added `test_dateless_timeformat_preserves_same_day_entries` — it writes a 09:00 entry, reopens and adds a 17:00 entry on the same day, and asserts both survive. Verified red before the fix (only the second entry survived) and green after. `tests/unit/` (184 passed) and the `file_storage.feature` folder-journal BDD scenarios (111 passed) pass locally, along with `ruff check` and `black --check`.

### Checklist

- [x] I have read the contributing doc.
- [x] I have included a link to the relevant issue number.
- [x] I have checked to ensure there aren't other open pull requests for the same issue.
- [x] I have written new tests for these changes, as needed.

---

Developed with the assistance of Claude Code (AI); reviewed and verified by me.
