### PR TITLE
fix(tests): normalize .txt fixture line endings so folder journals load on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.feature text eol=lf
 poetry.lock text eol=lf
 pyrpoject.toml text eol=lf
+*.txt text eol=lf


### PR DESCRIPTION
On Windows with git's default `core.autocrlf=true`, five folder-journal tests fail on a clean clone:

```
FAILED tests/bdd/test_features.py::test_searching_for_a_string_within_tag_results[basic_folder.yaml]
FAILED tests/bdd/test_features.py::test_searching_for_a_string_within_and_tag_results[basic_folder.yaml]
FAILED tests/bdd/test_features.py::test_printing_a_journal_that_has_multiline_entries_with_tags[basic_folder.yaml]
FAILED tests/bdd/test_features.py::test_count_modifications_when_editing_whole_journal_and_adding_to_last_entry[basic_folder.yaml]
FAILED tests/bdd/test_features.py::test_combining_changetime_and_delete_and_edit_affects_appropriate_entries[basic_folder.yaml]
5 failed, 686 passed, 44 skipped
```

`.gitattributes` normalizes `*.journal` and `*.feature`, but folder journals are stored as `.txt`, which is not covered. Those fixtures check out with CRLF, and `Folder.open()` reads them through `codecs.open(filename, "r", "utf-8")`, which decodes without translating newlines, so the `\r` survives into the entry body and breaks tag and multiline parsing.

Measured on this checkout: `tests/data/journals/basic_folder/2020/08/29.txt` has 19 CR bytes and `2020/09/24.txt` has 11, while `basic_encrypted.journal` has 0. The blobs in git are already LF, so only the checkout attribute is missing, which is why this is a one-line change and no fixture content moves.

With the fixtures at LF the whole suite passes: `691 passed, 44 skipped`.

CI does not see this because the Windows matrix job in `testing_prs.yaml` turns `core.autocrlf` off before checkout, so it never gets CRLF fixtures.

Unrelated, but while in this file: line 4 reads `pyrpoject.toml`, so `pyproject.toml` is not actually being normalized. Left alone here to keep this to one concern.

Drafted with AI assistance; I ran both suite runs and the byte counts above myself.
