### PR TITLE
Enable automerge for Renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,9 +6,12 @@
   "schedule": [ "at any time" ],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 10,
+  "automerge": true,
+  "automergeType": "pr",
   "reviewers": [
     "wren",
-    "micahellison"
+    "micahellison",
+    "alichtman"
   ],
   "labels": [ "packaging" ]
 }


### PR DESCRIPTION
## Summary
- Enable `automerge` for Renovate-managed dependency PRs (all update types, merged after required status checks pass)
- Add `alichtman` as a reviewer alongside existing reviewers
- Requires "Allow auto-merge" to be enabled in the repo settings for Renovate to use GitHub's native automerge