### PR TITLE
fix: reject --format with --import instead of listing export formats (#1990)

### DIFF
--- a/jrnl/args.py
+++ b/jrnl/args.py
@@ -13,7 +13,6 @@ from jrnl.commands import preconfig_diagnostic
 from jrnl.commands import preconfig_version
 from jrnl.output import deprecated_cmd
 from jrnl.plugins import EXPORT_FORMATS
-from jrnl.plugins import IMPORT_FORMATS
 from jrnl.plugins import util
 
 
@@ -37,6 +36,25 @@ class IgnoreNoneAppendAction(argparse._AppendAction):
     def __call__(self, parser, namespace, values, option_string=None):
         if values is not None:
             super().__call__(parser, namespace, values, option_string)
+
+
+def parse_import_and_format(args: list[str], parser: argparse.ArgumentParser) -> None:
+    """
+    --format selects an export format, so it cannot be combined with --import.
+
+    This runs against the raw arguments, before argparse validates --format,
+    because that validation is what produces the misleading message: --format
+    is restricted to the *export* formats, so `--import --format jrnl` -- the
+    combination the --import help text itself describes -- is rejected as an
+    invalid choice, and the user is handed a list of export formats to pick
+    from instead of being told the two options do not go together.
+    """
+
+    if "--import" not in args:
+        return
+
+    if any(arg == "--format" or arg.startswith("--format=") for arg in args):
+        parser.error("argument --format: not allowed with argument --import")
 
 
 def parse_not_arg(
@@ -168,14 +186,12 @@ def parse_args(args: list[str] = []) -> argparse.Namespace:
         metavar="TYPE",
         const=postconfig_import,
         dest="postconfig_cmd",
-        help=f"""
+        help="""
         Import entries from another journal.
 
         Optional parameters:
 
         --file FILENAME (default: uses stdin)
-
-        --format [{util.oxford_list(IMPORT_FORMATS)}] (default: jrnl)
         """,
     )
     standalone.add_argument(
@@ -450,6 +466,7 @@ def parse_args(args: list[str] = []) -> argparse.Namespace:
     # Handle '-123' as a shortcut for '-n 123'
     num = re.compile(r"^-(\d+)$")
     args = [num.sub(r"-n \1", arg) for arg in args]
+    parse_import_and_format(args, parser)
     parsed_args = parser.parse_intermixed_args(args)
     parsed_args = parse_not_arg(args, parsed_args, parser)
 

--- a/tests/unit/test_parse_args.py
+++ b/tests/unit/test_parse_args.py
@@ -148,6 +148,34 @@ def test_import_alone():
     assert cli_as_dict("--import") == expected_args(postconfig_cmd=postconfig_import)
 
 
+@pytest.mark.parametrize(
+    "cli",
+    [
+        "--import --format whatformats",
+        "--import --format json",
+        "--import --format=json",
+        "--format json --import",
+    ],
+)
+def test_import_with_format_is_rejected(cli, capsys):
+    """--format is export-only, so pairing it with --import must say exactly that.
+
+    "--format json" is the case worth noting: json is a valid *export* format,
+    so argparse accepted it and the run only failed later, at import time, with
+    "not a valid importer". The other spellings used to be rejected with an
+    invalid-choice error listing every export format.
+    """
+    with pytest.raises(SystemExit) as wrapped_e:
+        cli_as_dict(cli)
+
+    assert wrapped_e.value.code == 2
+    assert "not allowed with argument --import" in capsys.readouterr().err
+
+
+def test_format_without_import_is_unaffected():
+    assert cli_as_dict("--format json") == expected_args(export="json")
+
+
 def test_file_flag_alone():
     assert cli_as_dict("--file test.txt") == expected_args(filename="test.txt")
     assert cli_as_dict("--file 'lorem ipsum.txt'") == expected_args(


### PR DESCRIPTION
Fixes #1990.

## The problem

`--format` is an export option — `dest="export"`, `choices=EXPORT_FORMATS` — so it has never meant anything for `--import`. What was missing is any message saying so:

```
$ echo "new entry" | jrnl --import --format whatformats
jrnl: error: argument --format: invalid choice: 'whatformats'
      (choose from 'boxed', 'calendar', 'dates', 'fancy', ...)
```

The error hands the user a list of export formats to choose from, implying one of them would work. None of them do. Three distinct spellings all misled in slightly different ways:

| Command | Before | After |
|---|---|---|
| `--import --format whatformats` | invalid choice, lists every export format | `argument --format: not allowed with argument --import` |
| `--import --format jrnl` | invalid choice — `jrnl` is an importer, not an exporter, so the combination `--import`'s own help text described was rejected | same clear message |
| `--import --format json` | accepted by argparse, then failed later at import time as "not a valid importer" | same clear message, up front |

## The fix

`parse_import_and_format()` checks the raw argument list for the pair and reports it as a plain conflict, using argparse's own phrasing for option conflicts.

It has to run *before* `parse_intermixed_args`, because argparse validates `choices` while consuming the option — that invalid-choice error is precisely what needs replacing, so anything running after parsing would never be reached. This mirrors the existing `parse_not_arg` seam, which likewise inspects raw args and calls `parser.error()`.

Both `--format json` and `--format=json` spellings are handled, in either order relative to `--import`.

I also dropped the `--format [jrnl] (default: jrnl)` line from `--import`'s help text — that line is what advertised the combination in the first place, and it referred to a value argparse rejects. `docs/reference-command-line.md` already lists only `--file` under `--import`, so this brings the inline help in line with the docs (the documentation half of #1485).

## Note on `postconfig_import`

`postconfig_import` still contains `format = args.export if args.export else "jrnl"`. I left it alone deliberately: with this change `args.export` can no longer be set alongside `--import` from the CLI, but the line is harmless, and removing it would change behavior for anything constructing the namespace directly. Happy to strip it in a follow-up if you'd prefer the dead branch gone.

## Testing

Added to `tests/unit/test_parse_args.py`:

- `test_import_with_format_is_rejected` — parametrized over all four spellings (`--format whatformats`, `--format json`, `--format=json`, and `--format json --import` with the options reversed). Asserts exit code 2 *and* the message text, since the invalid-choice path already exited 2 — checking only the code would have passed without the fix.
- `test_format_without_import_is_unaffected` — guard that plain `--format json` still parses to `export="json"`.

**Verified failing on unfixed `main`**: all four parametrized cases fail; the guard passes both ways, as intended.

Full suite: **691 passed, 44 skipped** (686 before this change — the 5 new cases). The 5 `tests/bdd/test_features.py` `basic_folder.yaml` failures are pre-existing; I confirmed the identical 5 fail on a clean checkout.

`ruff check` and `black --check` are clean on both files.